### PR TITLE
LRQA-25821,LRQA-26205

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -989,8 +989,10 @@
     test.batch.run.property.values[functional-tomcat8-oracle12-jdk8]=true,true
     test.batch.run.property.names[functional-tomcat8-postgresql94-jdk8]=portal.smoke,portal.upgrades
     test.batch.run.property.values[functional-tomcat8-postgresql94-jdk8]=true,true
-    test.batch.run.property.names[functional-tomcat8-sybase16-jdk8]=portal.smoke,portal.upgrades
-    test.batch.run.property.values[functional-tomcat8-sybase16-jdk8]=true,true
+    test.batch.run.property.names[functional-tomcat8-sybase16-jdk8]=portal.smoke
+    test.batch.run.property.values[functional-tomcat8-sybase16-jdk8]=true
+    #test.batch.run.property.names[functional-tomcat8-sybase16-jdk8]=portal.smoke,portal.upgrades
+    #test.batch.run.property.values[functional-tomcat8-sybase16-jdk8]=true,true
     test.batch.run.property.names[functional-weblogic121-mysql56-jdk8]=portal.smoke
     test.batch.run.property.values[functional-weblogic121-mysql56-jdk8]=true
     test.batch.run.property.names[functional-websphere85-mysql56-jdk8]=portal.smoke

--- a/test.properties
+++ b/test.properties
@@ -985,8 +985,10 @@
     test.batch.run.property.values[functional-tomcat8-mysql56-jdk8]=true,true
     test.batch.run.property.names[functional-tomcat8-mysql56-jdk8-quarantine]=portal.acceptance.quarantine
     test.batch.run.property.values[functional-tomcat8-mysql56-jdk8-quarantine]=true
-    test.batch.run.property.names[functional-tomcat8-oracle12-jdk8]=portal.smoke,portal.upgrades
-    test.batch.run.property.values[functional-tomcat8-oracle12-jdk8]=true,true
+    test.batch.run.property.names[functional-tomcat8-oracle12-jdk8]=portal.smoke
+    test.batch.run.property.values[functional-tomcat8-oracle12-jdk8]=true
+    #test.batch.run.property.names[functional-tomcat8-oracle12-jdk8]=portal.smoke,portal.upgrades
+    #test.batch.run.property.values[functional-tomcat8-oracle12-jdk8]=true,true
     test.batch.run.property.names[functional-tomcat8-postgresql94-jdk8]=portal.smoke,portal.upgrades
     test.batch.run.property.values[functional-tomcat8-postgresql94-jdk8]=true,true
     test.batch.run.property.names[functional-tomcat8-sybase16-jdk8]=portal.smoke


### PR DESCRIPTION
Sybase and Oracle upgrades tests are failing due to [LRQA-25821](https://issues.liferay.com/browse/LRQA-25821) and [LRQA-26205](https://issues.liferay.com/browse/LRQA-26205), and we don't have time to fix them prior to getting the Journal sub-repo up and running. We will still run PortalSmoke on both databases in the PR Tester to make sure they're still working.