### PR TITLE
LRQA-27926

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -435,13 +435,17 @@ app.server.type=@{app.server.type}]]></echo>
 /*/*/javadoc
 /*/*/lib
 /*/*/tmp
+/*/*/*/build/node
 /*/*/*/ivy.xml.MD5
 /*/*/*/javadoc
 /*/*/*/lib
+/*/*/*/node_modules
 /*/*/*/tmp
+/*/*/*/*/build/node
 /*/*/*/*/ivy.xml.MD5
 /*/*/*/*/javadoc
 /*/*/*/*/lib
+/*/*/*/*/node_modules
 /*/*/*/*/tmp</echo>
 
 			<delete>

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1806,7 +1806,15 @@ ${output.content}</echo>
 			</test-action>
 
 			<test-set-up>
-				<prepare-test-build />
+				<if>
+					<isset property="env.DIST_PATH" />
+					<then>
+						<prepare-test-environment />
+					</then>
+					<else>
+						<prepare-test-build />
+					</else>
+				</if>
 			</test-set-up>
 		</run-batch-test>
 	</target>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-27926

@pyoo47, because of the npm caching mechanism that was recently created, node_modules directories are created in modules that require npm packages as frontend dependencies. This results in a lot of extra files that are being added to the source zips in the tomcat dist job. Currently, I think this is about 1 GB of extra files, but will be much more as more modules use the npm mechanism. These files are not required in any batch jobs. It eventually will be needed in the frontend js batch job, but that will only be one batch job. Let me know if you have any questions, thanks\!