### PR TITLE
master-qa-28850

### DIFF
--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -2832,7 +2832,7 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void typeEditor(String locator, String value) throws Exception {
+	public void typeEditor(String locator, String value) {
 		WebDriverHelper.typeEditor(this, locator, value);
 	}
 

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySelenium.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySelenium.java
@@ -609,7 +609,7 @@ public interface LiferaySelenium {
 
 	public void typeCKEditor(String locator, String value);
 
-	public void typeEditor(String locator, String value) throws Exception;
+	public void typeEditor(String locator, String value);
 
 	public void typeKeys(String locator, String value);
 

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/WebDriverHelper.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/WebDriverHelper.java
@@ -1004,15 +1004,9 @@ public class WebDriverHelper {
 	}
 
 	public static void typeEditor(
-			WebDriver webDriver, String locator, String value)
-		throws Exception {
+		WebDriver webDriver, String locator, String value) {
 
 		WebElement webElement = getWebElement(webDriver, locator);
-
-		if (webElement == null) {
-			throw new Exception(
-				"Element is not present at \"" + locator + "\"");
-		}
 
 		WrapsDriver wrapsDriver = (WrapsDriver)webElement;
 

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/WebDriverHelper.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/WebDriverHelper.java
@@ -1006,28 +1006,21 @@ public class WebDriverHelper {
 	public static void typeEditor(
 		WebDriver webDriver, String locator, String value) {
 
-		WebElement webElement = getWebElement(webDriver, locator);
-
-		WrapsDriver wrapsDriver = (WrapsDriver)webElement;
+		WrapsDriver wrapsDriver = (WrapsDriver)getWebElement(
+			webDriver, locator);
 
 		JavascriptExecutor javascriptExecutor =
 			(JavascriptExecutor)wrapsDriver.getWrappedDriver();
 
 		StringBuilder sb = new StringBuilder();
 
-		if (locator.contains("cke")) {
-			sb.append("var element = arguments[0].contentWindow.document;");
-			sb.append("element.body.textContent = '");
-		}
-		else {
-			sb.append("var element = arguments[0];");
-			sb.append("element.textContent = '");
-		}
+		sb.append("CKEDITOR.instances[\"");
+		sb.append(getEditorName(webDriver, locator));
+		sb.append("\"].setData(\"");
+		sb.append(HtmlUtil.escapeJS(value.replace("\\", "\\\\")));
+		sb.append("\");");
 
-		sb.append(value);
-		sb.append("';");
-
-		javascriptExecutor.executeScript(sb.toString(), webElement);
+		javascriptExecutor.executeScript(sb.toString());
 	}
 
 	public static void uncheck(WebDriver webdDriver, String locator) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-28850

I'm reverting these two commits because the updated typeEditor method is unable to type into a comment field, and would cause acceptance tests to fail. There's currently not a clean way of typing into CKEditor fields (CKEditor, AlloyEditor) without using the CKEditor API, so I'll leave the original typeEditor method as is.

cc @kenjiheigel @lesliewong92