### PR TITLE
LRQA-29185 Update poshi validation for errors involving comments

### DIFF
--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
@@ -35,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.dom4j.Document;
+import org.dom4j.DocumentException;
 import org.dom4j.Element;
 import org.dom4j.io.SAXReader;
 
@@ -331,7 +332,15 @@ public class PoshiRunnerGetterUtil {
 
 		SAXReader saxReader = new SAXReader();
 
-		Document document = saxReader.read(inputStream);
+		Document document = null;
+
+		try {
+			document = saxReader.read(inputStream);
+		}
+		catch (DocumentException de) {
+			throw new Exception(
+				de.getMessage() + "\nInvalid syntax in " + filePath);
+		}
 
 		Element rootElement = document.getRootElement();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-29185 

@pyoo, just making the validation less cryptic. We had an issue today where poshi validation failed, but we didn't know what caused it. There's more information in the ticket. I discussed this with Hashi briefly.