### PR TITLE
LRQA-32963 PluginGitIDFailureMessage was missing a slash in the plugi…

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginGitIDFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PluginGitIDFailureMessageGenerator.java
@@ -102,7 +102,7 @@ public class PluginGitIDFailureMessageGenerator
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("https://github.com/liferay");
+		sb.append("https://github.com/liferay/");
 		sb.append(pluginsRepositoryName);
 		sb.append("/commits/");
 		sb.append(


### PR DESCRIPTION
…ns link