### PR TITLE
LRQA-32801 Implement round-trip conversion logic between poshi syntax and a more readable syntax

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
@@ -14,7 +14,9 @@
 
 package com.liferay.poshi.runner;
 
+import com.liferay.poshi.runner.elements.PoshiElementFactory;
 import com.liferay.poshi.runner.selenium.SeleniumUtil;
+import com.liferay.poshi.runner.util.Dom4JUtil;
 import com.liferay.poshi.runner.util.ExternalMethod;
 import com.liferay.poshi.runner.util.FileUtil;
 import com.liferay.poshi.runner.util.OSDetector;
@@ -250,12 +252,25 @@ public class PoshiRunnerGetterUtil {
 	public static Element getRootElementFromFilePath(String filePath)
 		throws Exception {
 
+		String fileContent = FileUtil.read(filePath);
+
+		System.out.println(filePath);
+
+		if (!fileContent.contains("<definition") &&
+			filePath.endsWith(".testcase")) {
+
+			Element element = PoshiElementFactory.newPoshiElementFromFile(
+				filePath);
+
+			fileContent = Dom4JUtil.format(element);
+		}
+
 		boolean cdata = false;
 		int lineNumber = 1;
 		StringBuilder sb = new StringBuilder();
 
 		BufferedReader bufferedReader = new BufferedReader(
-			new StringReader(FileUtil.read(filePath)));
+			new StringReader(fileContent));
 
 		String line = null;
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
@@ -16,7 +16,6 @@ package com.liferay.poshi.runner;
 
 import com.liferay.poshi.runner.elements.PoshiElementFactory;
 import com.liferay.poshi.runner.selenium.SeleniumUtil;
-import com.liferay.poshi.runner.util.Dom4JUtil;
 import com.liferay.poshi.runner.util.ExternalMethod;
 import com.liferay.poshi.runner.util.FileUtil;
 import com.liferay.poshi.runner.util.OSDetector;
@@ -259,10 +258,7 @@ public class PoshiRunnerGetterUtil {
 		if (!fileContent.contains("<definition") &&
 			filePath.endsWith(".testcase")) {
 
-			Element element = PoshiElementFactory.newPoshiElementFromFile(
-				filePath);
-
-			fileContent = Dom4JUtil.format(element);
+			return PoshiElementFactory.newPoshiElementFromFile(filePath);
 		}
 
 		boolean cdata = false;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerGetterUtil.java
@@ -253,8 +253,6 @@ public class PoshiRunnerGetterUtil {
 
 		String fileContent = FileUtil.read(filePath);
 
-		System.out.println(filePath);
-
 		if (!fileContent.contains("<definition") &&
 			filePath.endsWith(".testcase")) {
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -86,10 +86,7 @@ public class CommandElement extends PoshiElement {
 				continue;
 			}
 
-			Element element = PoshiElementFactory.newPoshiElement(
-				readableBlock);
-
-			add(element);
+			add(PoshiElementFactory.newPoshiElement(readableBlock));
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -65,7 +65,7 @@ public class CommandElement extends PoshiElement {
 
 	@Override
 	public void addElements(String readableSyntax) {
-		List<String> readableBlocks = StringUtil.split(
+		List<String> readableBlocks = StringUtil.partition(
 			readableSyntax, READABLE_EXECUTE_BLOCK_KEYS);
 
 		for (String readableBlock : readableBlocks) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -14,7 +14,15 @@
 
 package com.liferay.poshi.runner.elements;
 
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.BACKGROUND;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.DESCRIPTION;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.FEATURE;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.PRIORITY;
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.SCENARIO;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.SETUP;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.TEARDOWN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_PROPERTIES;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_VARIABLES;
 import static com.liferay.poshi.runner.util.StringPool.COLON;
 
 import com.liferay.poshi.runner.util.StringUtil;
@@ -46,10 +54,43 @@ public class CommandElement extends PoshiElement {
 
 	@Override
 	public void addAttributes(String readableSyntax) {
+		if (readableSyntax.contains("Description:")) {
+			_addDescriptionAttribute(readableSyntax);
+		}
+
+		addAttribute("name", _getCommandName(readableSyntax));
+
+		_addPriorityAttribute(readableSyntax);
 	}
 
 	@Override
 	public void addElements(String readableSyntax) {
+		List<String> readableBlocks = StringUtil.split(
+			readableSyntax, READABLE_EXECUTE_BLOCK_KEYS);
+
+		for (String readableBlock : readableBlocks) {
+			if (readableBlock.contains(BACKGROUND) ||
+				readableBlock.contains(FEATURE) ||
+				readableBlock.contains(SCENARIO) ||
+				readableBlock.contains(SETUP) ||
+				readableBlock.contains(TEARDOWN)) {
+
+				continue;
+			}
+
+			if (readableBlock.contains(THESE_PROPERTIES) ||
+				readableBlock.contains(THESE_VARIABLES)) {
+
+				addVariableElements(readableBlock);
+
+				continue;
+			}
+
+			Element element = PoshiElementFactory.newPoshiElement(
+				readableBlock);
+
+			add(element);
+		}
 	}
 
 	@Override
@@ -89,6 +130,25 @@ public class CommandElement extends PoshiElement {
 
 	protected String getReadableCommandTitle() {
 		return SCENARIO + COLON;
+	}
+
+	private void _addDescriptionAttribute(String readableSyntax) {
+		String description = getAttributeValue(
+			DESCRIPTION + COLON, readableSyntax);
+
+		addAttribute("description", description);
+	}
+
+	private void _addPriorityAttribute(String readableSyntax) {
+		String priority = getAttributeValue(PRIORITY + COLON, readableSyntax);
+
+		addAttribute("priority", priority);
+	}
+
+	private String _getCommandName(String readableSyntax) {
+		String scenario = getAttributeValue(SCENARIO + COLON, readableSyntax);
+
+		return StringUtil.removeSpaces(scenario);
 	}
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.SCENARIO;
+import static com.liferay.poshi.runner.util.StringPool.COLON;
+
+import com.liferay.poshi.runner.util.StringUtil;
+
+import java.util.List;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class CommandElement extends PoshiElement {
+
+	public CommandElement(Element element) {
+		this("command", element);
+	}
+
+	public CommandElement(String name, Element element) {
+		super(name, element);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n");
+		sb.append(getReadableCommandTitle());
+		sb.append(" ");
+
+		if (attributeValue("name") != null) {
+			String name = attributeValue("name");
+
+			sb.append(toPhrase(name));
+		}
+
+		if (attributeValue("description") != null) {
+			String description = attributeValue("description");
+
+			sb.append("\n");
+			sb.append("Description: ");
+			sb.append(description);
+		}
+
+		if (attributeValue("priority") != null) {
+			String priority = attributeValue("priority");
+
+			sb.append("\n");
+			sb.append("Priority: ");
+			sb.append(priority);
+		}
+
+		sb.append(super.toReadableSyntax());
+
+		return sb.toString();
+	}
+
+	protected String getReadableCommandTitle() {
+		return SCENARIO + COLON;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -45,6 +45,14 @@ public class CommandElement extends PoshiElement {
 	}
 
 	@Override
+	public void addAttributes(String readableSyntax) {
+	}
+
+	@Override
+	public void addElements(String readableSyntax) {
+	}
+
+	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -32,8 +32,16 @@ public class CommandElement extends PoshiElement {
 		this("command", element);
 	}
 
+	public CommandElement(String readableSyntax) {
+		this("command", readableSyntax);
+	}
+
 	public CommandElement(String name, Element element) {
 		super(name, element);
+	}
+
+	public CommandElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -44,10 +44,34 @@ public class DefinitionElement extends PoshiElement {
 
 	@Override
 	public void addAttributes(String readableSyntax) {
+		addAttribute("component-name", "portal-acceptance");
 	}
 
 	@Override
 	public void addElements(String readableSyntax) {
+		List<String> readableBlocks = StringUtil.split(
+			readableSyntax, READABLE_COMMAND_BLOCK_KEYS);
+
+		for (String readableBlock : readableBlocks) {
+			if (readableBlock.startsWith(FEATURE)) {
+				continue;
+			}
+			else if (readableBlock.startsWith(BACKGROUND)) {
+				List<String> readableCommandBlocks = StringUtil.split(
+					readableBlock, READABLE_COMMAND_BLOCK_KEYS);
+
+				for (String readableCommandBlock : readableCommandBlocks) {
+					addVariableElements(readableCommandBlock);
+				}
+
+				continue;
+			}
+
+			Element element = PoshiElementFactory.newPoshiElement(
+				readableBlock);
+
+			add(element);
+		}
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -24,7 +24,6 @@ import static com.liferay.poshi.runner.util.StringPool.COLON;
 
 import com.liferay.poshi.runner.util.StringUtil;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.dom4j.Element;
@@ -88,10 +87,8 @@ public class DefinitionElement extends PoshiElement {
 		sb.append(" ");
 		sb.append(THESE_PROPERTIES);
 
-		for (Iterator<PoshiElement> i =
-			elementIterator("property"); i.hasNext();) {
-
-			PoshiElement poshiElement = i.next();
+		for (PoshiElement poshiElement :
+				toPoshiElementList(elements("property"))) {
 
 			sb.append(poshiElement.toReadableSyntax());
 		}
@@ -102,41 +99,29 @@ public class DefinitionElement extends PoshiElement {
 			sb.append(" ");
 			sb.append(THESE_VARIABLES);
 
-			for (Iterator<PoshiElement> i = elementIterator("var");
-				 i.hasNext();) {
-
-				PoshiElement poshiElement = i.next();
-
+			for (PoshiElement poshiElement : toPoshiElementList(elements())) {
 				sb.append(poshiElement.toReadableSyntax());
 			}
 		}
 
 		sb.append("\n");
 
-		for (Iterator<PoshiElement> i = elementIterator("set-up");
-			 i.hasNext();) {
-
-			PoshiElement poshiElement = i.next();
+		for (PoshiElement poshiElement :
+				toPoshiElementList(elements("set-up"))) {
 
 			sb.append(poshiElement.toReadableSyntax());
 		}
 
 		sb.append("\n");
 
-		for (Iterator<PoshiElement> i = elementIterator("tear-down");
-			 i.hasNext();) {
-
-			PoshiElement poshiElement = i.next();
+		for (PoshiElement poshiElement :
+				toPoshiElementList(elements("tear-down"))) {
 
 			sb.append(poshiElement.toReadableSyntax());
 		}
 
-		for (Iterator<PoshiElement> i = elementIterator("command");
-			 i.hasNext();) {
-
-			sb.append("\n");
-
-			PoshiElement poshiElement = i.next();
+		for (PoshiElement poshiElement :
+				toPoshiElementList(elements("command"))) {
 
 			sb.append(poshiElement.toReadableSyntax());
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -38,6 +38,10 @@ public class DefinitionElement extends PoshiElement {
 		super("definition", element);
 	}
 
+	public DefinitionElement(String readableSyntax) {
+		super("definition", readableSyntax);
+	}
+
 	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.AND;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.BACKGROUND;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.FEATURE;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.GIVEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_PROPERTIES;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_VARIABLES;
+import static com.liferay.poshi.runner.util.StringPool.COLON;
+
+import com.liferay.poshi.runner.util.StringUtil;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class DefinitionElement extends PoshiElement {
+
+	public DefinitionElement(Element element) {
+		super("definition", element);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(FEATURE);
+		sb.append(COLON);
+		sb.append("\n\n");
+		sb.append(BACKGROUND);
+		sb.append(": This executes once per feature file");
+		sb.append("\n\t");
+		sb.append(GIVEN);
+		sb.append(" ");
+		sb.append(THESE_PROPERTIES);
+
+		for (Iterator<PoshiElement> i =
+			elementIterator("property"); i.hasNext();) {
+
+			PoshiElement poshiElement = i.next();
+
+			sb.append(poshiElement.toReadableSyntax());
+		}
+
+		if (elements("var").size() != 0) {
+			sb.append("\n\t");
+			sb.append(AND);
+			sb.append(" ");
+			sb.append(THESE_VARIABLES);
+
+			for (Iterator<PoshiElement> i = elementIterator("var");
+				 i.hasNext();) {
+
+				PoshiElement poshiElement = i.next();
+
+				sb.append(poshiElement.toReadableSyntax());
+			}
+		}
+
+		sb.append("\n");
+
+		for (Iterator<PoshiElement> i = elementIterator("set-up");
+			 i.hasNext();) {
+
+			PoshiElement poshiElement = i.next();
+
+			sb.append(poshiElement.toReadableSyntax());
+		}
+
+		sb.append("\n");
+
+		for (Iterator<PoshiElement> i = elementIterator("tear-down");
+			 i.hasNext();) {
+
+			PoshiElement poshiElement = i.next();
+
+			sb.append(poshiElement.toReadableSyntax());
+		}
+
+		for (Iterator<PoshiElement> i = elementIterator("command");
+			 i.hasNext();) {
+
+			sb.append("\n");
+
+			PoshiElement poshiElement = i.next();
+
+			sb.append(poshiElement.toReadableSyntax());
+		}
+
+		return sb.toString();
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -66,10 +66,10 @@ public class DefinitionElement extends PoshiElement {
 				continue;
 			}
 
-			Element element = PoshiElementFactory.newPoshiElement(
+			PoshiElement poshiElement = PoshiElementFactory.newPoshiElement(
 				readableBlock);
 
-			add(element);
+			add(poshiElement);
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -43,6 +43,14 @@ public class DefinitionElement extends PoshiElement {
 	}
 
 	@Override
+	public void addAttributes(String readableSyntax) {
+	}
+
+	@Override
+	public void addElements(String readableSyntax) {
+	}
+
+	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -48,7 +48,7 @@ public class DefinitionElement extends PoshiElement {
 
 	@Override
 	public void addElements(String readableSyntax) {
-		List<String> readableBlocks = StringUtil.split(
+		List<String> readableBlocks = StringUtil.partition(
 			readableSyntax, READABLE_COMMAND_BLOCK_KEYS);
 
 		for (String readableBlock : readableBlocks) {
@@ -56,7 +56,7 @@ public class DefinitionElement extends PoshiElement {
 				continue;
 			}
 			else if (readableBlock.startsWith(BACKGROUND)) {
-				List<String> readableCommandBlocks = StringUtil.split(
+				List<String> readableCommandBlocks = StringUtil.partition(
 					readableBlock, READABLE_COMMAND_BLOCK_KEYS);
 
 				for (String readableCommandBlock : readableCommandBlocks) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -38,6 +38,14 @@ public class ExecuteElement extends PoshiElement {
 	}
 
 	@Override
+	public void addAttributes(String readableSyntax) {
+	}
+
+	@Override
+	public void addElements(String readableSyntax) {
+	}
+
+	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -62,7 +62,7 @@ public class ExecuteElement extends PoshiElement {
 
 	@Override
 	public void addElements(String readableSyntax) {
-		List<String> readableBlocks = StringUtil.split(
+		List<String> readableBlocks = StringUtil.partition(
 			readableSyntax, READABLE_VARIABLE_BLOCK_KEYS);
 
 		for (String readableBlock : readableBlocks) {
@@ -148,7 +148,7 @@ public class ExecuteElement extends PoshiElement {
 	private void _addFunctionAttributes(String readableSyntax) {
 		String[] keys = {AT_LOCATOR, THE_VALUE};
 
-		List<String> functionItems = StringUtil.split(readableSyntax, keys);
+		List<String> functionItems = StringUtil.partition(readableSyntax, keys);
 
 		for (String functionItem : functionItems) {
 			if (functionItem.contains(AT_LOCATOR)) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -74,10 +74,10 @@ public class ExecuteElement extends PoshiElement {
 				continue;
 			}
 
-			Element element = PoshiElementFactory.newPoshiElement(
+			PoshiElement poshiElement = PoshiElementFactory.newPoshiElement(
 				readableBlock);
 
-			add(element);
+			add(poshiElement);
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -33,6 +33,10 @@ public class ExecuteElement extends PoshiElement {
 		super("execute", element);
 	}
 
+	public ExecuteElement(String readableSyntax) {
+		super("execute", readableSyntax);
+	}
+
 	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.AT_LOCATOR;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THE_VALUE;
+
+import com.liferay.poshi.runner.util.StringUtil;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ExecuteElement extends PoshiElement {
+
+	public ExecuteElement(Element element) {
+		super("execute", element);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n\t");
+		sb.append(getReadableExecuteKey());
+
+		if (attributeValue("function") != null) {
+			sb.append(" ");
+
+			String function = attributeValue("function");
+
+			sb.append(_getReadableSyntaxCommandPhrase(function));
+
+			List<String> functionAttributes = Arrays.asList(
+				"value1", "locator1", "value2", "locator2");
+
+			for (String functionAttribute : functionAttributes) {
+				if (attributeValue(functionAttribute) != null) {
+					if (functionAttribute.startsWith("locator")) {
+						sb.append(" ");
+						sb.append(AT_LOCATOR);
+					}
+					else {
+						sb.append(" ");
+						sb.append(THE_VALUE);
+					}
+
+					sb.append(" '");
+
+					sb.append(attributeValue(functionAttribute));
+
+					sb.append("'");
+				}
+			}
+		}
+		else if (attributeValue("macro") != null) {
+			sb.append(" ");
+
+			String macro = attributeValue("macro");
+
+			sb.append(_getReadableSyntaxCommandPhrase(macro));
+		}
+
+		sb.append(super.toReadableSyntax());
+
+		return sb.toString();
+	}
+
+	private String _getReadableSyntaxCommandPhrase(String classCommandName) {
+		StringBuilder sb = new StringBuilder();
+
+		if (classCommandName.contains("#")) {
+			String className = classCommandName.split("#")[0];
+
+			sb.append(className);
+
+			sb.append(" ");
+
+			String commandName = classCommandName.split("#")[1];
+
+			String commandPhrase = toPhrase(commandName);
+
+			sb.append(commandPhrase);
+
+			return sb.toString();
+		}
+
+		return classCommandName;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -147,8 +147,7 @@ public class ExecuteElement extends PoshiElement {
 	private void _addFunctionAttributes(String readableSyntax) {
 		String[] keys = {AT_LOCATOR, THE_VALUE};
 
-		List<String> functionItems = StringUtil.split(
-			readableSyntax, keys);
+		List<String> functionItems = StringUtil.split(readableSyntax, keys);
 
 		for (String functionItem : functionItems) {
 			if (functionItem.contains(AT_LOCATOR)) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -14,13 +14,21 @@
 
 package com.liferay.poshi.runner.elements;
 
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.AND;
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.AT_LOCATOR;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.GIVEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THEN;
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THE_VALUE;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.WHEN;
 
 import com.liferay.poshi.runner.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.dom4j.Element;
 
@@ -39,10 +47,38 @@ public class ExecuteElement extends PoshiElement {
 
 	@Override
 	public void addAttributes(String readableSyntax) {
+		if (readableSyntax.contains(AT_LOCATOR) ||
+			readableSyntax.contains(THE_VALUE)) {
+
+			_attributes = new TreeMap<>();
+
+			_addFunctionAttributes(readableSyntax);
+
+			return;
+		}
+
+		addAttribute("macro", _getClassCommandName(readableSyntax));
 	}
 
 	@Override
 	public void addElements(String readableSyntax) {
+		List<String> readableBlocks = StringUtil.split(
+			readableSyntax, READABLE_VARIABLE_BLOCK_KEYS);
+
+		for (String readableBlock : readableBlocks) {
+			readableBlock = readableBlock.trim();
+
+			if (readableBlock.contains(AND) || readableBlock.contains(GIVEN) ||
+				readableBlock.contains(THEN) || readableBlock.contains(WHEN)) {
+
+				continue;
+			}
+
+			Element element = PoshiElementFactory.newPoshiElement(
+				readableBlock);
+
+			add(element);
+		}
 	}
 
 	@Override
@@ -94,6 +130,85 @@ public class ExecuteElement extends PoshiElement {
 		return sb.toString();
 	}
 
+	private void _addFunctionAttribute(
+		String readableSyntax, String attributeType) {
+
+		String attributeValue = getAttributeValue("'", "'", readableSyntax);
+
+		if (attributeValue(attributeType + "1") == null) {
+			_attributes.put(attributeType + "1", attributeValue);
+
+			return;
+		}
+
+		_attributes.put(attributeType + "2", attributeValue);
+	}
+
+	private void _addFunctionAttributes(String readableSyntax) {
+		String[] keys = {AT_LOCATOR, THE_VALUE};
+
+		List<String> functionItems = StringUtil.split(
+			readableSyntax, keys);
+
+		for (String functionItem : functionItems) {
+			if (functionItem.contains(AT_LOCATOR)) {
+				_addFunctionAttribute(functionItem, "locator");
+
+				continue;
+			}
+
+			if (functionItem.contains(THE_VALUE)) {
+				_addFunctionAttribute(functionItem, "value");
+
+				continue;
+			}
+
+			_attributes.put("function", _getClassCommandName(functionItem));
+		}
+
+		for (String key : _attributes.keySet()) {
+			addAttribute(key, _attributes.get(key));
+		}
+	}
+
+	private String _getClassCommandName(String readableSyntax) {
+		int index = readableSyntax.indexOf("\n");
+
+		if (index < 0) {
+			index = readableSyntax.length();
+		}
+
+		String line = readableSyntax.substring(0, index);
+
+		for (String key : READABLE_EXECUTE_BLOCK_KEYS) {
+			if (line.startsWith(key)) {
+				Pattern pattern = Pattern.compile(
+					".*?" + key + ".*?.([A-z]*)(.*)");
+
+				Matcher matcher = pattern.matcher(line);
+
+				if (matcher.find()) {
+					StringBuilder sb = new StringBuilder();
+
+					sb.append(matcher.group(1));
+
+					String commandName = matcher.group(2);
+
+					commandName = StringUtil.removeSpaces(commandName);
+
+					if (commandName.length() > 0) {
+						sb.append("#");
+						sb.append(commandName);
+					}
+
+					return sb.toString();
+				}
+			}
+		}
+
+		return null;
+	}
+
 	private String _getReadableSyntaxCommandPhrase(String classCommandName) {
 		StringBuilder sb = new StringBuilder();
 
@@ -115,5 +230,7 @@ public class ExecuteElement extends PoshiElement {
 
 		return classCommandName;
 	}
+
+	private Map<String, String> _attributes;
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -25,8 +25,6 @@ import com.liferay.poshi.runner.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,8 +47,6 @@ public class ExecuteElement extends PoshiElement {
 	public void addAttributes(String readableSyntax) {
 		if (readableSyntax.contains(AT_LOCATOR) ||
 			readableSyntax.contains(THE_VALUE)) {
-
-			_attributes = new TreeMap<>();
 
 			_addFunctionAttributes(readableSyntax);
 
@@ -137,12 +133,12 @@ public class ExecuteElement extends PoshiElement {
 		String attributeValue = getAttributeValue("'", "'", readableSyntax);
 
 		if (attributeValue(attributeType + "1") == null) {
-			_attributes.put(attributeType + "1", attributeValue);
+			addAttribute(attributeType + "1", attributeValue);
 
 			return;
 		}
 
-		_attributes.put(attributeType + "2", attributeValue);
+		addAttribute(attributeType + "2", attributeValue);
 	}
 
 	private void _addFunctionAttributes(String readableSyntax) {
@@ -163,11 +159,7 @@ public class ExecuteElement extends PoshiElement {
 				continue;
 			}
 
-			_attributes.put("function", _getClassCommandName(functionItem));
-		}
-
-		for (String key : _attributes.keySet()) {
-			addAttribute(key, _attributes.get(key));
+			addAttribute("function", _getClassCommandName(functionItem));
 		}
 	}
 
@@ -230,7 +222,5 @@ public class ExecuteElement extends PoshiElement {
 
 		return classCommandName;
 	}
-
-	private Map<String, String> _attributes;
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -99,7 +99,10 @@ public class ExecuteElement extends PoshiElement {
 				"value1", "locator1", "value2", "locator2");
 
 			for (String functionAttribute : functionAttributes) {
-				if (attributeValue(functionAttribute) != null) {
+				String functionAttributeValue = attributeValue(
+					functionAttribute);
+
+				if (functionAttributeValue != null) {
 					if (functionAttribute.startsWith("locator")) {
 						sb.append(" ");
 						sb.append(AT_LOCATOR);
@@ -110,9 +113,7 @@ public class ExecuteElement extends PoshiElement {
 					}
 
 					sb.append(" '");
-
-					sb.append(attributeValue(functionAttribute));
-
+					sb.append(functionAttributeValue);
 					sb.append("'");
 				}
 			}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.AND;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.GIVEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.WHEN;
+
+import com.liferay.poshi.runner.util.StringUtil;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.dom4j.Attribute;
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
+
+/**
+ * @author Kenji Heigel
+ */
+public abstract class PoshiElement extends DefaultElement {
+
+	public PoshiElement(String name, Element element) {
+		super(name);
+
+		_addAttributes(element);
+		_addElements(element);
+	}
+
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		for (Iterator<PoshiElement> i = elementIterator(); i.hasNext();) {
+			PoshiElement poshiElement = i.next();
+
+			sb.append(poshiElement.toReadableSyntax());
+		}
+
+		return sb.toString();
+	}
+
+	protected String getReadableExecuteKey() {
+		List<Element> siblingElements = getSiblingElements();
+
+		int index = siblingElements.indexOf(this);
+
+		if (index == 0) {
+			return GIVEN;
+		}
+
+		if (index == 1) {
+			return WHEN;
+		}
+
+		if (index == (siblingElements.size() - 1)) {
+			return THEN;
+		}
+
+		return AND;
+	}
+
+	protected List<Element> getSiblingElements() {
+		Element parentElement = getParent();
+
+		return parentElement.elements();
+	}
+
+	protected static String toPhrase(String s) {
+		String phrase = s.replaceAll(_PHRASE_REGEX, " $0");
+
+		if (phrase.startsWith(" ")) {
+			return phrase.substring(1);
+		}
+
+		return phrase;
+	}
+
+	private void _addAttributes(Element element) {
+		for (Iterator i = element.attributeIterator(); i.hasNext();) {
+			Attribute attribute = (Attribute)i.next();
+
+			add((Attribute)attribute.clone());
+		}
+	}
+
+	private void _addElements(Element element) {
+		for (Iterator i = element.elementIterator(); i.hasNext();) {
+			Element childElement = PoshiElementFactory.newPoshiElement(
+				(Element)i.next());
+
+			add(childElement);
+		}
+	}
+
+	private static final String _PHRASE_REGEX =
+		"([\\d]+|[A-Z][a-z]+|[A-Z]+(?![a-z]))";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -96,6 +96,16 @@ public abstract class PoshiElement extends DefaultElement {
 		return sb.toString();
 	}
 
+	protected static String toPhrase(String s) {
+		String phrase = s.replaceAll(_PHRASE_REGEX, " $0");
+
+		if (phrase.startsWith(" ")) {
+			return phrase.substring(1);
+		}
+
+		return phrase;
+	}
+
 	protected String getAttributeValue(String startKey, String readableSyntax) {
 		return getAttributeValue(startKey, "\n", readableSyntax);
 	}
@@ -137,16 +147,6 @@ public abstract class PoshiElement extends DefaultElement {
 		Element parentElement = getParent();
 
 		return parentElement.elements();
-	}
-
-	protected static String toPhrase(String s) {
-		String phrase = s.replaceAll(_PHRASE_REGEX, " $0");
-
-		if (phrase.startsWith(" ")) {
-			return phrase.substring(1);
-		}
-
-		return phrase;
 	}
 
 	protected static final String[] READABLE_COMMAND_BLOCK_KEYS = {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -28,9 +28,10 @@ import static com.liferay.poshi.runner.util.StringPool.COLON;
 import static com.liferay.poshi.runner.util.StringPool.PIPE;
 import static com.liferay.poshi.runner.util.StringPool.TAB;
 
+import com.liferay.poshi.runner.util.Dom4JUtil;
 import com.liferay.poshi.runner.util.StringUtil;
 
-import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.dom4j.Attribute;
@@ -87,9 +88,7 @@ public abstract class PoshiElement extends DefaultElement {
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 
-		for (Iterator<PoshiElement> i = elementIterator(); i.hasNext();) {
-			PoshiElement poshiElement = i.next();
-
+		for (PoshiElement poshiElement : toPoshiElementList(elements())) {
 			sb.append(poshiElement.toReadableSyntax());
 		}
 
@@ -146,7 +145,21 @@ public abstract class PoshiElement extends DefaultElement {
 	protected List<Element> getSiblingElements() {
 		Element parentElement = getParent();
 
-		return parentElement.elements();
+		return Dom4JUtil.toElementList(parentElement.elements());
+	}
+
+	protected List<PoshiElement> toPoshiElementList(List<?> list) {
+		if (list == null) {
+			return null;
+		}
+
+		List<PoshiElement> elementList = new ArrayList<>(list.size());
+
+		for (Object object : list) {
+			elementList.add((PoshiElement)object);
+		}
+
+		return elementList;
 	}
 
 	protected static final String[] READABLE_COMMAND_BLOCK_KEYS = {
@@ -163,19 +176,18 @@ public abstract class PoshiElement extends DefaultElement {
 	};
 
 	private void _addAttributes(Element element) {
-		for (Iterator i = element.attributeIterator(); i.hasNext();) {
-			Attribute attribute = (Attribute)i.next();
+		for (Attribute attribute :
+				Dom4JUtil.toAttributeList(element.attributes())) {
 
 			add((Attribute)attribute.clone());
 		}
 	}
 
 	private void _addElements(Element element) {
-		for (Iterator i = element.elementIterator(); i.hasNext();) {
-			Element childElement = PoshiElementFactory.newPoshiElement(
-				(Element)i.next());
+		for (Element childElement :
+				Dom4JUtil.toElementList(element.elements())) {
 
-			add(childElement);
+			add(PoshiElementFactory.newPoshiElement(childElement));
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -78,10 +78,10 @@ public abstract class PoshiElement extends DefaultElement {
 				continue;
 			}
 
-			Element element = PoshiElementFactory.newPoshiElement(
+			PoshiElement poshiElement = PoshiElementFactory.newPoshiElement(
 				readableVariableBlock);
 
-			add(element);
+			add(poshiElement);
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -40,6 +40,10 @@ public abstract class PoshiElement extends DefaultElement {
 		_addElements(element);
 	}
 
+	public PoshiElement(String name, String readableSyntax) {
+		super(name);
+	}
+
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -15,9 +15,18 @@
 package com.liferay.poshi.runner.elements;
 
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.AND;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.BACKGROUND;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.FEATURE;
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.GIVEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.SCENARIO;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.SETUP;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.TEARDOWN;
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_PROPERTIES;
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.WHEN;
+import static com.liferay.poshi.runner.util.StringPool.COLON;
+import static com.liferay.poshi.runner.util.StringPool.PIPE;
+import static com.liferay.poshi.runner.util.StringPool.TAB;
 
 import com.liferay.poshi.runner.util.StringUtil;
 
@@ -44,6 +53,30 @@ public abstract class PoshiElement extends DefaultElement {
 		super(name);
 	}
 
+	public void addVariableElements(String readableSyntax) {
+		List<String> readableVariableBlocks = StringUtil.split(
+			readableSyntax, READABLE_VARIABLE_BLOCK_KEYS);
+
+		for (String readableVariableBlock : readableVariableBlocks) {
+			if (!readableVariableBlock.contains(PIPE)) {
+				continue;
+			}
+
+			if (readableSyntax.contains(THESE_PROPERTIES)) {
+				Element element = new PropertyElement(readableVariableBlock);
+
+				add(element);
+
+				continue;
+			}
+
+			Element element = PoshiElementFactory.newPoshiElement(
+				readableVariableBlock);
+
+			add(element);
+		}
+	}
+
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 
@@ -54,6 +87,23 @@ public abstract class PoshiElement extends DefaultElement {
 		}
 
 		return sb.toString();
+	}
+
+	protected String getAttributeValue(String startKey, String readableSyntax) {
+		return getAttributeValue(startKey, "\n", readableSyntax);
+	}
+
+	protected String getAttributeValue(
+		String startKey, String endKey, String readableSyntax) {
+
+		int start = readableSyntax.indexOf(startKey);
+
+		int end = readableSyntax.indexOf(endKey, start + startKey.length());
+
+		String substring = readableSyntax.substring(
+			start + startKey.length(), end);
+
+		return substring.trim();
 	}
 
 	protected String getReadableExecuteKey() {
@@ -91,6 +141,19 @@ public abstract class PoshiElement extends DefaultElement {
 
 		return phrase;
 	}
+
+	protected static final String[] READABLE_COMMAND_BLOCK_KEYS = {
+		BACKGROUND + COLON, FEATURE + COLON, SCENARIO + COLON, SETUP + COLON,
+		TEARDOWN + COLON
+	};
+
+	protected static final String[] READABLE_EXECUTE_BLOCK_KEYS = {
+		TAB + AND, TAB + GIVEN, TAB + THEN, TAB + WHEN
+	};
+
+	protected static final String[] READABLE_VARIABLE_BLOCK_KEYS = {
+		TAB + TAB + PIPE
+	};
 
 	private void _addAttributes(Element element) {
 		for (Iterator i = element.attributeIterator(); i.hasNext();) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -51,7 +51,14 @@ public abstract class PoshiElement extends DefaultElement {
 
 	public PoshiElement(String name, String readableSyntax) {
 		super(name);
+
+		addAttributes(readableSyntax);
+		addElements(readableSyntax);
 	}
+
+	public abstract void addAttributes(String readableSyntax);
+
+	public abstract void addElements(String readableSyntax);
 
 	public void addVariableElements(String readableSyntax) {
 		List<String> readableVariableBlocks = StringUtil.split(

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -62,7 +62,7 @@ public abstract class PoshiElement extends DefaultElement {
 	public abstract void addElements(String readableSyntax);
 
 	public void addVariableElements(String readableSyntax) {
-		List<String> readableVariableBlocks = StringUtil.split(
+		List<String> readableVariableBlocks = StringUtil.partition(
 			readableSyntax, READABLE_VARIABLE_BLOCK_KEYS);
 
 		for (String readableVariableBlock : readableVariableBlocks) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -73,7 +73,7 @@ public class PoshiElementFactory {
 		return new UnsupportedElement(element);
 	}
 
-	public static Element newPoshiElement(String readableSyntax) {
+	public static PoshiElement newPoshiElement(String readableSyntax) {
 		try (BufferedReader bufferedReader = new BufferedReader(
 				new StringReader(readableSyntax))) {
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -24,6 +24,14 @@ import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THEN;
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.WHEN;
 import static com.liferay.poshi.runner.util.StringPool.PIPE;
 
+import com.liferay.poshi.runner.util.Dom4JUtil;
+import com.liferay.poshi.runner.util.FileUtil;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.StringReader;
+
+import org.dom4j.Document;
 import org.dom4j.Element;
 
 /**
@@ -112,6 +120,31 @@ public class PoshiElementFactory {
 		}
 
 		return new UnsupportedElement(readableSyntax);
+	}
+
+	public static Element newPoshiElementFromFile(String filePath) {
+		File file = new File(filePath);
+
+		try {
+			String fileContent = FileUtil.read(file);
+
+			if (fileContent.contains("<definition")) {
+				Document document = Dom4JUtil.parse(fileContent);
+
+				Element rootElement = document.getRootElement();
+
+				return newPoshiElement(rootElement);
+			}
+
+			return newPoshiElement(fileContent);
+		}
+		catch (Exception e) {
+			System.out.println("The Poshi element could not be generated.");
+
+			e.printStackTrace();
+		}
+
+		return null;
 	}
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -114,7 +114,7 @@ public class PoshiElementFactory {
 			}
 		}
 		catch (Exception e) {
-			System.out.println("The Poshi element could not be generated.");
+			System.out.println("Unable to generate the Poshi element");
 
 			e.printStackTrace();
 		}
@@ -139,7 +139,7 @@ public class PoshiElementFactory {
 			return newPoshiElement(fileContent);
 		}
 		catch (Exception e) {
-			System.out.println("The Poshi element could not be generated.");
+			System.out.println("Unable to generate the Poshi element");
 
 			e.printStackTrace();
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class PoshiElementFactory {
+
+	public static Element newPoshiElement(Element element) {
+		String elementName = element.getName();
+
+		if (elementName.equals("command")) {
+			return new CommandElement(element);
+		}
+
+		if (elementName.equals("definition")) {
+			return new DefinitionElement(element);
+		}
+
+		if (elementName.equals("execute")) {
+			return new ExecuteElement(element);
+		}
+
+		if (elementName.equals("property")) {
+			return new PropertyElement(element);
+		}
+
+		if (elementName.equals("set-up")) {
+			return new SetUpElement(element);
+		}
+
+		if (elementName.equals("tear-down")) {
+			return new TearDownElement(element);
+		}
+
+		if (elementName.equals("var")) {
+			return new VarElement(element);
+		}
+
+		return new UnsupportedElement(element);
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -14,6 +14,16 @@
 
 package com.liferay.poshi.runner.elements;
 
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.AND;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.FEATURE;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.GIVEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.SCENARIO;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.SETUP;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.TEARDOWN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THEN;
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.WHEN;
+import static com.liferay.poshi.runner.util.StringPool.PIPE;
+
 import org.dom4j.Element;
 
 /**
@@ -53,6 +63,55 @@ public class PoshiElementFactory {
 		}
 
 		return new UnsupportedElement(element);
+	}
+
+	public static Element newPoshiElement(String readableSyntax) {
+		try (BufferedReader bufferedReader = new BufferedReader(
+				new StringReader(readableSyntax))) {
+
+			String line = null;
+
+			while ((line = bufferedReader.readLine()) != null) {
+				line = line.trim();
+
+				if (line.length() == 0) {
+					continue;
+				}
+
+				if (line.startsWith(FEATURE)) {
+					return new DefinitionElement(readableSyntax);
+				}
+
+				if (line.startsWith(SCENARIO)) {
+					return new CommandElement(readableSyntax);
+				}
+
+				if (line.startsWith(SETUP)) {
+					return new SetUpElement(readableSyntax);
+				}
+
+				if (line.startsWith(TEARDOWN)) {
+					return new TearDownElement(readableSyntax);
+				}
+
+				if (line.startsWith(AND) || line.startsWith(GIVEN) ||
+					line.startsWith(THEN) || line.startsWith(WHEN)) {
+
+					return new ExecuteElement(readableSyntax);
+				}
+
+				if (line.startsWith(PIPE)) {
+					return new VarElement(readableSyntax);
+				}
+			}
+		}
+		catch (Exception e) {
+			System.out.println("The Poshi element could not be generated.");
+
+			e.printStackTrace();
+		}
+
+		return new UnsupportedElement(readableSyntax);
 	}
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -39,7 +39,7 @@ import org.dom4j.Element;
  */
 public class PoshiElementFactory {
 
-	public static Element newPoshiElement(Element element) {
+	public static PoshiElement newPoshiElement(Element element) {
 		String elementName = element.getName();
 
 		if (elementName.equals("command")) {
@@ -122,7 +122,7 @@ public class PoshiElementFactory {
 		return new UnsupportedElement(readableSyntax);
 	}
 
-	public static Element newPoshiElementFromFile(String filePath) {
+	public static PoshiElement newPoshiElementFromFile(String filePath) {
 		File file = new File(filePath);
 
 		try {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PropertyElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PropertyElement.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_PROPERTIES;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class PropertyElement extends VarElement {
+
+	public PropertyElement(Element element) {
+		super("property", element);
+	}
+
+	@Override
+	protected String getReadableVariableKey() {
+		return THESE_PROPERTIES;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PropertyElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PropertyElement.java
@@ -27,6 +27,10 @@ public class PropertyElement extends VarElement {
 		super("property", element);
 	}
 
+	public PropertyElement(String readableSyntax) {
+		super("property", readableSyntax);
+	}
+
 	@Override
 	protected String getReadableVariableKey() {
 		return THESE_PROPERTIES;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ReadableSyntaxKeys.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ReadableSyntaxKeys.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ReadableSyntaxKeys {
+
+	public static final String AND = "And";
+
+	public static final String AT_LOCATOR = "at locator";
+
+	public static final String BACKGROUND = "Background";
+
+	public static final String DESCRIPTION = "Description";
+
+	public static final String FEATURE = "Feature";
+
+	public static final String GIVEN = "Given";
+
+	public static final String PRIORITY = "Priority";
+
+	public static final String SCENARIO = "Scenario";
+
+	public static final String SETUP = "Setup";
+
+	public static final String TEARDOWN = "Teardown";
+
+	public static final String THE_VALUE = "the value";
+
+	public static final String THEN = "Then";
+
+	public static final String THESE_PROPERTIES = "these properties";
+
+	public static final String THESE_VARIABLES = "these variables";
+
+	public static final String WHEN = "When";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/SetUpElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/SetUpElement.java
@@ -30,6 +30,10 @@ public class SetUpElement extends CommandElement {
 	}
 
 	@Override
+	public void addAttributes(String readableSyntax) {
+	}
+
+	@Override
 	protected String getReadableCommandTitle() {
 		return "Setup: This executes before each scenario";
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/SetUpElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/SetUpElement.java
@@ -25,6 +25,10 @@ public class SetUpElement extends CommandElement {
 		super("set-up", element);
 	}
 
+	public SetUpElement(String readableSyntax) {
+		super("set-up", readableSyntax);
+	}
+
 	@Override
 	protected String getReadableCommandTitle() {
 		return "Setup: This executes before each scenario";

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/SetUpElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/SetUpElement.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class SetUpElement extends CommandElement {
+
+	public SetUpElement(Element element) {
+		super("set-up", element);
+	}
+
+	@Override
+	protected String getReadableCommandTitle() {
+		return "Setup: This executes before each scenario";
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TearDownElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TearDownElement.java
@@ -25,6 +25,10 @@ public class TearDownElement extends CommandElement {
 		super("tear-down", element);
 	}
 
+	public TearDownElement(String readableSyntax) {
+		super("tear-down", readableSyntax);
+	}
+
 	protected String getReadableCommandTitle() {
 		return "Teardown: This executes after each scenario";
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TearDownElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TearDownElement.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class TearDownElement extends CommandElement {
+
+	public TearDownElement(Element element) {
+		super("tear-down", element);
+	}
+
+	protected String getReadableCommandTitle() {
+		return "Teardown: This executes after each scenario";
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TearDownElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TearDownElement.java
@@ -29,6 +29,10 @@ public class TearDownElement extends CommandElement {
 		super("tear-down", readableSyntax);
 	}
 
+	@Override
+	public void addAttributes(String readableSyntax) {
+	}
+
 	protected String getReadableCommandTitle() {
 		return "Teardown: This executes after each scenario";
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
@@ -25,6 +25,10 @@ public class UnsupportedElement extends PoshiElement {
 		super(element.getName(), element);
 	}
 
+	public UnsupportedElement(String readableSyntax) {
+		super("unsupported", readableSyntax);
+	}
+
 	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class UnsupportedElement extends PoshiElement {
+
+	public UnsupportedElement(Element element) {
+		super(element.getName(), element);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n");
+		sb.append("##########################################################");
+		sb.append("\n");
+		sb.append("The Poshi ");
+		sb.append(getName());
+		sb.append(" element is not supported in the readable syntax. ");
+		sb.append("Please update this test.");
+		sb.append("\n");
+		sb.append("##########################################################");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
@@ -30,6 +30,14 @@ public class UnsupportedElement extends PoshiElement {
 	}
 
 	@Override
+	public void addAttributes(String readableSyntax) {
+	}
+
+	@Override
+	public void addElements(String readableSyntax) {
+	}
+
+	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
@@ -27,8 +27,16 @@ public class VarElement extends PoshiElement {
 		this("var", element);
 	}
 
+	public VarElement(String readableSyntax) {
+		this("var", readableSyntax);
+	}
+
 	public VarElement(String name, Element element) {
 		super(name, element);
+	}
+
+	public VarElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
@@ -16,9 +16,6 @@ package com.liferay.poshi.runner.elements;
 
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_VARIABLES;
 
-import java.util.Map;
-import java.util.TreeMap;
-
 import org.dom4j.Element;
 
 /**
@@ -43,23 +40,17 @@ public class VarElement extends PoshiElement {
 	}
 
 	public void addAttributes(String readableSyntax) {
-		Map<String, String> attributes = new TreeMap<>();
-
 		String[] items = readableSyntax.split("\\|");
 
-		attributes.put("name", items[1].trim());
+		addAttribute("name", items[1].trim());
 
 		String value = items[2].trim();
 
 		if (value.contains("Util#")) {
-			attributes.put("method", value);
+			addAttribute("method", value);
 		}
 		else {
-			attributes.put("value", value);
-		}
-
-		for (String key : attributes.keySet()) {
-			addAttribute(key, attributes.get(key));
+			addAttribute("value", value);
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
@@ -39,6 +39,13 @@ public class VarElement extends PoshiElement {
 		super(name, readableSyntax);
 	}
 
+	public void addAttributes(String readableSyntax) {
+	}
+
+	@Override
+	public void addElements(String readableSyntax) {
+	}
+
 	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
@@ -16,6 +16,9 @@ package com.liferay.poshi.runner.elements;
 
 import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_VARIABLES;
 
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.dom4j.Element;
 
 /**
@@ -40,6 +43,24 @@ public class VarElement extends PoshiElement {
 	}
 
 	public void addAttributes(String readableSyntax) {
+		Map<String, String> attributes = new TreeMap<>();
+
+		String[] items = readableSyntax.split("\\|");
+
+		attributes.put("name", items[1].trim());
+
+		String value = items[2].trim();
+
+		if (value.contains("Util#")) {
+			attributes.put("method", value);
+		}
+		else {
+			attributes.put("value", value);
+		}
+
+		for (String key : attributes.keySet()) {
+			addAttribute(key, attributes.get(key));
+		}
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import static com.liferay.poshi.runner.elements.ReadableSyntaxKeys.THESE_VARIABLES;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class VarElement extends PoshiElement {
+
+	public VarElement(Element element) {
+		this("var", element);
+	}
+
+	public VarElement(String name, Element element) {
+		super(name, element);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		Element parentElement = getParent();
+
+		String parentElementName = parentElement.getName();
+
+		if (parentElementName.equals("command") ||
+			parentElementName.equals("set-up") ||
+			parentElementName.equals("tear-down")) {
+
+			sb.append("\n\t");
+			sb.append(getReadableExecuteKey());
+			sb.append(" ");
+			sb.append(getReadableVariableKey());
+		}
+
+		sb.append("\n\t\t");
+		sb.append("|");
+		sb.append(attributeValue("name"));
+		sb.append("|");
+
+		if (attributeValue("method") != null) {
+			sb.append(attributeValue("method"));
+		}
+		else if (attributeValue("value") != null) {
+			sb.append(attributeValue("value"));
+		}
+
+		sb.append("|");
+
+		return sb.toString();
+	}
+
+	protected String getReadableVariableKey() {
+		return THESE_VARIABLES;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.util;
+
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.Writer;
+
+import java.util.Iterator;
+
+import org.dom4j.Attribute;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.Node;
+import org.dom4j.Text;
+import org.dom4j.io.OutputFormat;
+import org.dom4j.io.SAXReader;
+import org.dom4j.io.XMLWriter;
+import org.dom4j.tree.DefaultElement;
+
+/**
+ * @author Peter Yoo
+ */
+public class Dom4JUtil {
+
+	public static void addToElement(Element element, Object... items) {
+		for (int i = 0; i < items.length; i++) {
+			Object item = items[i];
+
+			if (item == null) {
+				continue;
+			}
+
+			if (item instanceof Element) {
+				element.add((Element)item);
+
+				continue;
+			}
+
+			if (item instanceof String) {
+				element.addText((String)item);
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Only elements and strings may be added");
+		}
+	}
+
+	public static String format(Element element) throws IOException {
+		return format(element, true);
+	}
+
+	public static String format(Element element, boolean pretty)
+		throws IOException {
+
+		Writer writer = new CharArrayWriter();
+
+		OutputFormat outputFormat = OutputFormat.createPrettyPrint();
+
+		outputFormat.setTrimText(false);
+
+		XMLWriter xmlWriter = null;
+
+		if (pretty) {
+			xmlWriter = new XMLWriter(writer, outputFormat);
+		}
+		else {
+			xmlWriter = new XMLWriter(writer);
+		}
+
+		xmlWriter.write(element);
+
+		return writer.toString();
+	}
+
+	public static Element getNewElement(String childElementTag) {
+		return getNewElement(childElementTag, null);
+	}
+
+	public static Element getNewElement(
+		String childElementTag, Element parentElement, Object... items) {
+
+		Element childElement = new DefaultElement(childElementTag);
+
+		if (parentElement != null) {
+			parentElement.add(childElement);
+		}
+
+		if ((items != null) && (items.length > 0)) {
+			addToElement(childElement, items);
+		}
+
+		return childElement;
+	}
+
+	public static Document parse(String xml) throws DocumentException {
+		SAXReader saxReader = new SAXReader();
+
+		return saxReader.read(new StringReader(xml));
+	}
+
+	public static void replace(
+		Element element, boolean cascade, String replacementText,
+		String targetText) {
+
+		Iterator<?> attributeIterator = element.attributeIterator();
+
+		while (attributeIterator.hasNext()) {
+			Attribute attribute = (Attribute)attributeIterator.next();
+
+			String text = attribute.getValue();
+
+			attribute.setValue(text.replace(targetText, replacementText));
+		}
+
+		Iterator<?> nodeIterator = element.nodeIterator();
+
+		while (nodeIterator.hasNext()) {
+			Node node = (Node)nodeIterator.next();
+
+			if (node instanceof Text) {
+				Text textNode = (Text)node;
+
+				String text = textNode.getText();
+
+				if (text.contains(targetText)) {
+					text = text.replace(targetText, replacementText);
+
+					textNode.setText(text);
+				}
+
+				continue;
+			}
+
+			if (node instanceof Element && cascade) {
+				replace((Element)node, cascade, replacementText, targetText);
+
+				continue;
+			}
+		}
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
@@ -158,6 +158,20 @@ public class Dom4JUtil {
 		}
 	}
 
+	public static List<Attribute> toAttributeList(List<?> list) {
+		if (list == null) {
+			return null;
+		}
+
+		List<Attribute> attributeList = new ArrayList<>(list.size());
+
+		for (Object object : list) {
+			attributeList.add((Attribute)object);
+		}
+
+		return attributeList;
+	}
+
 	public static List<Element> toElementList(List<?> list) {
 		if (list == null) {
 			return null;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
@@ -19,7 +19,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.Writer;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import org.dom4j.Attribute;
 import org.dom4j.Document;
@@ -154,6 +156,20 @@ public class Dom4JUtil {
 				continue;
 			}
 		}
+	}
+
+	public static List<Element> toElementList(List<?> list) {
+		if (list == null) {
+			return null;
+		}
+
+		List<Element> elementList = new ArrayList<>(list.size());
+
+		for (Object object : list) {
+			elementList.add((Element)object);
+		}
+
+		return elementList;
 	}
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/StringUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/StringUtil.java
@@ -14,6 +14,9 @@
 
 package com.liferay.poshi.runner.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -389,6 +392,10 @@ public class StringUtil {
 		return sb.substring(0, lengthInt);
 	}
 
+	public static String removeSpaces(String s) {
+		return s.replaceAll(" ", "");
+	}
+
 	public static String replace(String s, String oldSub, String newSub) {
 		if (s == null) {
 			return null;
@@ -499,6 +506,45 @@ public class StringUtil {
 		}
 
 		return s.split(delimiter);
+	}
+
+	public static List<String> split(String s, String[] delimiters) {
+		List delimiterIndexes = new ArrayList<>();
+
+		for (String delimiter : delimiters) {
+			int index = s.indexOf(delimiter);
+
+			while (index >= 0) {
+				delimiterIndexes.add(index);
+
+				index = s.indexOf(delimiter, index + 1);
+			}
+		}
+
+		if (!delimiterIndexes.contains(0)) {
+			delimiterIndexes.add(0);
+		}
+
+		if (!delimiterIndexes.contains(s.length())) {
+			delimiterIndexes.add(s.length());
+		}
+
+		Collections.sort(delimiterIndexes);
+
+		List<String> substrings = new ArrayList<>();
+
+		for (int i = 0; i < delimiterIndexes.size(); i++) {
+			if ((i + 1) == delimiterIndexes.size()) {
+				continue;
+			}
+
+			String substring = s.substring(
+				(int)delimiterIndexes.get(i), (int)delimiterIndexes.get(i + 1));
+
+			substrings.add(substring);
+		}
+
+		return substrings;
 	}
 
 	public static boolean startsWith(String s, String start) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/StringUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/StringUtil.java
@@ -368,6 +368,45 @@ public class StringUtil {
 		return true;
 	}
 
+	public static List<String> partition(String s, String[] delimiters) {
+		List<Integer> delimiterIndexes = new ArrayList<>();
+
+		for (String delimiter : delimiters) {
+			int index = s.indexOf(delimiter);
+
+			while (index >= 0) {
+				delimiterIndexes.add(index);
+
+				index = s.indexOf(delimiter, index + 1);
+			}
+		}
+
+		if (!delimiterIndexes.contains(0)) {
+			delimiterIndexes.add(0);
+		}
+
+		if (!delimiterIndexes.contains(s.length())) {
+			delimiterIndexes.add(s.length());
+		}
+
+		Collections.sort(delimiterIndexes);
+
+		List<String> substrings = new ArrayList<>();
+
+		for (int i = 0; i < delimiterIndexes.size(); i++) {
+			if ((i + 1) == delimiterIndexes.size()) {
+				continue;
+			}
+
+			String substring = s.substring(
+				(int)delimiterIndexes.get(i), (int)delimiterIndexes.get(i + 1));
+
+			substrings.add(substring);
+		}
+
+		return substrings;
+	}
+
 	public static String quote(String s, String quote) {
 		if (s == null) {
 			return null;
@@ -506,45 +545,6 @@ public class StringUtil {
 		}
 
 		return s.split(delimiter);
-	}
-
-	public static List<String> split(String s, String[] delimiters) {
-		List delimiterIndexes = new ArrayList<>();
-
-		for (String delimiter : delimiters) {
-			int index = s.indexOf(delimiter);
-
-			while (index >= 0) {
-				delimiterIndexes.add(index);
-
-				index = s.indexOf(delimiter, index + 1);
-			}
-		}
-
-		if (!delimiterIndexes.contains(0)) {
-			delimiterIndexes.add(0);
-		}
-
-		if (!delimiterIndexes.contains(s.length())) {
-			delimiterIndexes.add(s.length());
-		}
-
-		Collections.sort(delimiterIndexes);
-
-		List<String> substrings = new ArrayList<>();
-
-		for (int i = 0; i < delimiterIndexes.size(); i++) {
-			if ((i + 1) == delimiterIndexes.size()) {
-				continue;
-			}
-
-			String substring = s.substring(
-				(int)delimiterIndexes.get(i), (int)delimiterIndexes.get(i + 1));
-
-			substrings.add(substring);
-		}
-
-		return substrings;
 	}
 
 	public static boolean startsWith(String s, String start) {

--- a/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
+++ b/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
@@ -17,9 +17,6 @@ package com.liferay.poshi.runner.elements;
 import com.liferay.poshi.runner.util.Dom4JUtil;
 import com.liferay.poshi.runner.util.FileUtil;
 
-import java.io.BufferedReader;
-import java.io.StringReader;
-
 import org.dom4j.Document;
 import org.dom4j.Element;
 
@@ -86,22 +83,11 @@ public class PoshiElementFactoryTest {
 	private static String _removeWhitespace(String s) {
 		StringBuilder sb = new StringBuilder();
 
-		try (BufferedReader bufferedReader = new BufferedReader(
-				new StringReader(s))) {
-
-			String line = bufferedReader.readLine();
-
-			while (line != null) {
-				sb.append(line.trim());
-
-				line = bufferedReader.readLine();
-			}
-
-			return sb.toString();
+		for (String line : s.split("\n")) {
+			sb.append(line.trim());
 		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
+
+		return sb.toString();
 	}
 
 	private static final String _TEST_FILE_PATH =

--- a/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
+++ b/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import com.liferay.poshi.runner.util.Dom4JUtil;
+import com.liferay.poshi.runner.util.FileUtil;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+
+import org.dom4j.Document;
+import org.dom4j.Element;
+
+import org.junit.Test;
+
+/**
+ * @author Kenji Heigel
+ */
+public class PoshiElementFactoryTest {
+
+	@Test
+	public void testPoshiToReadableToXML() throws Exception {
+		DefinitionElement element =
+			(DefinitionElement)PoshiElementFactory.newPoshiElementFromFile(
+				_TEST_FILE_PATH);
+
+		String dom4JElementString = _getCompressedXMLTest();
+
+		String readableSyntax = element.toReadableSyntax();
+
+		Element fromReadableSyntax = PoshiElementFactory.newPoshiElement(
+			readableSyntax);
+
+		String fromReadableSyntaxElementString = Dom4JUtil.format(
+			fromReadableSyntax, false);
+
+		if (!fromReadableSyntaxElementString.equals(dom4JElementString)) {
+			System.out.println("Expected:" + dom4JElementString);
+			System.out.println("Actual:  " + fromReadableSyntaxElementString);
+
+			throw new Exception("Readable syntax does not translate to XML");
+		}
+	}
+
+	@Test
+	public void testPoshiToXML() throws Exception {
+		Element element = PoshiElementFactory.newPoshiElementFromFile(
+			_TEST_FILE_PATH);
+
+		String dom4JElementString = _getCompressedXMLTest();
+
+		String poshiElementString = Dom4JUtil.format(element, false);
+
+		if (!poshiElementString.equals(dom4JElementString)) {
+			System.out.println("Expected:" + dom4JElementString);
+			System.out.println("Actual:  " + poshiElementString);
+
+			throw new Exception("Poshi syntax does not translate to XML");
+		}
+	}
+
+	private static String _getCompressedXMLTest() throws Exception {
+		String fileContent = FileUtil.read(_TEST_FILE_PATH);
+
+		Document document = Dom4JUtil.parse(fileContent);
+
+		Element dom4JElement = document.getRootElement();
+
+		String dom4JElementString = Dom4JUtil.format(dom4JElement, false);
+
+		return _removeWhitespace(dom4JElementString);
+	}
+
+	private static String _removeWhitespace(String s) {
+		StringBuilder sb = new StringBuilder();
+
+		try (BufferedReader bufferedReader = new BufferedReader(
+				new StringReader(s))) {
+
+			String line = bufferedReader.readLine();
+
+			while (line != null) {
+				sb.append(line.trim());
+
+				line = bufferedReader.readLine();
+			}
+
+			return sb.toString();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static final String _TEST_FILE_PATH =
+		"src/test/resources/com/liferay/poshi/runner/dependencies" +
+			"/PoshiSyntax.testcase";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -1,0 +1,52 @@
+<definition component-name="portal-acceptance">
+    <property name="portal.release" value="true" />
+    <property name="portal.upstream" value="true" />
+    <property name="testray.main.component.name" value="Smoke" />
+
+    <set-up>
+        <execute macro="TestCase#setUpPortalInstance" />
+
+        <execute macro="SignIn#signIn" />
+    </set-up>
+
+    <tear-down>
+        <execute macro="PortalInstances#tearDownCP">
+            <var method="TestPropsUtil#get('test.portal.instance')" name="testPortalInstance" />
+        </execute>
+    </tear-down>
+
+    <command name="AddUser" priority="5">
+        <var name="userEmailAddress" value="userea@liferay.com" />
+        <var name="userFirstName" value="userfn" />
+        <var name="userLastName" value="userln" />
+        <var name="userScreenName" value="usersn" />
+
+        <execute macro="ProductMenu#gotoControlPanelUsers">
+            <var name="portlet" value="Users and Organizations" />
+        </execute>
+
+        <execute macro="User#addCP">
+            <var name="userEmailAddress" value="${userEmailAddress}" />
+            <var name="userFirstName" value="${userFirstName}" />
+            <var name="userLastName" value="${userLastName}" />
+            <var name="userScreenName" value="${userScreenName}" />
+        </execute>
+    </command>
+
+    <command description="Ensure that the super admin can add pages, add portlets, navigate to the product menu, use the WYSIWYG editor, and view alert messages." name="Smoke" priority="5">
+        <property name="portal.smoke" value="true" />
+        <property name="test.assert.warning.exceptions" value="true" />
+
+        <execute macro="Smoke#viewWelcomePage" />
+
+        <execute macro="Smoke#runSmoke" />
+
+        <execute function="AssertElementPresent" locator1="Home#PAGE" value1="Welcome" />
+
+        <execute function="Click" locator1="Home#PAGE" />
+
+        <execute function="Type" value1="Welcome" />
+
+        <execute function="AssertElementPresent#assertElementPresent" locator1="Home#PAGE" value1="Welcome" />
+    </command>
+</definition>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32801

Changes: Updated unit test to compare Elements instead of strings, thereby removing the need for attribute sorting. Also updated the factory to use PoshiElements for the other methods