### PR TITLE
LRQA-33872 Catch StringIndexOutOfBoundsException from  invalid className in the TestResult constructor

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResult.java
@@ -70,9 +70,19 @@ public class TestResult {
 
 		int x = className.lastIndexOf(".");
 
-		simpleClassName = className.substring(x + 1);
+		try {
+			simpleClassName = className.substring(x + 1);
 
-		packageName = className.substring(0, x);
+			packageName = className.substring(0, x);
+		}
+		catch (StringIndexOutOfBoundsException sioobe) {
+			packageName = className;
+			simpleClassName = className;
+
+			System.out.println(
+				"Invalid test className: " + className + " in build: " +
+					axisBuild.getBuildURL());
+		}
 
 		testName = caseJSONObject.getString("name");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-33872