### PR TITLE
LRQA-34094 Use local URL to get failure data for upstream comparison on GitHub comment

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1843,10 +1843,14 @@ public abstract class BaseBuild implements Build {
 				String upstreamJobName =
 					getJobName().replace("pullrequest", "upstream");
 
-				upstreamFailuresJobJSONObject =
-					JenkinsResultsParserUtil.toJSONObject(
+				String upstreamFailuresJSONURL =
+					JenkinsResultsParserUtil.getLocalURL(
 						UPSTREAM_FAILURES_JOB_BASE_URL + upstreamJobName +
 							"/builds/latest/test.results.json");
+
+				upstreamFailuresJobJSONObject =
+					JenkinsResultsParserUtil.toJSONObject(
+						upstreamFailuresJSONURL);
 			}
 		}
 		catch (IOException ioe) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-34094

@pyoo47, upstream comparison isn't working cause we weren't using the local URL on jenkins. This should fix it