### PR TITLE
LRQA-32801 Poshi readable translation: Add support for echo, and, or, not elements

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/AndPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/AndPoshiElement.java
@@ -103,8 +103,13 @@ public class AndPoshiElement extends BasePoshiElement {
 
 		if (!(parentPoshiElement instanceof AndPoshiElement ||
 			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement)) {
+			parentPoshiElement instanceof NotPoshiElement ||
+			parentPoshiElement instanceof OrPoshiElement)) {
 
+			return false;
+		}
+
+		if (readableSyntax.contains(" || ")) {
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
@@ -76,13 +76,14 @@ public class ConditionPoshiElement extends ExecutePoshiElement {
 
 		if (!(parentPoshiElement instanceof AndPoshiElement ||
 			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement) {
+			parentPoshiElement instanceof NotPoshiElement ||
+			parentPoshiElement instanceof OrPoshiElement)) {
 
 			return false;
 		}
 
 		if (readableSyntax.contains(" && ") ||
-			readableSyntax.startsWith("!")) {
+			readableSyntax.contains(" || ") || readableSyntax.startsWith("!")) {
 
 			return false;
 		}
@@ -92,7 +93,6 @@ public class ConditionPoshiElement extends ExecutePoshiElement {
 
 			return true;
 		}
-
 
 		return false;
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
@@ -74,12 +74,22 @@ public class ConditionPoshiElement extends ExecutePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if ((parentPoshiElement instanceof IfPoshiElement) &&
-			readableSyntax.endsWith(")") &&
+		if (!(parentPoshiElement instanceof IfPoshiElement ||
+			parentPoshiElement instanceof NotPoshiElement) {
+
+			return false;
+		}
+
+		if (readableSyntax.startsWith("!")) {
+			return false;
+		}
+
+		if (readableSyntax.endsWith(")") &&
 			!readableSyntax.startsWith("isSet(")) {
 
 			return true;
 		}
+
 
 		return false;
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EchoPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EchoPoshiElement.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class EchoPoshiElement extends BasePoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new EchoPoshiElement(element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (_isElementType(readableSyntax)) {
+			return new EchoPoshiElement(readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		String content = getQuotedContent(readableSyntax);
+
+		addAttribute("message", content);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		String message = attributeValue("message");
+
+		return createReadableBlock(message);
+	}
+
+	protected EchoPoshiElement() {
+	}
+
+	protected EchoPoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected EchoPoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	@Override
+	protected String createReadableBlock(String content) {
+		StringBuilder sb = new StringBuilder();
+
+		String blockName = getBlockName();
+		String pad = getPad();
+
+		sb.append("\n\n");
+		sb.append(pad);
+		sb.append(blockName);
+		sb.append("(\"");
+
+		String trimmedContent = content.trim();
+
+		sb.append(trimmedContent);
+
+		sb.append("\");");
+
+		return sb.toString();
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "echo";
+	}
+
+	private boolean _isElementType(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (!isBalancedReadableSyntax(readableSyntax)) {
+			return false;
+		}
+
+		if (!readableSyntax.endsWith(");")) {
+			return false;
+		}
+
+		if (!readableSyntax.startsWith("echo(")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final String _ELEMENT_NAME = "echo";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
@@ -90,13 +90,15 @@ public class EqualsPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof IfPoshiElement ||
+		if (!(parentPoshiElement instanceof AndPoshiElement ||
+			parentPoshiElement instanceof IfPoshiElement ||
 			parentPoshiElement instanceof NotPoshiElement) {
 
 			return false;
 		}
 
-		if (readableSyntax.startsWith("!(")) {
+		if (readableSyntax.contains(" && ") ||
+			readableSyntax.startsWith("!(")) {
 
 			return false;
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
@@ -92,12 +92,14 @@ public class EqualsPoshiElement extends BasePoshiElement {
 
 		if (!(parentPoshiElement instanceof AndPoshiElement ||
 			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement) {
+			parentPoshiElement instanceof NotPoshiElement ||
+			parentPoshiElement instanceof OrPoshiElement)) {
 
 			return false;
 		}
 
 		if (readableSyntax.contains(" && ") ||
+			readableSyntax.contains(" || ") ||
 			readableSyntax.startsWith("!(")) {
 
 			return false;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
@@ -90,9 +90,18 @@ public class EqualsPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if ((parentPoshiElement instanceof IfPoshiElement) &&
-			readableSyntax.contains("==")) {
+		if (!(parentPoshiElement instanceof IfPoshiElement ||
+			parentPoshiElement instanceof NotPoshiElement) {
 
+			return false;
+		}
+
+		if (readableSyntax.startsWith("!(")) {
+
+			return false;
+		}
+
+		if (readableSyntax.contains("==")) {
 			return true;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -179,6 +179,6 @@ public class IfPoshiElement extends BasePoshiElement {
 	private static final String _ELEMENT_NAME = "if";
 
 	private static final String[] _conditionNames =
-		{"and", "condition", "equals", "isset", "not"};
+		{"and", "condition", "equals", "isset", "not", "or"};
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -179,6 +179,6 @@ public class IfPoshiElement extends BasePoshiElement {
 	private static final String _ELEMENT_NAME = "if";
 
 	private static final String[] _conditionNames =
-		{"condition", "equals", "isset"};
+		{"condition", "equals", "isset", "not"};
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -179,6 +179,6 @@ public class IfPoshiElement extends BasePoshiElement {
 	private static final String _ELEMENT_NAME = "if";
 
 	private static final String[] _conditionNames =
-		{"condition", "equals", "isset", "not"};
+		{"and", "condition", "equals", "isset", "not"};
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IsSetPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IsSetPoshiElement.java
@@ -72,7 +72,8 @@ public class IsSetPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof IfPoshiElement ||
+		if (!(parentPoshiElement instanceof AndPoshiElement ||
+			parentPoshiElement instanceof IfPoshiElement ||
 			parentPoshiElement instanceof NotPoshiElement)) {
 
 			return false;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
@@ -82,7 +82,9 @@ public class NotPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof IfPoshiElement) {
+		if (!(parentPoshiElement instanceof AndPoshiElement ||
+			parentPoshiElement instanceof IfPoshiElement)) {
+
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
@@ -83,7 +83,8 @@ public class NotPoshiElement extends BasePoshiElement {
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
 		if (!(parentPoshiElement instanceof AndPoshiElement ||
-			parentPoshiElement instanceof IfPoshiElement)) {
+			parentPoshiElement instanceof IfPoshiElement ||
+			parentPoshiElement instanceof OrPoshiElement)) {
 
 			return false;
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
@@ -19,12 +19,12 @@ import org.dom4j.Element;
 /**
  * @author Kenji Heigel
  */
-public class IsSetPoshiElement extends BasePoshiElement {
+public class NotPoshiElement extends BasePoshiElement {
 
 	@Override
 	public PoshiElement clone(Element element) {
 		if (isElementType(_ELEMENT_NAME, element)) {
-			return new IsSetPoshiElement(element);
+			return new NotPoshiElement(element);
 		}
 
 		return null;
@@ -35,7 +35,7 @@ public class IsSetPoshiElement extends BasePoshiElement {
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
 		if (_isElementType(parentPoshiElement, readableSyntax)) {
-			return new IsSetPoshiElement(readableSyntax);
+			return new NotPoshiElement(readableSyntax);
 		}
 
 		return null;
@@ -43,53 +43,58 @@ public class IsSetPoshiElement extends BasePoshiElement {
 
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
-		String issetContent = getParentheticalContent(readableSyntax);
-
-		addAttribute("var", issetContent);
+		add(
+			PoshiElementFactory.newPoshiElement(
+				this, getParentheticalContent(readableSyntax)));
 	}
 
 	@Override
 	public String toReadableSyntax() {
-		return "isSet(" + attributeValue("var") + ")";
+		StringBuilder sb = new StringBuilder();
+
+		for (PoshiElement poshiElement : toPoshiElements(elements())) {
+			sb.append("!(");
+
+			sb.append(poshiElement.toReadableSyntax());
+
+			sb.append(")");
+		}
+
+		return sb.toString();
 	}
 
-	protected IsSetPoshiElement() {
+	protected NotPoshiElement() {
 	}
 
-	protected IsSetPoshiElement(Element element) {
+	protected NotPoshiElement(Element element) {
 		super(_ELEMENT_NAME, element);
 	}
 
-	protected IsSetPoshiElement(String readableSyntax) {
+	protected NotPoshiElement(String readableSyntax) {
 		super(_ELEMENT_NAME, readableSyntax);
 	}
 
 	@Override
 	protected String getBlockName() {
-		return "isSet";
+		return "not";
 	}
 
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement)) {
-
+		if (!(parentPoshiElement instanceof IfPoshiElement) {
 			return false;
 		}
+
+		readableSyntax = readableSyntax.trim();
 
 		if (readableSyntax.startsWith("!")) {
-			return false;
-		}
-
-		if (readableSyntax.startsWith("isSet(")) {
 			return true;
 		}
-
 
 		return false;
 	}
 
-	private static final String _ELEMENT_NAME = "isset";
+	private static final String _ELEMENT_NAME = "not";
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -26,6 +26,8 @@
 			<var name="portlet" value="Users and Organizations" />
 		</execute>
 
+		<echo message="This is a message." />
+
 		<for list="${breadcrumbListVisible}" param="breadcrumbName">
 			<var name="key_breadcrumbName" value="${breadcrumbName}" />
 

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -71,7 +71,9 @@
 				</execute>
 
 				<if>
-					<isset var="duplicate" />
+					<not>
+						<isset var="duplicate" />
+					</not>
 					<then>
 						<execute macro="Alert#viewErrorMessage">
 							<var name="errorMessage" value="A configuration with this ID already exists. Please enter a unique ID." />
@@ -108,6 +110,28 @@
 
 		<if>
 			<condition function="IsElementPresent" locator1="Blogs#ADD_BLOGS_ENTRY" />
+			<then>
+				<execute macro="Alert#viewSuccessMessage" />
+			</then>
+		</if>
+
+		<if>
+			<and>
+				<condition function="IsElementPresent" locator1="Blogs#ADD_BLOGS_ENTRY" />
+				<equals arg1="${check}" arg2="true" />
+				<isset var="duplicate" />
+			</and>
+			<then>
+				<execute macro="Alert#viewSuccessMessage" />
+			</then>
+		</if>
+
+		<if>
+			<or>
+				<condition function="IsElementPresent" locator1="Blogs#ADD_BLOGS_ENTRY" />
+				<equals arg1="${check}" arg2="true" />
+				<isset var="duplicate" />
+			</or>
 			<then>
 				<execute macro="Alert#viewSuccessMessage" />
 			</then>

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -28,6 +28,8 @@ definition {
 			portlet = "Users and Organizations"
 		);
 
+		echo("This is a message.");
+
 		for (breadcrumbName : "${breadcrumbListVisible}") {
 			var key_breadcrumbName = "${breadcrumbName}";
 			var breadcrumbNameUppercase = "StringUtil.upperCase('${breadcrumbName}')";

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -66,7 +66,7 @@ definition {
 				errorMessage = "A configuration with this ID already exists. Please enter a unique ID."
 			);
 
-			if (isSet(duplicate)) {
+			if (!(isSet(duplicate))) {
 				Alert.viewErrorMessage(
 					errorMessage = "A configuration with this ID already exists. Please enter a unique ID."
 				);
@@ -93,6 +93,14 @@ definition {
 		}
 
 		if (IsElementPresent(locator1 = "Blogs#ADD_BLOGS_ENTRY")) {
+			Alert.viewSuccessMessage();
+		}
+
+		if ((IsElementPresent(locator1 = "Blogs#ADD_BLOGS_ENTRY")) && ("${check}" == "true") && (isSet(duplicate))) {
+			Alert.viewSuccessMessage();
+		}
+
+		if ((IsElementPresent(locator1 = "Blogs#ADD_BLOGS_ENTRY")) || ("${check}" == "true") || (isSet(duplicate))) {
 			Alert.viewSuccessMessage();
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32801

#### Key changes
* Added support for `echo` elements
* Added basic support for logical operator elements (`and`, `or` , and `not`)

#### Translation status
##### At head: 
1618 / 2126 (76%) test commands were successfully translated
236 / 328 (71%) test files were successfully translated with 898 tests (42%)
##### With this pull:
1697 / 2126 (79%) test commands were successfully translated
239 / 328 (72%) test files were successfully translated with 928 tests (43%)