### PR TITLE
LRQA-32801 Add more prints to readable translation unit test failures

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
+++ b/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
@@ -40,8 +40,16 @@ public class PoshiElementFactoryTest {
 		String readableSyntax = poshiElement.toReadableSyntax();
 
 		if (!readableSyntax.equals(baselineReadableSyntax)) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("\n\nBaseline readable syntax:");
+			sb.append(baselineReadableSyntax);
+			sb.append("\n\nGenerated readable syntax:");
+			sb.append(readableSyntax);
+
 			throw new Exception(
-				"Poshi syntax does not translate to readable syntax");
+				"Poshi syntax does not translate to readable syntax" +
+					sb.toString());
 		}
 	}
 
@@ -58,7 +66,15 @@ public class PoshiElementFactoryTest {
 		Element baselineElement = _getBaselineElement();
 
 		if (!_areElementsEqual(baselineElement, elementFromReadableSyntax)) {
-			throw new Exception("Readable syntax does not translate to XML");
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("\n\nBaseline XML:");
+			sb.append(Dom4JUtil.format(baselineElement));
+			sb.append("\n\nXML from readable syntax:");
+			sb.append(Dom4JUtil.format(elementFromReadableSyntax));
+
+			throw new Exception(
+				"Readable syntax does not translate to XML" + sb.toString());
 		}
 	}
 
@@ -69,7 +85,15 @@ public class PoshiElementFactoryTest {
 			_POSHI_TEST_FILE_PATH);
 
 		if (!_areElementsEqual(baselineElement, poshiElement)) {
-			throw new Exception("Poshi syntax does not translate to XML.");
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("\n\nBaseline XML:");
+			sb.append(Dom4JUtil.format(baselineElement));
+			sb.append("\n\nGenerated XML:");
+			sb.append(Dom4JUtil.format(poshiElement));
+
+			throw new Exception(
+				"Poshi syntax does not translate to XML." + sb.toString());
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
+++ b/modules/test/poshi-runner/poshi-runner/src/test/java/com/liferay/poshi/runner/elements/PoshiElementFactoryTest.java
@@ -48,7 +48,7 @@ public class PoshiElementFactoryTest {
 			sb.append(readableSyntax);
 
 			throw new Exception(
-				"Poshi syntax does not translate to readable syntax" +
+				"Poshi syntax does not translate to readable syntax." +
 					sb.toString());
 		}
 	}
@@ -74,7 +74,7 @@ public class PoshiElementFactoryTest {
 			sb.append(Dom4JUtil.format(elementFromReadableSyntax));
 
 			throw new Exception(
-				"Readable syntax does not translate to XML" + sb.toString());
+				"Readable syntax does not translate to XML." + sb.toString());
 		}
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32801 

@pyoo47, couldn't figure out why the test failed in those recent pulls. I haven't seen it fail recently though. Adding in these prints to give more information in case it happens again.