### PR TITLE
LRQA-35329 Bug Fix: Readable syntax for echo elements shouldn't be translated to execute elements

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -231,7 +231,9 @@ public class ExecutePoshiElement extends BasePoshiElement {
 			return false;
 		}
 
-		if (readableSyntax.startsWith("property ")) {
+		if (readableSyntax.startsWith("echo(") ||
+			readableSyntax.startsWith("property ")) {
+
 			return false;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-35329

@pyoo47, @jpince, see my last comment for an explanation of the inconsistency of the issue.