### PR TITLE
LRQA-35480 Readable poshi translation: Add full CDATA translation

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.regex.Pattern;
 
 import org.dom4j.Attribute;
 import org.dom4j.Element;
@@ -277,6 +278,9 @@ public abstract class BasePoshiElement
 
 		return poshiElements;
 	}
+
+	protected static final Pattern nestedVarAssignmentPattern = Pattern.compile(
+		"(\\w*? = \".*?\"|\\w*? = escapeText\\(\".*?\\))", Pattern.DOTALL);
 
 	private void _addAttributes(Element element) {
 		for (Attribute attribute :

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
@@ -147,6 +147,15 @@ public abstract class BasePoshiElement
 		return RegexUtil.getGroup(readableSyntax, ".*?\"(.*)\"", 1);
 	}
 
+	protected String getValueFromAssignment(String assignment) {
+		int end = assignment.length();
+		int start = assignment.indexOf("=");
+
+		String value = assignment.substring(start + 1, end);
+
+		return value.trim();
+	}
+
 	protected boolean isBalancedReadableSyntax(String readableSyntax) {
 		Stack<Character> stack = new Stack<>();
 
@@ -232,6 +241,10 @@ public abstract class BasePoshiElement
 		}
 
 		return false;
+	}
+
+	protected String quoteContent(String content) {
+		return "\"" + content + "\"";
 	}
 
 	protected List<PoshiElementAttribute> toPoshiElementAttributes(

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
@@ -183,27 +183,32 @@ public class CommandPoshiElement extends BasePoshiElement {
 		List<String> readableBlocks = new ArrayList<>();
 
 		for (String line : readableSyntax.split("\n")) {
-			line = line.trim();
+			String trimmedLine = line.trim();
 
-			if (line.length() == 0) {
+			if (trimmedLine.length() == 0) {
 				sb.append("\n");
 
 				continue;
 			}
 
-			if (line.startsWith("setUp") || line.startsWith("tearDown")) {
-				continue;
-			}
-
-			if ((line.endsWith(" {") && line.startsWith("test")) ||
-				line.startsWith("@")) {
-
-				readableBlocks.add(line);
+			if (trimmedLine.startsWith("setUp") ||
+				trimmedLine.startsWith("tearDown")) {
 
 				continue;
 			}
 
-			if (!line.startsWith("else {") && !line.startsWith("else if")) {
+			if ((trimmedLine.endsWith(" {") &&
+				 trimmedLine.startsWith("test")) ||
+				trimmedLine.startsWith("@")) {
+
+				readableBlocks.add(trimmedLine);
+
+				continue;
+			}
+
+			if (!trimmedLine.startsWith("else {") &&
+				!trimmedLine.startsWith("else if")) {
+
 				String readableBlock = sb.toString();
 
 				readableBlock = readableBlock.trim();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
@@ -227,12 +227,7 @@ public class CommandPoshiElement extends BasePoshiElement {
 	}
 
 	protected boolean isCDATAVar(String readableSyntax) {
-		String trimmedReadableSyntax = readableSyntax.trim();
-
-		if (!readableSyntax.contains("return(\n") &&
-			(StringUtil.count(readableSyntax, "\n") > 1) &&
-			trimmedReadableSyntax.startsWith("var ")) {
-
+		if (readableSyntax.contains("escapeText(")) {
 			return true;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
@@ -15,10 +15,10 @@
 package com.liferay.poshi.runner.elements;
 
 import com.liferay.poshi.runner.util.RegexUtil;
-import com.liferay.poshi.runner.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 
 import org.dom4j.Element;
 
@@ -154,6 +154,20 @@ public class CommandPoshiElement extends BasePoshiElement {
 
 			if (isCDATAVar(item)) {
 				item = item.replaceFirst("\t", pad + "\t");
+
+				String trimmedItem = item.trim();
+
+				if (!trimmedItem.startsWith("var")) {
+					Matcher matcher = nestedVarAssignmentPattern.matcher(item);
+
+					item = matcher.replaceAll("\t$1");
+
+					if (item.endsWith(");")) {
+						item = item.substring(0, item.length() - 2);
+
+						item = item + "\t);";
+					}
+				}
 
 				sb.append(item);
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
@@ -153,7 +153,7 @@ public class CommandPoshiElement extends BasePoshiElement {
 			}
 
 			if (isCDATAVar(item)) {
-				item = item.replaceFirst("var ", pad + "var ");
+				item = item.replaceFirst("\t", pad + "\t");
 
 				sb.append(item);
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
@@ -53,8 +53,8 @@ public class ConditionPoshiElement extends ExecutePoshiElement {
 	}
 
 	@Override
-	protected String createReadableBlock(String content) {
-		String readableBlock = super.createReadableBlock(content);
+	protected String createFunctionReadableBlock(String content) {
+		String readableBlock = super.createFunctionReadableBlock(content);
 
 		readableBlock = readableBlock.trim();
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionPoshiElement.java
@@ -142,23 +142,24 @@ public class DefinitionPoshiElement extends BasePoshiElement {
 		List<String> readableBlocks = new ArrayList<>();
 
 		for (String line : readableSyntax.split("\n")) {
-			line = line.trim();
+			String trimmedLine = line.trim();
 
-			if (line.length() == 0) {
+			if (trimmedLine.length() == 0) {
 				sb.append("\n");
 
 				continue;
 			}
 
-			if (line.startsWith("@") && !line.startsWith("@description") &&
-				!line.startsWith("@priority")) {
+			if (trimmedLine.startsWith("@") &&
+				!trimmedLine.startsWith("@description") &&
+				!trimmedLine.startsWith("@priority")) {
 
 				readableBlocks.add(line);
 
 				continue;
 			}
 
-			if (line.startsWith("definition {")) {
+			if (trimmedLine.startsWith("definition {")) {
 				continue;
 			}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -220,15 +220,20 @@ public class ExecutePoshiElement extends BasePoshiElement {
 
 		String trimmedContent = content.trim();
 
-		if (!trimmedContent.equals("")) {
-			if (content.contains("\n")) {
-				content = content.replaceAll("\n", ",\n" + pad);
-				content = content.replaceFirst(",", "");
-				content = content + "\n" + pad;
-			}
-
-			sb.append(content);
+		if (content.contains("escapeText(")) {
+			content = trimmedContent;
 		}
+		else {
+			if (!trimmedContent.equals("")) {
+				if (content.contains("\n")) {
+					content = content.replaceAll("\n", ",\n" + pad);
+					content = content.replaceFirst(",", "");
+					content = content + "\n" + pad;
+				}
+			}
+		}
+
+		sb.append(content);
 
 		sb.append(");");
 
@@ -285,6 +290,6 @@ public class ExecutePoshiElement extends BasePoshiElement {
 	private static final String _ELEMENT_NAME = "execute";
 
 	private static final Pattern _assignmentPattern = Pattern.compile(
-		"([^,]*? = \".*?\")");
+		"([^,]*? = \".*?\"|[^,]*? = escapeText\\(\".*?\\))", Pattern.DOTALL);
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -94,7 +94,7 @@ public class ExecutePoshiElement extends BasePoshiElement {
 
 		List<String> assignments = new ArrayList<>();
 
-		Matcher matcher = _assignmentPattern.matcher(content);
+		Matcher matcher = nestedVarAssignmentPattern.matcher(content);
 
 		while (matcher.find()) {
 			assignments.add(matcher.group());
@@ -288,8 +288,5 @@ public class ExecutePoshiElement extends BasePoshiElement {
 	}
 
 	private static final String _ELEMENT_NAME = "execute";
-
-	private static final Pattern _assignmentPattern = Pattern.compile(
-		"([^,]*? = \".*?\"|[^,]*? = escapeText\\(\".*?\\))", Pattern.DOTALL);
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForPoshiElement.java
@@ -107,13 +107,15 @@ public class ForPoshiElement extends BasePoshiElement {
 		List<String> readableBlocks = new ArrayList<>();
 
 		for (String line : readableSyntax.split("\n")) {
-			if (line.startsWith("for (")) {
+			String trimmedLine = line.trim();
+
+			if (trimmedLine.startsWith("for (")) {
 				readableBlocks.add(line);
 
 				continue;
 			}
 
-			if (!line.startsWith("else {")) {
+			if (!trimmedLine.startsWith("else {")) {
 				String readableBlock = sb.toString();
 
 				readableBlock = readableBlock.trim();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -131,12 +131,14 @@ public class IfPoshiElement extends BasePoshiElement {
 		List<String> readableBlocks = new ArrayList<>();
 
 		for (String line : readableSyntax.split("\n")) {
+			String trimmedLine = line.trim();
+
 			String readableBlock = sb.toString();
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getReadableName() + " (") &&
-				line.endsWith("{") && (readableBlock.length() == 0)) {
+			if (trimmedLine.startsWith(getReadableName() + " (") &&
+				trimmedLine.endsWith("{") && (readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
@@ -88,19 +88,21 @@ public class OnPoshiElement extends BasePoshiElement {
 		List<String> readableBlocks = new ArrayList<>();
 
 		for (String line : readableSyntax.split("\n")) {
+			String trimmedLine = line.trim();
+
 			String readableBlock = sb.toString();
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getReadableName() + " (") &&
-				line.endsWith("{") && (readableBlock.length() == 0)) {
+			if (trimmedLine.startsWith(getReadableName() + " (") &&
+				trimmedLine.endsWith("{") && (readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);
 
 				continue;
 			}
 
-			if (line.endsWith("{") && readableBlocks.isEmpty()) {
+			if (trimmedLine.endsWith("{") && readableBlocks.isEmpty()) {
 				continue;
 			}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
@@ -109,19 +109,21 @@ public class TaskPoshiElement extends BasePoshiElement {
 		List<String> readableBlocks = new ArrayList<>();
 
 		for (String line : readableSyntax.split("\n")) {
+			String trimmedLine = line.trim();
+
 			String readableBlock = sb.toString();
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getReadableName() + " (") &&
-				line.endsWith("{") && (readableBlock.length() == 0)) {
+			if (trimmedLine.startsWith(getReadableName() + " (") &&
+				trimmedLine.endsWith("{") && (readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);
 
 				continue;
 			}
 
-			if (line.endsWith("{") && readableBlocks.isEmpty()) {
+			if (trimmedLine.endsWith("{") && readableBlocks.isEmpty()) {
 				continue;
 			}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ThenPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ThenPoshiElement.java
@@ -81,13 +81,17 @@ public class ThenPoshiElement extends BasePoshiElement {
 		List<String> readableBlocks = new ArrayList<>();
 
 		for (String line : readableSyntax.split("\n")) {
+			String trimmedLine = line.trim();
+
 			String readableBlock = sb.toString();
 
-			if (line.endsWith("{") && readableBlocks.isEmpty()) {
+			if (trimmedLine.endsWith("{") && readableBlocks.isEmpty()) {
 				continue;
 			}
 
-			if (!line.startsWith("else {")) {
+			if (!trimmedLine.startsWith("else {")) {
+				readableBlock = readableBlock.trim();
+
 				if (isValidReadableBlock(readableBlock)) {
 					readableBlocks.add(readableBlock);
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/Dom4JUtil.java
@@ -65,12 +65,24 @@ public class Dom4JUtil {
 	}
 
 	public static String format(Element element) throws IOException {
-		return format(element, true);
+		Node node = element;
+
+		return format(node, true);
 	}
 
 	public static String format(Element element, boolean pretty)
 		throws IOException {
 
+		Node node = element;
+
+		return format(node, pretty);
+	}
+
+	public static String format(Node node) throws IOException {
+		return format(node, true);
+	}
+
+	public static String format(Node node, boolean pretty) throws IOException {
 		Writer writer = new CharArrayWriter();
 
 		OutputFormat outputFormat = OutputFormat.createPrettyPrint();
@@ -87,7 +99,7 @@ public class Dom4JUtil {
 			xmlWriter = new XMLWriter(writer);
 		}
 
-		xmlWriter.write(element);
+		xmlWriter.write(node);
 
 		return writer.toString();
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -172,7 +172,7 @@
 		<var name="wikiPageContent"><![CDATA[<p id='demo'>PASS</p>
 
 <script type='text/javascript'>
-document.getElementById('demo').innerHTML = 'FAIL';
+	document.getElementById('demo').innerHTML = 'FAIL';
 </script>]]></var>
 
 		<execute macro="AlloyEditor#addSourceContent">

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -183,6 +183,11 @@
 ]]></var>
 		</execute>
 
+		<execute macro="KaleoDesigner#viewSourceXMLLine">
+			<var name="kdSourceXML"><![CDATA[<name>Timer Name</name>]]></var>
+			<var name="line" value="21" />
+		</execute>
+
 		<execute macro="Smoke#viewWelcomePage" />
 
 		<take-screenshot />

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -126,7 +126,7 @@
 			</then>
 			<else>
 				<fail message="Element not present" />
-            </else>
+			</else>
 		</if>
 
 		<if>
@@ -174,6 +174,14 @@
 <script type='text/javascript'>
 document.getElementById('demo').innerHTML = 'FAIL';
 </script>]]></var>
+
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content"><![CDATA[
+<h2 class="text-center">Space Program 大学生涯教育</h2>
+
+<p class="text-center">地球から、宇宙の果てへ</p>
+]]></var>
+		</execute>
 
 		<execute macro="Smoke#viewWelcomePage" />
 

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -130,7 +130,7 @@ definition {
 		var wikiPageContent = escapeText("<p id='demo'>PASS</p>
 
 <script type='text/javascript'>
-document.getElementById('demo').innerHTML = 'FAIL';
+	document.getElementById('demo').innerHTML = 'FAIL';
 </script>");
 
 		AlloyEditor.addSourceContent(content = escapeText("

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -127,11 +127,11 @@ definition {
 			),
 			siteName
 		);
-		var wikiPageContent = "<p id='demo'>PASS</p>
+		var wikiPageContent = escapeText("<p id='demo'>PASS</p>
 
 <script type='text/javascript'>
 document.getElementById('demo').innerHTML = 'FAIL';
-</script>";
+</script>");
 
 		Smoke.viewWelcomePage();
 

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -133,6 +133,12 @@ definition {
 document.getElementById('demo').innerHTML = 'FAIL';
 </script>");
 
+		AlloyEditor.addSourceContent(content = escapeText("
+<h2 class="text-center">Space Program 大学生涯教育</h2>
+
+<p class="text-center">地球から、宇宙の果てへ</p>
+"));
+
 		Smoke.viewWelcomePage();
 
 		takeScreenshot();

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -133,11 +133,18 @@ definition {
 	document.getElementById('demo').innerHTML = 'FAIL';
 </script>");
 
-		AlloyEditor.addSourceContent(content = escapeText("
+		AlloyEditor.addSourceContent(
+			content = escapeText("
 <h2 class="text-center">Space Program 大学生涯教育</h2>
 
 <p class="text-center">地球から、宇宙の果てへ</p>
-"));
+")
+		);
+
+		KaleoDesigner.viewSourceXMLLine(
+			kdSourceXML = escapeText("<name>Timer Name</name>"),
+			line = "21"
+		);
 
 		Smoke.viewWelcomePage();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-35481
https://issues.liferay.com/browse/LRQA-35766

#### Key changes
* Account for all CDATA usages in translator
* Add new method to output Node objects (good to have in general, but I'm using it as I generate translation metrics 

#### Translation status
##### At head:
2036 / 2147 \(94%\) test commands were successfully translated
267 / 326 \(81%\) test files were successfully translated accounting for  1275 / 2147 \(59%\) test commands
##### With this pull:

2065 / 2147 \(96%\) test commands were successfully translated
279 / 326 \(85%\) test files were successfully translated accounting for  1437 / 2147 \(66%\) test commands