### PR TITLE
LRQA-36241 PR tester GitHub message updates

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -1108,11 +1108,6 @@ public class TopLevelBuild extends BaseBuild {
 				UpstreamFailureUtil.loadUpstreamJobFailuresJSONObject(this);
 			}
 
-			Dom4JUtil.addToElement(
-				rootElement, Dom4JUtil.getNewElement("hr"),
-				Dom4JUtil.getNewElement(
-					"h4", null, "Failures unique to this pull:"));
-
 			Map<Build, Element> downstreamBuildFailureMessages =
 				getDownstreamBuildMessages("ABORTED", "FAILURE", "UNSTABLE");
 
@@ -1156,6 +1151,23 @@ public class TopLevelBuild extends BaseBuild {
 			}
 
 			failureElements.add(0, super.getGitHubMessageElement());
+
+			Dom4JUtil.addToElement(rootElement, Dom4JUtil.getNewElement("hr"));
+
+			if ((failureElements.size() == 1) &&
+				(upstreamJobFailureElements.size() > 0)) {
+
+				Dom4JUtil.addToElement(
+					rootElement,
+					Dom4JUtil.getNewElement(
+						"h4", null, "This pull contains no unique failures."));
+			}
+			else {
+				Dom4JUtil.addToElement(
+					rootElement,
+					Dom4JUtil.getNewElement(
+						"h4", null, "Failures unique to this pull:"));
+			}
 
 			Dom4JUtil.getOrderedListElement(
 				failureElements, rootElement, maxFailureCount);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -1167,10 +1167,10 @@ public class TopLevelBuild extends BaseBuild {
 					rootElement,
 					Dom4JUtil.getNewElement(
 						"h4", null, "Failures unique to this pull:"));
-			}
 
-			Dom4JUtil.getOrderedListElement(
-				failureElements, rootElement, maxFailureCount);
+				Dom4JUtil.getOrderedListElement(
+					failureElements, rootElement, maxFailureCount);
+			}
 
 			String acceptanceUpstreamJobURL = getAcceptanceUpstreamURL();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -1155,7 +1155,7 @@ public class TopLevelBuild extends BaseBuild {
 			Dom4JUtil.addToElement(rootElement, Dom4JUtil.getNewElement("hr"));
 
 			if ((failureElements.size() == 1) &&
-				(upstreamJobFailureElements.size() > 0)) {
+				!upstreamJobFailureElements.isEmpty()) {
 
 				Dom4JUtil.addToElement(
 					rootElement,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -1150,7 +1150,9 @@ public class TopLevelBuild extends BaseBuild {
 				}
 			}
 
-			failureElements.add(0, super.getGitHubMessageElement());
+			if (failureElements.isEmpty()) {
+				failureElements.add(0, super.getGitHubMessageElement());
+			}
 
 			Dom4JUtil.addToElement(rootElement, Dom4JUtil.getNewElement("hr"));
 

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(7.0.x)_unresolved-req-failure/expected_message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(7.0.x)_unresolved-req-failure/expected_message.html
@@ -989,22 +989,6 @@
     <li>
       <div>
         <h5>
-          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(7.0.x)_unresolved-req-failure/test-1-14/test-portal-acceptance-pullrequest(7.0.x)/103/">test-portal-acceptance-pullrequest(7.0.x)</a>
-        </h5>
-        <div>
-          <h6>Job Results:</h6>
-          <p>17 Jobs Passed.
-            <br/>129 Jobs Failed.
-          </p>
-        </div>
-        <pre>
-          <code>Downstream jobs FAILED.</code>
-        </pre>
-      </div>
-    </li>
-    <li>
-      <div>
-        <h5>
           <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(7.0.x)_unresolved-req-failure/test-1-21/test-portal-acceptance-pullrequest-batch(7.0.x)/2725/">test-portal-acceptance-pullrequest-batch(7.0.x)/empty-temp-dir-jdk8</a>
         </h5>
         <div>
@@ -1167,6 +1151,55 @@
      [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.doProcess(DirectoryWatcher.java:512)
      [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.process(DirectoryWatcher.java:361)
      [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.run(DirectoryWatcher.java:312)</code>
+                </pre>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </li>
+    <li>
+      <div>
+        <h5>
+          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(7.0.x)_unresolved-req-failure/test-1-1/test-portal-acceptance-pullrequest-batch(7.0.x)/5800/">test-portal-acceptance-pullrequest-batch(7.0.x)/functional-smoke-tomcat80-db2105-jdk8/0</a>
+        </h5>
+        <div>
+          <h6>Job Results:</h6>
+          <p>0 Tests Passed.
+            <br/>1 Test Failed.
+          </p>
+        </div>
+        <ol>
+          <li>
+            <div>
+              <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(7.0.x)_unresolved-req-failure/test-1-1/test-portal-acceptance-pullrequest-batch(7.0.x)/AXIS_VARIABLE=0,label_exp=!master/5800//consoleText">AXIS_VARIABLE=0,label_exp=!master #5800</a>
+              <div>
+                <p>Startup error:
+                  <strong>Unresolved Requirement(s)</strong>
+                </p>
+                <pre>
+                  <code>     [exec]   Unresolved requirement: Import-Package: com.liferay.portal.kernel.repository.model; version="[7.1.0,7.2.0)"
+     [exec]
+     [exec] 	at org.eclipse.osgi.container.Module.start(Module.java:429)
+     [exec] 	at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:402)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundle(DirectoryWatcher.java:1253)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundles(DirectoryWatcher.java:1225)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.doProcess(DirectoryWatcher.java:512)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.process(DirectoryWatcher.java:361)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.run(DirectoryWatcher.java:312)
+     [exec] 12:32:27,390 ERROR [fileinstall-/opt/dev/projects/github/liferay-portal-7.0.x/bundles/osgi/modules][org_apache_felix_fileinstall:112] Exiting the JVM
+     [exec] org.osgi.framework.BundleException: Could not resolve module: com.liferay.document.library.repository.external [272]
+     [exec]   Unresolved requirement: Import-Package: com.liferay.portal.kernel.repository.model; version="[7.1.0,7.2.0)"
+     [exec]
+     [exec] 	at org.eclipse.osgi.container.Module.start(Module.java:429)
+     [exec] 	at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:402)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundle(DirectoryWatcher.java:1253)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundles(DirectoryWatcher.java:1225)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.doProcess(DirectoryWatcher.java:512)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.process(DirectoryWatcher.java:361)
+     [exec] 	at org.apache.felix.fileinstall.internal.DirectoryWatcher.run(DirectoryWatcher.java:312)
+     [exec] 12:32:27,473 INFO  [fileinstall-/opt/dev/projects/github/liferay-portal-7.0.x/bundles/osgi/portal][BundleStartStopLogger:35] STARTED com.liferay.portal.scripting.ruby_2.0.9 [105]
+     [exec] 12:32:27,610 INFO  [fileinstall-/opt/dev/projects/github/liferay-portal-7.0.x/bundles/osgi/portal][BundleStartStopLogger:35] STARTED com.liferay.portal.security.service.access.policy.api_2.0.7 [125]</code>
                 </pre>
               </div>
             </div>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_generic-failure/expected_message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_generic-failure/expected_message.html
@@ -333,22 +333,6 @@
     <li>
       <div>
         <h5>
-          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_generic-failure/test-1-1/test-portal-acceptance-pullrequest(master)/1375/">test-portal-acceptance-pullrequest(master)</a>
-        </h5>
-        <div>
-          <h6>Job Results:</h6>
-          <p>96 Jobs Passed.
-            <br/>2 Jobs Failed.
-          </p>
-        </div>
-        <pre>
-          <code>Downstream jobs FAILED.</code>
-        </pre>
-      </div>
-    </li>
-    <li>
-      <div>
-        <h5>
           <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_generic-failure/test-1-12/test-portal-acceptance-pullrequest-batch(master)/32411/">test-portal-acceptance-pullrequest-batch(master)/lpkg-startup-jdk8</a>
         </h5>
         <div>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/expected_message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/expected_message.html
@@ -442,22 +442,6 @@
     <li>
       <div>
         <h5>
-          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-21/test-portal-acceptance-pullrequest(master)/999/">test-portal-acceptance-pullrequest(master)</a>
-        </h5>
-        <div>
-          <h6>Job Results:</h6>
-          <p>123 Jobs Passed.
-            <br/>6 Jobs Failed.
-          </p>
-        </div>
-        <pre>
-          <code>Downstream jobs FAILED.</code>
-        </pre>
-      </div>
-    </li>
-    <li>
-      <div>
-        <h5>
           <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-23/test-portal-acceptance-pullrequest-batch(master)/7862/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat80-mysql56-jdk8/11</a>
         </h5>
         <div>
@@ -663,9 +647,35 @@
         </ol>
       </div>
     </li>
-    <li>...</li>
-  </ol>
-  <h4>For upstream results, click
+    <li>
+      <div>
+        <h5>
+          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-21/test-portal-acceptance-pullrequest-batch(master)/85911/">test-portal-acceptance-pullrequest-batch(master)/unit-jdk8</a>
+        </h5>
+        <div>
+          <h6>Job Results:</h6>
+          <p>2673 Tests Passed.
+            <br/>2 Tests Failed.
+          </p>
+        </div>
+        <ol>
+          <li>
+            <div>
+              <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-21/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/85911//consoleText">AXIS_VARIABLE=0,label_exp=!master #85911</a>
+              <ol>
+                <li>
+                  <div>
+                    <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-21/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/85911//testReport/com.liferay.portal.library/LibraryReferenceTest/testEclipseJarsInLib">LibraryReferenceTest.testEclipseJarsInLib</a>
+                    <pre>
+                      <code>junit.framework.AssertionFailedError: .classpath has a nonexistent reference to lib/development/com.liferay.util.taglib.compat.jar
+	at com.liferay.portal.library.LibraryReferenceTest.testNonexistentJarReferences(LibraryReferenceTest.java:212)
+	at com.liferay.portal.library.LibraryReferenceTest.testEclipseJarsInLib(LibraryReferenceTest.java:84)
+</code>                    </pre>                  </div>                </li>                <li>                  <div>                    <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-21/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/85911//testReport/com.liferay.portal.library/LibraryReferenceTest/testNetBeansJarsInLib">LibraryReferenceTest.testNetBeansJarsInLib</a>
+                    <pre>
+                      <code>junit.framework.AssertionFailedError: nbproject/project.xml has a nonexistent reference to lib/development/com.liferay.util.taglib.compat.jar
+	at com.liferay.portal.library.LibraryReferenceTest.testNonexistentJarReferences(LibraryReferenceTest.java:212)
+	at com.liferay.portal.library.LibraryReferenceTest.testNetBeansJarsInLib(LibraryReferenceTest.java:137)
+</code>                    </pre>                  </div>                </li>              </ol>            </div>          </li>        </ol>      </div>    </li>  </ol>  <h4>For upstream results, click
     <a href="https://test-1-1.liferay.com/job/test-portal-acceptance-upstream(master)">here</a>.
   </h4>
 </html>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_semantic_versioning_failure/expected_message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_semantic_versioning_failure/expected_message.html
@@ -359,22 +359,6 @@
     <li>
       <div>
         <h5>
-          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_semantic_versioning_failure/test-1-3/test-portal-acceptance-pullrequest(master)/2003/">test-portal-acceptance-pullrequest(master)</a>
-        </h5>
-        <div>
-          <h6>Job Results:</h6>
-          <p>101 Jobs Passed.
-            <br/>3 Jobs Failed.
-          </p>
-        </div>
-        <pre>
-          <code>Downstream jobs FAILED.</code>
-        </pre>
-      </div>
-    </li>
-    <li>
-      <div>
-        <h5>
           <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_semantic_versioning_failure/test-1-21/test-portal-acceptance-pullrequest-batch(master)/60415/">test-portal-acceptance-pullrequest-batch(master)/modules-integration-oracle121-jdk8</a>
         </h5>
         <div>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_source-format-failure/expected_message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/BuildTest/test-portal-acceptance-pullrequest(master)_source-format-failure/expected_message.html
@@ -464,22 +464,6 @@
     <li>
       <div>
         <h5>
-          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_source-format-failure/test-1-2/test-portal-acceptance-pullrequest(master)/2209/">test-portal-acceptance-pullrequest(master)</a>
-        </h5>
-        <div>
-          <h6>Job Results:</h6>
-          <p>129 Jobs Passed.
-            <br/>6 Jobs Failed.
-          </p>
-        </div>
-        <pre>
-          <code>Downstream jobs FAILED.</code>
-        </pre>
-      </div>
-    </li>
-    <li>
-      <div>
-        <h5>
           <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_source-format-failure/test-1-23/test-portal-acceptance-pullrequest-batch(master)/8220/">test-portal-acceptance-pullrequest-batch(master)/functional-smoke-wildfly100-mariadb100-jdk8/0</a>
         </h5>
         <div>
@@ -628,7 +612,75 @@
         </ol>
       </div>
     </li>
-    <li>...</li>
+    <li>
+      <div>
+        <h5>
+          <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_source-format-failure/test-1-15/test-portal-acceptance-pullrequest-batch(master)/94121/">test-portal-acceptance-pullrequest-batch(master)/source-format-jdk8</a>
+        </h5>
+        <div>
+          <h6>Job Results:</h6>
+          <p>0 Tests Passed.
+            <br/>1 Test Failed.
+          </p>
+        </div>
+        <ol>
+          <li>
+            <div>
+              <a href="${dependencies.url}/BuildTest/test-portal-acceptance-pullrequest(master)_source-format-failure/test-1-15/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/94121//consoleText">AXIS_VARIABLE=0,label_exp=!master #94121</a>
+              <pre>
+                <code>     [java] 	@Override
+     [java] 	public [List&lt;AssetDisplayTemplate&gt; getAssetDisplayTemplates(long groupId) {
+     [java] 		return assetDisplayTemplatePersistence.findByGroupId(groupId);
+     [java] 	}
+     [java]
+     [java] 	@Override
+     [java] 	public List&lt;AssetDisplayTemplate&gt; getAssetDisplayTemplates(
+     [java] 		long groupId, int start, int end,
+     [java] 		OrderByComparator&lt;AssetDisplayTemplate&gt; orderByComparator) {
+     [java]
+     [java] 		return assetDisplayTemplatePersistence.findByGroupId(
+     [java] 			groupId, start, end, orderByComparator);
+     [java] 	}
+     [java]
+     [java] 	@Override
+     [java] 	public int getAssetDisplayTemplatesCount(long groupId) {
+     [java] 		return assetDisplayTemplatePersistence.countByGroupId(groupId]);
+     [java] 	}
+     [java]
+     [java] 	@Override
+     [java] 	p...&gt; but was:&lt;...
+     [java] 	@Override
+     [java] 	public [int getAssetDisplayTemplatesCount(long groupId) {
+     [java] 		return assetDisplayTemplatePersistence.countByGroupId(groupId);
+     [java] 	}
+     [java]
+     [java] 	@Override
+     [java] 	public List&lt;AssetDisplayTemplate&gt; getAssetDisplayTemplates(long groupId) {
+     [java] 		return assetDisplayTemplatePersistence.findByGroupId(groupId);
+     [java] 	}
+     [java]
+     [java] 	@Override
+     [java] 	public List&lt;AssetDisplayTemplate&gt; getAssetDisplayTemplates(
+     [java] 		long groupId, int start, int end,
+     [java] 		OrderByComparator&lt;AssetDisplayTemplate&gt; orderByComparator) {
+     [java]
+     [java] 		return assetDisplayTemplatePersistence.findByGroupId(
+     [java] 			groupId, start, end, orderByComparator]);
+     [java] 	}
+     [java]
+     [java] 	@Override
+     [java] 	p...&gt;
+     [java] 	at com.liferay.source.formatter.BaseSourceProcessor.processFormattedFile(BaseSourceProcessor.java:351)
+     [java] 	at com.liferay.source.formatter.BaseSourceProcessor._format(BaseSourceProcessor.java:526)
+     [java] 	at com.liferay.source.formatter.BaseSourceProcessor.access$000(BaseSourceProcessor.java:67)
+     [java] 	at com.liferay.source.formatter.BaseSourceProcessor$1.call(BaseSourceProcessor.java:103)
+     [java] 	at com.liferay.source.formatter.BaseSourceProcessor$1.call(BaseSourceProcessor.java:98)</code>
+              </pre>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </li>
   </ol>
   <h4>For upstream results, click
     <a href="https://test-1-1.liferay.com/job/test-portal-acceptance-upstream(master)">here</a>.


### PR DESCRIPTION
[LRQA-36241](https://issues.liferay.com/browse/LRQA-36241) Clarify github message when there are only upstream failures and nothing unique
[LRQA-37192](https://issues.liferay.com/browse/LRQA-37192) Only show top level failure section if it's the only failure

#### Unique failure change: 
It got way to complicated trying to change the summary title. Just sending the basic change. It'll look like https://github.com/michaelhashimoto/liferay-portal/pull/1177#issuecomment-356479345 instead of https://github.com/brianchandotcom/liferay-portal/pull/54213#issuecomment-356430862

#### Top level failure change
Omitted top level portions are reflected in the expected_message.html files. Also note that RebaseErrorTopLEvelBuildTemplate.html doesn't need to be updated because for rebase errors, only the top level fails and no downstreams. 