### PR TITLE
LRQA-37392 Fix nullpointer exception for getInvokedTime in jenkins report

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
@@ -144,11 +144,23 @@ public class BatchBuild extends BaseBuild {
 			return invokedTime;
 		}
 
-		Pattern pattern = Pattern.compile(
-			JenkinsResultsParserUtil.combine(
-				"\\s*\\[echo\\]\\s*", Pattern.quote(getJobName()), "/",
-				Pattern.quote(getJobVariant()),
-				"\\s*invoked time: (?<invokedTime>[^\\n]*)"));
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\\s*\\[echo\\]\\s*");
+
+		sb.append(Pattern.quote(getJobName()));
+
+		String jobVariant = getJobVariant();
+
+		if ((jobVariant != null) && !jobVariant.isEmpty()) {
+			sb.append("/");
+
+			sb.append(Pattern.quote(jobVariant));
+		}
+
+		sb.append("\\s*invoked time: (?<invokedTime>[^\\n]*)");
+
+		Pattern pattern = Pattern.compile(sb.toString());
 
 		Build parentBuild = getParentBuild();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-37392

This is causing a null pointer exception in test-portal-upstream(7.0.x) because the dist batch for this job does not have a job variant. 