### PR TITLE
LRQA-37766 Use the invoked time for data points instead of start time

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2393,11 +2393,17 @@ public abstract class BaseBuild implements Build {
 			int endIndex = _getIndex(buildStartTime + build.getDuration());
 			int startIndex = _getIndex(buildStartTime);
 
-			_timeline[startIndex]._invocationsCount++;
-
 			for (int i = startIndex; i <= endIndex; i++) {
 				_timeline[i]._slaveUsageCount++;
 			}
+
+			Long buildInvokedTime = build.getInvokedTime();
+
+			if (buildInvokedTime == null) {
+				return;
+			}
+
+			_timeline[_getIndex(buildInvokedTime)]._invocationsCount++;
 		}
 
 		protected int[] getIndexData() {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-37766

@pyoo47 - You were right the data points were being recorded wrong within the graph.

We were recording the "Axis Invocations" based off of the start times within the graph, so I just shifted it over to the invoked time found from the build model.

It seems like the other calculations being made were fine, it was just this one was off.

Please let me know if you have any questions.

Thanks!

---

I attached examples of the old report that was generated vs the new report in the JIRA ticket:
[https://issues.liferay.com/browse/LRQA-37766](https://issues.liferay.com/browse/LRQA-37766?focusedCommentId=1234212&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1234212)