### PR TITLE
LRQA-37883 Generate build description using build object

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -298,111 +298,290 @@ public abstract class BaseBuild implements Build {
 		String buildDescriptionPropertyKey,
 		String buildDescriptionPropertyValue) {
 
+		String jobName = getJobName();
+
 		StringBuilder sb = new StringBuilder();
 
 		if (buildDescriptionPropertyKey.equals("app.name")) {
+			sb.append("<strong>App Name</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"code.coverage.report.link")) {
+
+			sb.append("<a href=\"");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("\">Code Coverage Report</a>");
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.DATA_ARCHIVE_BRANCH_NAME")) {
+
+			String dataArchiveBranchName = buildDescriptionPropertyValue;
+
+			sb.append(
+				"<strong><a href=\"https://github.com/liferay" +
+					"/liferay-qa-portal-legacy-ee/commits/");
+			sb.append(dataArchiveBranchName);
+			sb.append("\">");
+			sb.append(dataArchiveBranchName);
+			sb.append("</a></strong>");
 		}
 		else if (buildDescriptionPropertyKey.equals(
-					"env.GITHUB_PULL_REQUEST_NUMBER")) {
+					"env.GITHUB_PULL_REQUEST_LINK")) {
+
+			String githubPullRequestNumber =
+				buildDescriptionPropertyValue.substring(
+					buildDescriptionPropertyValue.lastIndexOf("/"));
+
+			sb.append("<a href=\"");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("\">PR#");
+			sb.append(githubPullRequestNumber);
+			sb.append("</a>");
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.GITHUB_RECEIVER_USERNAME")) {
+
+			sb.append("<strong>");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("</strong>");
 		}
 		else if (buildDescriptionPropertyKey.equals("env.JOB_VARIANT")) {
+			sb.append("<strong>Project</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals("env.MIRRORS_URL")) {
+			String mirrorsURL = buildDescriptionPropertyValue;
+
+			String mirrorsFileName = mirrorsURL.substring(
+				mirrorsURL.lastIndexOf("/") + 1);
+
+			sb.append("<a href=\"");
+			sb.append(mirrorsURL);
+			sb.append("\">");
+			sb.append(mirrorsFileName);
+			sb.append("</a>");
 		}
 		else if (buildDescriptionPropertyKey.equals("env.PORTAL_GIT_COMMIT")) {
+			sb.append("<strong>GIT ID</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals("env.PROJECT_NAMES")) {
-		}
-		else if (buildDescriptionPropertyKey.equals("env.REPOSITORY_NAME")) {
+			sb.append("<strong>Projects</strong> - ");
+
+			for (String projectName :
+					buildDescriptionPropertyValue.split(",")) {
+
+				projectName = projectName.replace("-", " ");
+
+				projectName = StringUtils.capitalize(projectName);
+
+				sb.append(projectName);
+
+				sb.append(" - ");
+			}
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_BUILD_EXTRAAPPS_ZIP_URL")) {
+
+			sb.append("<a href=\"");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("\">extraapps.zip</a>");
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_BUILD_FIX_PACK_ZIP_URL")) {
+
+			if (!jobName.contains("portal-patch-batch")) {
+				sb.append("<li>");
+			}
+
+			String fixPackZipURL = buildDescriptionPropertyValue;
+
+			int x = fixPackZipURL.lastIndexOf("/") + 1;
+			int y = fixPackZipURL.lastIndexOf(".");
+
+			String fixPackZipName = fixPackZipURL.substring(x, y);
+
+			sb.append("<a href=\"");
+			sb.append(fixPackZipURL);
+			sb.append("\">");
+			sb.append(fixPackZipName);
+			sb.append("</a>");
+
+			if (!jobName.contains("portal-patch-batch")) {
+				sb.append("</li>");
+			}
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_BUILD_TICKET_URLS")) {
+
+			String testBuildTicketURLs = buildDescriptionPropertyValue;
+
+			sb.append("<ul>");
+
+			for (String testBuildTicketURL : testBuildTicketURLs.split(",")) {
+				if (!testBuildTicketURL.isEmpty()) {
+					int x = testBuildTicketURL.lastIndexOf('/') + 1;
+
+					String testBuildTicketName = testBuildTicketURL.substring(
+						x);
+
+					sb.append("<li><a href=\"");
+					sb.append(testBuildTicketURL);
+					sb.append("\">");
+					sb.append(testBuildTicketName);
+					sb.append("</a></li>");
+				}
+			}
+
+			sb.append("</ul>");
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_PACKAGE_FILE_NAME")) {
+
+			sb.append("<strong>App Name</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_PLUGINS_GIT_ID")) {
+
+			sb.append("<strong>Plugins GIT ID</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_PORTAL_APP_VERSION")) {
+
+			sb.append("<strong>App Version</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_PORTAL_BRANCH_NAME")) {
+
+			if (jobName.contains("portal-release")) {
+				sb.append("<strong>Portal Release(");
+				sb.append(buildDescriptionPropertyValue);
+				sb.append(")</strong> -");
+			}
+			else if (jobName.contains("portal-training")) {
+				sb.append("<strong>Portal Training(");
+				sb.append(buildDescriptionPropertyValue);
+				sb.append(")</strong> -");
+			}
+			else {
+				sb.append("<strong>Portal Branch</strong> - ");
+				sb.append(buildDescriptionPropertyValue);
+			}
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_PORTAL_BUNDLE_VERSION")) {
-		}
-		else if (buildDescriptionPropertyKey.equals(
-					"env.TEST_PORTAL_FIX_PACK_VERSION")) {
+
+			sb.append("<strong>Portal Bundle Version</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_PORTAL_RELEASE_VERSION")) {
+
+			sb.append("<strong>Portal Bundle Version</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_QA_WEBSITES_BRANCH_NAME")) {
+
+			sb.append("<strong>Branch Name</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_QA_WEBSITES_BRANCH_USERNAME")) {
+
+			sb.append("<strong>Branch Username</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"env.TEST_QA_WEBSITES_GIT_ID")) {
+
+			sb.append("<strong>GIT ID</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"gradle.plugins.test.reports")) {
+
+			sb.append(buildDescriptionPropertyValue);
+		}
+		else if (buildDescriptionPropertyKey.equals("jenkins.report.link")) {
+			sb.append("<a href=\"");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("\">Jenkins Report</a>");
 		}
 		else if (buildDescriptionPropertyKey.equals("legacy.dump.url")) {
+			sb.append("<strong><a href=\"");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("\">Legacy Database Dumps</a></strong>");
 		}
 		else if (buildDescriptionPropertyKey.equals("plugin.name")) {
+			sb.append("<strong>Plugin</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals("plugins.repository")) {
 		}
 		else if (buildDescriptionPropertyKey.equals("portal.bundle.version")) {
+			sb.append("<strong>");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("</strong> - ");
 		}
 		else if (buildDescriptionPropertyKey.equals("portal.git.commit")) {
+			sb.append("<strong>GIT ID</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals("portal.repository")) {
 		}
 		else if (buildDescriptionPropertyKey.equals("portal.version")) {
+			sb.append("<strong>Portal Version</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals("test.plugins.git.id")) {
+			sb.append(" - <strong>Plugins GIT ID</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"test.plugins.release.tag")) {
+
+			sb.append("<strong>Plugins GIT REF</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"test.portal.bundle.version")) {
+
+			sb.append("<strong>Portal Bundle Version</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"test.portal.fix.pack.version")) {
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"test.qa.websites.branch.name")) {
+
+			sb.append("<strong>Branch Name</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"test.qa.websites.branch.username")) {
+
+			sb.append("<strong>Branch Username</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals(
 					"test.qa.websites.git.id")) {
+
+			sb.append("<strong>GIT ID</strong> - ");
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals("testray.poshi.report")) {
+			sb.append(buildDescriptionPropertyValue);
 		}
 		else if (buildDescriptionPropertyKey.equals("testray.run.shared.url")) {
-		}
-		else if (buildDescriptionPropertyKey.equals(
-					"top.level.user.content.url")) {
+			sb.append("<a href=\"");
+			sb.append(buildDescriptionPropertyValue);
+			sb.append("\">Poshi Reports</a>");
 		}
 
 		return sb.toString();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -273,7 +273,24 @@ public abstract class BaseBuild implements Build {
 	public String getBuildDescription(
 		LinkedHashMap<String, String> buildDescriptionProperties) {
 
-		return null;
+		StringBuilder sb = new StringBuilder();
+
+		List<String> keys = new ArrayList<>(
+			buildDescriptionProperties.keySet());
+
+		for (int i = 0; i < keys.size(); i++) {
+			String key = keys.get(i);
+
+			sb.append(
+				getBuildDescriptionPropertyElementString(
+					key, buildDescriptionProperties.get(key)));
+
+			if (i < (keys.size() - 1)) {
+				sb.append(" - ");
+			}
+		}
+
+		return sb.toString();
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -270,6 +270,128 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
+	public String getBuildDescription(
+		LinkedHashMap<String, String> buildDescriptionProperties) {
+
+		return null;
+	}
+
+	@Override
+	public String getBuildDescriptionPropertyElementString(
+		String buildDescriptionPropertyKey,
+		String buildDescriptionPropertyValue) {
+
+		StringBuilder sb = new StringBuilder();
+
+		if (buildDescriptionPropertyKey.equals("app.name")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.DATA_ARCHIVE_BRANCH_NAME")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.GITHUB_PULL_REQUEST_NUMBER")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.GITHUB_RECEIVER_USERNAME")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("env.JOB_VARIANT")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("env.MIRRORS_URL")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("env.PORTAL_GIT_COMMIT")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("env.PROJECT_NAMES")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("env.REPOSITORY_NAME")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_BUILD_EXTRAAPPS_ZIP_URL")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_BUILD_FIX_PACK_ZIP_URL")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_BUILD_TICKET_URLS")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_PACKAGE_FILE_NAME")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_PLUGINS_GIT_ID")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_PORTAL_APP_VERSION")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_PORTAL_BRANCH_NAME")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_PORTAL_BUNDLE_VERSION")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_PORTAL_FIX_PACK_VERSION")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_PORTAL_RELEASE_VERSION")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_QA_WEBSITES_BRANCH_NAME")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_QA_WEBSITES_BRANCH_USERNAME")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"env.TEST_QA_WEBSITES_GIT_ID")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"gradle.plugins.test.reports")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("legacy.dump.url")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("plugin.name")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("plugins.repository")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("portal.bundle.version")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("portal.git.commit")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("portal.repository")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("portal.version")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("test.plugins.git.id")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"test.plugins.release.tag")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"test.portal.bundle.version")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"test.portal.fix.pack.version")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"test.qa.websites.branch.name")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"test.qa.websites.branch.username")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"test.qa.websites.git.id")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("testray.poshi.report")) {
+		}
+		else if (buildDescriptionPropertyKey.equals("testray.run.shared.url")) {
+		}
+		else if (buildDescriptionPropertyKey.equals(
+					"top.level.user.content.url")) {
+		}
+
+		return sb.toString();
+	}
+
+	@Override
 	public JSONObject getBuildJSONObject() {
 		try {
 			return JenkinsResultsParserUtil.toJSONObject(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -14,6 +14,7 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -45,6 +46,13 @@ public interface Build {
 	public String getBranchName();
 
 	public String getBrowser();
+
+	public String getBuildDescription(
+		LinkedHashMap<String, String> buildDescriptionProperties);
+
+	public String getBuildDescriptionPropertyElementString(
+		String buildDescriptionPropertyKey,
+		String buildDescriptionPropertyValue);
 
 	public JSONObject getBuildJSONObject();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-37883

I would like some feedback about this implementation, if it looks okay then I will proceed to make changes on the jenkins side and test using this.

Workflow: 
1. jenkins job build script (inside beanshell) creates a build object using its build url
2. in the same beanshell, create and populate a LinkedHashMap containing property name mapped to its value in a predetermined order 
3. the build object calls getBuildDescription with LinkedHashMap as parameter which returns a generated string