### PR TITLE
LRQA-36161 SF

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -910,39 +910,6 @@ jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 		</sequential>
 	</macrodef>
 
-	<macrodef name="get-test-namespace">
-		<sequential>
-			<fail message="Please set the property ${test.class}." unless="test.class" />
-
-			<var name="test.namespace" unset="true" />
-
-			<beanshell>
-				<![CDATA[
-					import java.util.regex.Matcher;
-					import java.util.regex.Pattern;
-
-					String testClass = project.getProperty("test.class");
-
-					Pattern pattern = Pattern.compile("((?<namespace>\\w+)\\.)?(?<className>\\w+)(#(?<commandName>(\\w+(-\\w+)*|\\$\\{\\w+\\}|\\w+)*))?");
-
-					Matcher matcher = pattern.matcher(testClass);
-
-					if (!matcher.find()) {
-						throw new Exception("Invalid test class name: " + testClass);
-					}
-
-					String testNamespace = matcher.group("namespace");
-
-					if (testNamespace == null) {
-						testNamespace = project.getProperty("test.poshi.runner.default.namespace");
-					}
-
-					project.setProperty("test.namespace", testNamespace);
-				]]>
-			</beanshell>
-		</sequential>
-	</macrodef>
-
 	<macrodef name="get-test-method-name">
 		<sequential>
 			<fail message="Please set the property ${test.class}." unless="test.class" />
@@ -974,6 +941,39 @@ jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 
 						project.setProperty("test.method.name", testMethodName);
 					}
+				]]>
+			</beanshell>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="get-test-namespace">
+		<sequential>
+			<fail message="Please set the property ${test.class}." unless="test.class" />
+
+			<var name="test.namespace" unset="true" />
+
+			<beanshell>
+				<![CDATA[
+					import java.util.regex.Matcher;
+					import java.util.regex.Pattern;
+
+					String testClass = project.getProperty("test.class");
+
+					Pattern pattern = Pattern.compile("((?<namespace>\\w+)\\.)?(?<className>\\w+)(#(?<commandName>(\\w+(-\\w+)*|\\$\\{\\w+\\}|\\w+)*))?");
+
+					Matcher matcher = pattern.matcher(testClass);
+
+					if (!matcher.find()) {
+						throw new Exception("Invalid test class name: " + testClass);
+					}
+
+					String testNamespace = matcher.group("namespace");
+
+					if (testNamespace == null) {
+						testNamespace = project.getProperty("test.poshi.runner.default.namespace");
+					}
+
+					project.setProperty("test.namespace", testNamespace);
 				]]>
 			</beanshell>
 		</sequential>
@@ -1108,8 +1108,8 @@ jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 						</then>
 					</if>
 
-					<get-test-namespace />
 					<get-test-method-name />
+					<get-test-namespace />
 					<get-test-simple-class-name />
 
 					<beanshell>

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/LinkTag.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/LinkTag.java
@@ -61,4 +61,8 @@ public class LinkTag extends BaseClayTag {
 		putValue("target", target);
 	}
 
+	public void setTitle(String title) {
+		putValue("title", title);
+	}
+
 }

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1028,6 +1028,12 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description></description>
+			<name>title</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 	<tag>
 		<description></description>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-36161

The 'get-test-namespace' macrodef that was added is out of order, and it is causing a source-format problem on master.

This was the error message:
` [java] 1: Incorrect order 'macrodef': get-test-method-name: ./build-test.xml 
(SourceCheck:XMLBuildFileCheck)`

Example of console:
https://test-1-6.liferay.com/job/test-portal-acceptance-upstream-batch(master)/AXIS_VARIABLE=0,label_exp=!master/17385/console

