### PR TITLE
LRQA-39309 Update poshi to v1.0.82 & update default Firefox to v52.0

### DIFF
--- a/portal-web/build-test.gradle
+++ b/portal-web/build-test.gradle
@@ -13,7 +13,7 @@ poshiRunner {
 	}
 
 	openCVVersion = "2.4.10-0.10"
-	version = "1.0.80"
+	version = "1.0.82"
 }
 
 task updateGradleCache

--- a/test.properties
+++ b/test.properties
@@ -118,8 +118,8 @@
 
     #browser.firefox.version=22.0
     #browser.firefox.version=38.0
-    browser.firefox.version=45.0
-    #browser.firefox.version=52.0
+    #browser.firefox.version=45.0
+    browser.firefox.version=52.0
 
     #browser.firefox.bin.file[22.0]=
     #browser.firefox.bin.file[38.0]=


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-39309

@pyoo47, testing 7.0.x here: https://github.com/kenjiheigel/liferay-portal-ee/pull/221. If tests look clean, then we can ask BChan to backport to 7.0.x off of the master pull.

@jpince, @brianchiu, @brianwulbern