### PR TITLE
LRQA-39321 Add new SubrepositoryJob class to get information on subrepository pull requests

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
@@ -14,6 +14,10 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * @author Michael Hashimoto
  */
@@ -28,6 +32,28 @@ public abstract class BaseJob implements Job {
 		this.jobName = jobName;
 	}
 
+	protected String getProperty(Properties properties, String name) {
+		if (!properties.containsKey(name)) {
+			return null;
+		}
+
+		String value = properties.getProperty(name);
+
+		Matcher matcher = _propertiesPattern.matcher(value);
+
+		String newValue = value;
+
+		while (matcher.find()) {
+			newValue = newValue.replace(
+				matcher.group(0), getProperty(properties, matcher.group(1)));
+		}
+
+		return newValue;
+	}
+
 	protected String jobName;
+
+	private static final Pattern _propertiesPattern = Pattern.compile(
+		"\\$\\{([^\\}]+)\\}");
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDataJSONObject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDataJSONObject.java
@@ -100,6 +100,7 @@ public class BuildDataJSONObject extends JSONObject {
 			sb.append(entry.getKey());
 			sb.append("=");
 			sb.append(entry.getValue());
+			sb.append("\n");
 		}
 
 		JenkinsResultsParserUtil.write(destFilePath, sb.toString());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Job.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Job.java
@@ -14,16 +14,16 @@
 
 package com.liferay.jenkins.results.parser;
 
-import java.util.List;
+import java.util.Set;
 
 /**
  * @author Michael Hashimoto
  */
 public interface Job {
 
-	public List<String> getBatchNames();
+	public Set<String> getBatchNames();
 
-	public List<String> getDistTypes();
+	public Set<String> getDistTypes();
 
 	public String getJobName();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptancePullRequestJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptancePullRequestJob.java
@@ -14,9 +14,9 @@
 
 package com.liferay.jenkins.results.parser;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Michael Hashimoto
@@ -34,7 +34,7 @@ public class PortalAcceptancePullRequestJob extends PortalRepositoryJob {
 	}
 
 	@Override
-	public List<String> getBatchNames() {
+	public Set<String> getBatchNames() {
 		String testBatchNames = getProperty(
 			portalTestProperties, "test.batch.names[" + _testSuiteName + "]");
 
@@ -43,29 +43,29 @@ public class PortalAcceptancePullRequestJob extends PortalRepositoryJob {
 				portalTestProperties, "test.batch.names");
 		}
 
-		List<String> testBatchNamesList = getListFromString(testBatchNames);
+		Set<String> testBatchNamesSet = getSetFromString(testBatchNames);
 
 		if (_isPortalWebOnly()) {
-			List<String> irrelevantBatchNamesList = new ArrayList<>();
+			Set<String> irrelevantBatchNamesSet = new TreeSet<>();
 
-			for (String testBatchName : testBatchNamesList) {
+			for (String testBatchName : testBatchNamesSet) {
 				if (!testBatchName.contains("compile-jsp") &&
 					!testBatchName.contains("functional") &&
 					!testBatchName.contains("portal-web") &&
 					!testBatchName.contains("source-format")) {
 
-					irrelevantBatchNamesList.add(testBatchName);
+					irrelevantBatchNamesSet.add(testBatchName);
 				}
 			}
 
-			testBatchNamesList.removeAll(irrelevantBatchNamesList);
+			testBatchNamesSet.removeAll(irrelevantBatchNamesSet);
 		}
 
-		return testBatchNamesList;
+		return testBatchNamesSet;
 	}
 
 	@Override
-	public List<String> getDistTypes() {
+	public Set<String> getDistTypes() {
 		String testBatchDistAppServers = getProperty(
 			portalTestProperties,
 			"test.batch.dist.app.servers[" + _testSuiteName + "]");
@@ -75,7 +75,7 @@ public class PortalAcceptancePullRequestJob extends PortalRepositoryJob {
 				portalTestProperties, "test.batch.dist.app.servers");
 		}
 
-		return getListFromString(testBatchDistAppServers);
+		return getSetFromString(testBatchDistAppServers);
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
@@ -71,7 +71,6 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 	protected PortalRepositoryJob(String jobName) {
 		super(jobName);
 
-		branchName = _getBranchName();
 		gitWorkingDirectory = _getPortalGitWorkingDirectory();
 
 		portalTestProperties = JenkinsResultsParserUtil.getProperties(
@@ -120,16 +119,6 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 
 	protected final Properties portalTestProperties;
 
-	private String _getBranchName() {
-		Matcher matcher = _jobNamePattern.matcher(jobName);
-
-		if (matcher.find()) {
-			return matcher.group("branchName");
-		}
-
-		return "master";
-	}
-
 	private PortalGitWorkingDirectory _getPortalGitWorkingDirectory() {
 		if ((gitWorkingDirectory != null) &&
 			gitWorkingDirectory instanceof PortalGitWorkingDirectory) {
@@ -137,7 +126,6 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 			return (PortalGitWorkingDirectory)gitWorkingDirectory;
 		}
 
-		String branchName = _getBranchName();
 		String workingDirectoryPath = "/opt/dev/projects/github/liferay-portal";
 
 		if (!branchName.equals("master")) {
@@ -161,8 +149,6 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 		return portalGitWorkingDirectory;
 	}
 
-	private static final Pattern _jobNamePattern = Pattern.compile(
-		"[^\\(]+\\((?<branchName>[^\\)]+)\\)");
 	private static final Pattern _propertiesPattern = Pattern.compile(
 		"\\$\\{([^\\}]+)\\}");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -98,25 +96,6 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 		return list;
 	}
 
-	protected String getProperty(Properties properties, String name) {
-		if (!properties.containsKey(name)) {
-			return null;
-		}
-
-		String value = properties.getProperty(name);
-
-		Matcher matcher = _propertiesPattern.matcher(value);
-
-		String newValue = value;
-
-		while (matcher.find()) {
-			newValue = newValue.replace(
-				matcher.group(0), getProperty(properties, matcher.group(1)));
-		}
-
-		return newValue;
-	}
-
 	protected final Properties portalTestProperties;
 
 	private PortalGitWorkingDirectory _getPortalGitWorkingDirectory() {
@@ -148,8 +127,5 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 
 		return portalGitWorkingDirectory;
 	}
-
-	private static final Pattern _propertiesPattern = Pattern.compile(
-		"\\$\\{([^\\}]+)\\}");
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
@@ -17,10 +17,10 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 import java.io.IOException;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -30,19 +30,19 @@ import org.apache.commons.lang.StringUtils;
 public abstract class PortalRepositoryJob extends RepositoryJob {
 
 	@Override
-	public List<String> getBatchNames() {
+	public Set<String> getBatchNames() {
 		String testBatchNames = getProperty(
 			portalTestProperties, "test.batch.names");
 
-		return getListFromString(testBatchNames);
+		return getSetFromString(testBatchNames);
 	}
 
 	@Override
-	public List<String> getDistTypes() {
+	public Set<String> getDistTypes() {
 		String testBatchDistAppServers = getProperty(
 			portalTestProperties, "test.batch.dist.app.servers");
 
-		return getListFromString(testBatchDistAppServers);
+		return getSetFromString(testBatchDistAppServers);
 	}
 
 	@Override
@@ -76,24 +76,22 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 				gitWorkingDirectory.getWorkingDirectory(), "test.properties"));
 	}
 
-	protected List<String> getListFromString(String string) {
+	protected Set<String> getSetFromString(String string) {
 		if (string == null) {
-			return Collections.emptyList();
+			return Collections.emptySet();
 		}
 
-		List<String> list = new ArrayList<>();
+		Set<String> set = new TreeSet<>();
 
 		for (String item : StringUtils.split(string, ",")) {
-			if (list.contains(item) || item.startsWith("#")) {
+			if (item.startsWith("#")) {
 				continue;
 			}
 
-			list.add(item);
+			set.add(item);
 		}
 
-		Collections.sort(list);
-
-		return list;
+		return set;
 	}
 
 	protected final Properties portalTestProperties;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
@@ -84,6 +84,8 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 		Set<String> set = new TreeSet<>();
 
 		for (String item : StringUtils.split(string, ",")) {
+			item = item.trim();
+
 			if (item.startsWith("#")) {
 				continue;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RepositoryJob.java
@@ -14,6 +14,9 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * @author Michael Hashimoto
  */
@@ -29,9 +32,24 @@ public abstract class RepositoryJob extends BaseJob {
 
 	protected RepositoryJob(String jobName) {
 		super(jobName);
+
+		branchName = _getBranchName(jobName);
 	}
 
 	protected String branchName;
 	protected GitWorkingDirectory gitWorkingDirectory;
+
+	private String _getBranchName(String jobName) {
+		Matcher matcher = _jobNamePattern.matcher(jobName);
+
+		if (matcher.find()) {
+			return matcher.group("branchName");
+		}
+
+		return "master";
+	}
+
+	private static final Pattern _jobNamePattern = Pattern.compile(
+		"[^\\(]+\\((?<branchName>[^\\)]+)\\)");
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryAcceptancePullRequestJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryAcceptancePullRequestJob.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class SubrepositoryAcceptancePullRequestJob extends SubrepositoryJob {
+
+	public SubrepositoryAcceptancePullRequestJob(
+		String jobName, String repositoryName) {
+
+		super(jobName, repositoryName);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryJob.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.net.URL;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * @author Michael Hashimoto
+ */
+public abstract class SubrepositoryJob extends RepositoryJob {
+
+	@Override
+	public Set<String> getBatchNames() {
+		Set<String> batchNames = _getRequiredTestBatchNames();
+
+		String testBatchNames = getProperty(
+			subrepositoryTestProperties, "test.batch.names");
+
+		if (!Objects.isNull(testBatchNames)) {
+			Collections.addAll(batchNames, testBatchNames.split(","));
+		}
+
+		return batchNames;
+	}
+
+	@Override
+	public Set<String> getDistTypes() {
+		String distTypes = getProperty(
+			subrepositoryTestProperties, "subrepo.dist.app.servers");
+
+		return new TreeSet(Arrays.asList(distTypes.split(",")));
+	}
+
+	@Override
+	public GitWorkingDirectory getGitWorkingDirectory() {
+		if (gitWorkingDirectory == null) {
+			String repositoryDirectoryPath = _getRepositoryDirectoryPath();
+
+			try {
+				gitWorkingDirectory = new GitWorkingDirectory(
+					branchName, repositoryDirectoryPath);
+			}
+			catch (IOException ioe) {
+				throw new RuntimeException(
+					"Invalid Git working directory " + repositoryDirectoryPath,
+					ioe);
+			}
+		}
+
+		return gitWorkingDirectory;
+	}
+
+	protected SubrepositoryJob(String jobName, String repositoryName) {
+		super(jobName);
+
+		_repositoryName = repositoryName;
+
+		gitWorkingDirectory = getGitWorkingDirectory();
+
+		String defaultPropertiesFilePath = JenkinsResultsParserUtil.combine(
+			System.getenv("WORKSPACE"), "/commands/dependencies",
+			"/test-subrepository-batch.properties");
+
+		subrepositoryTestProperties = JenkinsResultsParserUtil.getProperties(
+			new File(defaultPropertiesFilePath));
+
+		File testPropertiesfile = new File(
+			gitWorkingDirectory.getWorkingDirectory(), "test.properties");
+
+		if (testPropertiesfile.exists()) {
+			subrepositoryTestProperties.putAll(
+				JenkinsResultsParserUtil.getProperties(testPropertiesfile));
+		}
+	}
+
+	protected final Properties subrepositoryTestProperties;
+
+	private boolean _containsIntegrationTest() throws IOException {
+		List<URL> urls = JenkinsResultsParserUtil.getIncludedResourceURLs(
+			new String[] {"**/src/testIntegration"},
+			gitWorkingDirectory.getWorkingDirectory());
+
+		if (urls.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private String _getRepositoryDirectoryPath() {
+		String repositoryDirectoryPath =
+			"/opt/dev/projects/github/" + _repositoryName;
+
+		if (!repositoryDirectoryPath.endsWith("-private")) {
+			repositoryDirectoryPath += "-private";
+		}
+
+		return repositoryDirectoryPath;
+	}
+
+	private Set<String> _getRequiredTestBatchNames() {
+		String testRequiredBatchNames = getProperty(
+			subrepositoryTestProperties, "test.required.batch.names");
+
+		Set<String> testRequiredBatchNamesSet = new HashSet<>();
+
+		try {
+			if (!_containsIntegrationTest()) {
+				for (String testBatchName : testRequiredBatchNames.split(",")) {
+					if (!testBatchName.contains("integration")) {
+						testRequiredBatchNamesSet.add(testBatchName);
+					}
+				}
+			}
+			else {
+				testRequiredBatchNamesSet = new HashSet<>(
+					Arrays.asList(testRequiredBatchNames.split(",")));
+			}
+		}
+		catch (IOException ioe) {
+			throw new RuntimeException(
+				"Unable to search for integration tests");
+		}
+
+		return testRequiredBatchNamesSet;
+	}
+
+	private final String _repositoryName;
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-39321

@pyoo47 I have some questions/concerns about the changes I made here:
1. I added the method _getIncludedResourceURLs_ in order to get the list of URL's of a given glob. I didn't use the _findFiles_ method as I need to search for directories as well (in this case, searching for the testIntegration directory).
2. We currently use both _subrepo_ and _subrepository_. _subrepo_ is usually used as part of the property name, _subrepository_ is usually used for file names/variables/ant targets. I'm not sure if we should change one to the other?