### PR TITLE
LRQA-40276

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -60,6 +60,12 @@ public class AutoCloseUtil {
 			List<Build> downstreamBuilds = topLevelBuild.getDownstreamBuilds(
 				null);
 
+			if (downstreamBuilds.isEmpty()) {
+				downstreamBuilds = new ArrayList<>();
+
+				downstreamBuilds.add(topLevelBuild);
+			}
+
 			List<Build> failedDownstreamBuilds = autoCloseRule.evaluate(
 				downstreamBuilds);
 
@@ -334,7 +340,7 @@ public class AutoCloseUtil {
 
 		String propertyNameTemplate =
 			"test.batch.names.auto.close[" + project.getProperty("repository") +
-				project.getProperty("repository") + "?]";
+				"?]";
 
 		String repositoryBranchAutoClosePropertyName =
 			propertyNameTemplate.replace(
@@ -375,7 +381,7 @@ public class AutoCloseUtil {
 				parameters.get("JENKINS_JOB_VARIANT");
 		}
 
-		return null;
+		return downstreamBuild.getJobName();
 	}
 
 	public static boolean isAutoCloseBranch(Project project) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -338,9 +338,10 @@ public class AutoCloseUtil {
 
 		List<AutoCloseRule> list = new ArrayList<>();
 
-		String propertyNameTemplate =
-			"test.batch.names.auto.close[" + project.getProperty("repository") +
-				"?]";
+		String propertyNameTemplate = JenkinsResultsParserUtil.combine(
+			"test.batch.names.auto.close[",
+			project.getProperty("repository"),
+			"?]");
 
 		String repositoryBranchAutoClosePropertyName =
 			propertyNameTemplate.replace(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -339,8 +339,7 @@ public class AutoCloseUtil {
 		List<AutoCloseRule> list = new ArrayList<>();
 
 		String propertyNameTemplate = JenkinsResultsParserUtil.combine(
-			"test.batch.names.auto.close[",
-			project.getProperty("repository"),
+			"test.batch.names.auto.close[", project.getProperty("repository"),
 			"?]");
 
 		String repositoryBranchAutoClosePropertyName =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -681,6 +681,10 @@ public abstract class BaseBuild implements Build {
 			batchName = getParameterValue("JENKINS_JOB_VARIANT");
 		}
 
+		if ((batchName == null) || batchName.isEmpty()) {
+			batchName = getJobName();
+		}
+
 		return batchName;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchTestClassGroup.java
@@ -214,7 +214,7 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		}
 	}
 
-	protected List<File> autoBalanceTestFiles = new ArrayList();
+	protected List<File> autoBalanceTestFiles = new ArrayList<>();
 	protected final Map<Integer, AxisTestClassGroup> axisTestClassGroups =
 		new HashMap<>();
 	protected final String batchName;


### PR DESCRIPTION
These changes should allow for topLevelBuilds to be passed along, which allows us to apply autoclose rules to non-batch builds; the change to getJobVariant and getBatchName should allow us to use the jobName in the instances where a batch or variant name is not available