### PR TITLE
LRQA-40276

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -116,7 +116,7 @@ public class AutoCloseUtil {
 				sb.append("<li><a href=\"");
 				sb.append(failureBuildURL);
 				sb.append("\">");
-				sb.append(getBatchName(failedDownstreamBuild));
+				sb.append(failedDownstreamBuild.getJobVariant());
 				sb.append("</a></li>");
 			}
 
@@ -190,7 +190,7 @@ public class AutoCloseUtil {
 		List<Build> downstreamBuilds = topLevelBuild.getDownstreamBuilds(null);
 
 		for (Build downstreamBuild : downstreamBuilds) {
-			String batchName = getBatchName(downstreamBuild);
+			String batchName = downstreamBuild.getJobVariant();
 
 			if (batchName == null) {
 				continue;
@@ -369,21 +369,6 @@ public class AutoCloseUtil {
 		return list;
 	}
 
-	public static String getBatchName(Build downstreamBuild) throws Exception {
-		Map<String, String> parameters = downstreamBuild.getParameters();
-
-		if (parameters.containsKey("JOB_VARIANT")) {
-			return parameters.get("JOB_VARIANT");
-		}
-
-		if (parameters.containsKey("JENKINS_JOB_VARIANT")) {
-			return downstreamBuild.getJobName() + "/" +
-				parameters.get("JENKINS_JOB_VARIANT");
-		}
-
-		return downstreamBuild.getJobName();
-	}
-
 	public static boolean isAutoCloseBranch(Project project) {
 		String repository = project.getProperty("repository");
 
@@ -539,33 +524,18 @@ public class AutoCloseUtil {
 			return ruleData;
 		}
 
-		protected String getBatchName(Build build) {
-			String batchName = build.getParameterValue("JOB_VARIANT");
-
-			if ((batchName == null) || batchName.isEmpty()) {
-				batchName = build.getParameterValue("JENKINS_JOB_VARIANT");
-			}
-
-			if ((batchName == null) || batchName.isEmpty()) {
-				return build.getJobName();
-			}
-
-			return batchName;
-		}
-
 		protected List<Build> getMatchingBuilds(List<Build> downstreamBuilds) {
 			List<Build> filteredDownstreamBuilds = new ArrayList<>(
 				downstreamBuilds.size());
 
 			for (Build downstreamBuild : downstreamBuilds) {
-				String batchName = getBatchName(downstreamBuild);
+				String jobVariant = downstreamBuild.getJobVariant();
 
-				if ((batchName == null) || batchName.isEmpty()) {
+				if ((jobVariant == null) || jobVariant.isEmpty()) {
 					continue;
 				}
 
-				Matcher matcher = rulePattern.matcher(
-					getBatchName(downstreamBuild));
+				Matcher matcher = rulePattern.matcher(jobVariant);
 
 				if (matcher.matches()) {
 					filteredDownstreamBuilds.add(downstreamBuild);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -60,6 +60,12 @@ public class AutoCloseUtil {
 			List<Build> downstreamBuilds = topLevelBuild.getDownstreamBuilds(
 				null);
 
+			if (downstreamBuilds.isEmpty()) {
+				downstreamBuilds = new ArrayList<>();
+
+				downstreamBuilds.add(topLevelBuild);
+			}
+
 			List<Build> failedDownstreamBuilds = autoCloseRule.evaluate(
 				downstreamBuilds);
 
@@ -334,7 +340,7 @@ public class AutoCloseUtil {
 
 		String propertyNameTemplate =
 			"test.batch.names.auto.close[" + project.getProperty("repository") +
-				project.getProperty("repository") + "?]";
+				"?]";
 
 		String repositoryBranchAutoClosePropertyName =
 			propertyNameTemplate.replace(
@@ -375,7 +381,7 @@ public class AutoCloseUtil {
 				parameters.get("JENKINS_JOB_VARIANT");
 		}
 
-		return null;
+		return downstreamBuild.getJobName();
 	}
 
 	public static boolean isAutoCloseBranch(Project project) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -338,9 +338,10 @@ public class AutoCloseUtil {
 
 		List<AutoCloseRule> list = new ArrayList<>();
 
-		String propertyNameTemplate =
-			"test.batch.names.auto.close[" + project.getProperty("repository") +
-				"?]";
+		String propertyNameTemplate = JenkinsResultsParserUtil.combine(
+			"test.batch.names.auto.close[",
+			project.getProperty("repository"),
+			"?]");
 
 		String repositoryBranchAutoClosePropertyName =
 			propertyNameTemplate.replace(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -339,8 +339,7 @@ public class AutoCloseUtil {
 		List<AutoCloseRule> list = new ArrayList<>();
 
 		String propertyNameTemplate = JenkinsResultsParserUtil.combine(
-			"test.batch.names.auto.close[",
-			project.getProperty("repository"),
+			"test.batch.names.auto.close[", project.getProperty("repository"),
 			"?]");
 
 		String repositoryBranchAutoClosePropertyName =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -675,17 +675,17 @@ public abstract class BaseBuild implements Build {
 
 	@Override
 	public String getJobVariant() {
-		String batchName = getParameterValue("JOB_VARIANT");
+		String jobVariant = getParameterValue("JOB_VARIANT");
 
-		if ((batchName == null) || batchName.isEmpty()) {
-			batchName = getParameterValue("JENKINS_JOB_VARIANT");
+		if ((jobVariant == null) || jobVariant.isEmpty()) {
+			jobVariant = getParameterValue("JENKINS_JOB_VARIANT");
 		}
 
-		if ((batchName == null) || batchName.isEmpty()) {
-			batchName = getJobName();
+		if ((jobVariant == null) || jobVariant.isEmpty()) {
+			jobVariant = getJobName();
 		}
 
-		return batchName;
+		return jobVariant;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -681,6 +681,10 @@ public abstract class BaseBuild implements Build {
 			batchName = getParameterValue("JENKINS_JOB_VARIANT");
 		}
 
+		if ((batchName == null) || batchName.isEmpty()) {
+			batchName = getJobName();
+		}
+
 		return batchName;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchTestClassGroup.java
@@ -214,7 +214,7 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		}
 	}
 
-	protected List<File> autoBalanceTestFiles = new ArrayList();
+	protected List<File> autoBalanceTestFiles = new ArrayList<>();
 	protected final Map<Integer, AxisTestClassGroup> axisTestClassGroups =
 		new HashMap<>();
 	protected final String batchName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceFormatBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceFormatBuild.java
@@ -16,6 +16,7 @@ package com.liferay.jenkins.results.parser;
 
 import com.liferay.jenkins.results.parser.failure.message.generator.FailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.GenericFailureMessageGenerator;
+import com.liferay.jenkins.results.parser.failure.message.generator.RebaseFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.SourceFormatFailureMessageGenerator;
 
 import org.dom4j.Element;
@@ -35,6 +36,10 @@ public class SourceFormatBuild extends TopLevelBuild {
 		return new Element[] {getFailureMessageElement()};
 	}
 
+	public PullRequest getPullRequest() {
+		return _pullRequest;
+	}
+
 	protected SourceFormatBuild(String url) {
 		this(url, null);
 	}
@@ -47,15 +52,13 @@ public class SourceFormatBuild extends TopLevelBuild {
 
 	@Override
 	protected FailureMessageGenerator[] getFailureMessageGenerators() {
-		return _FAILURE_MESSAGE_GENERATORS;
-	}
-
-	private static final FailureMessageGenerator[] _FAILURE_MESSAGE_GENERATORS =
-		{
+		return new FailureMessageGenerator[] {
+			new RebaseFailureMessageGenerator(),
 			new SourceFormatFailureMessageGenerator(),
 
 			new GenericFailureMessageGenerator()
 		};
+	}
 
 	private PullRequest _pullRequest;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/BaseFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/BaseFailureMessageGenerator.java
@@ -43,13 +43,14 @@ public abstract class BaseFailureMessageGenerator
 
 		Map<String, String> pullRequestDetailsMap = null;
 
-		if (topLevelBuild instanceof SourceFormatBuild){
-			SourceFormatBuild sourceFormatBuild = (SourceFormatBuild)topLevelBuild;
+		if (topLevelBuild instanceof SourceFormatBuild) {
+			SourceFormatBuild sourceFormatBuild =
+				(SourceFormatBuild)topLevelBuild;
 
 			pullRequestDetailsMap = getDetailsMapFromPullRequest(
 				sourceFormatBuild.getPullRequest());
 		}
-		else{
+		else {
 			pullRequestDetailsMap =
 				topLevelBuild.getBaseGitRepositoryDetailsTempMap();
 		}
@@ -61,8 +62,7 @@ public abstract class BaseFailureMessageGenerator
 		sb.append("/");
 		sb.append(baseRepositoryName);
 		sb.append("/tree/");
-		sb.append(
-			pullRequestDetailsMap.get("github.sender.branch.name"));
+		sb.append(pullRequestDetailsMap.get("github.sender.branch.name"));
 
 		String url = sb.toString();
 
@@ -70,8 +70,7 @@ public abstract class BaseFailureMessageGenerator
 
 		sb.append(pullRequestDetailsMap.get("github.origin.name"));
 		sb.append("/");
-		sb.append(
-			pullRequestDetailsMap.get("github.sender.branch.name"));
+		sb.append(pullRequestDetailsMap.get("github.sender.branch.name"));
 
 		return Dom4JUtil.getNewAnchorElement(url, sb.toString());
 	}
@@ -177,8 +176,6 @@ public abstract class BaseFailureMessageGenerator
 	private String _getConsoleTextSnippet(
 		String consoleText, boolean truncateTop, int start, int end) {
 
-		System.out.println("CONSOLETEXT: " + consoleText);
-
 		if ((end - start) > 2500) {
 			if (truncateTop) {
 				start = end - 2500;
@@ -193,8 +190,6 @@ public abstract class BaseFailureMessageGenerator
 				if (newlineEnd != -1) {
 					end = newlineEnd;
 				}
-
-				System.out.println("LAST END: " + String.valueOf(end));
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RebaseFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RebaseFailureMessageGenerator.java
@@ -16,7 +16,6 @@ package com.liferay.jenkins.results.parser.failure.message.generator;
 
 import com.liferay.jenkins.results.parser.Build;
 import com.liferay.jenkins.results.parser.Dom4JUtil;
-import com.liferay.jenkins.results.parser.SourceFormatBuild;
 
 import org.dom4j.Element;
 
@@ -35,13 +34,22 @@ public class RebaseFailureMessageGenerator extends BaseFailureMessageGenerator {
 			return null;
 		}
 
-		int end = consoleText.indexOf(_TOKEN_REBASE_END);
-
-		end = consoleText.lastIndexOf("\n", end);
-
-		int start = consoleText.lastIndexOf(_TOKEN_REBASE_START, end);
+		int start = consoleText.lastIndexOf(_TOKEN_REBASE_START);
 
 		start = consoleText.lastIndexOf("\n", start);
+
+		int end = consoleText.indexOf(_TOKEN_REBASE_END, start);
+
+		if (end != -1) {
+			end = consoleText.lastIndexOf("\n", end);
+
+			if (end == -1) {
+				end = consoleText.length();
+			}
+		}
+		else {
+			end = consoleText.length();
+		}
 
 		return Dom4JUtil.getNewElement(
 			"div", null,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RebaseFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RebaseFailureMessageGenerator.java
@@ -16,6 +16,7 @@ package com.liferay.jenkins.results.parser.failure.message.generator;
 
 import com.liferay.jenkins.results.parser.Build;
 import com.liferay.jenkins.results.parser.Dom4JUtil;
+import com.liferay.jenkins.results.parser.SourceFormatBuild;
 
 import org.dom4j.Element;
 
@@ -51,7 +52,7 @@ public class RebaseFailureMessageGenerator extends BaseFailureMessageGenerator {
 				Dom4JUtil.getNewElement(
 					"strong", null,
 					getBaseBranchAnchorElement(build.getTopLevelBuild())),
-				getConsoleTextSnippetElement(consoleText, true, start, end)));
+				getConsoleTextSnippetElement(consoleText, false, start, end)));
 	}
 
 	private static final String _TOKEN_REBASE_END = "git rebase --abort";


### PR DESCRIPTION
Should offer a few fixes and improvements to allow for non-downstream builds to work in AutoClose rules, fix to propertyNameTemplate, unified variable names and simplified methods to increase reuse; changes the way that a RebaseFailureMessage is generated.

There is currently no unit test for the RebaseFailureMessageGenerator, and as such there was nothing to regenerate.