### PR TITLE
LRQA-40772 Rename some references to be more consistent

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
@@ -115,10 +115,10 @@ public class JobFactory {
 						moduleDir, "\\.lfrbuild-portal");
 
 				if (lfrBuildPortalFiles.isEmpty()) {
-					File gitRepoFile = new File(moduleDir, ".gitrepo");
+					File gitrepoFile = new File(moduleDir, ".gitrepo");
 
 					Properties properties =
-						JenkinsResultsParserUtil.getProperties(gitRepoFile);
+						JenkinsResultsParserUtil.getProperties(gitrepoFile);
 
 					String subrepositoryRemote = properties.getProperty(
 						"remote");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
@@ -48,7 +48,7 @@ public class MergeCentralSubrepositoryUtil {
 			return;
 		}
 
-		List<String> failedGitRepos = new ArrayList<>();
+		List<String> failedGitrepoPaths = new ArrayList<>();
 
 		List<File> gitrepoFiles = JenkinsResultsParserUtil.findFiles(
 			modulesDir, ".gitrepo");
@@ -107,7 +107,7 @@ public class MergeCentralSubrepositoryUtil {
 					mergeBranchName);
 			}
 			catch (Exception e) {
-				failedGitRepos.add(gitrepoFile.getParent());
+				failedGitrepoPaths.add(gitrepoFile.getParent());
 
 				e.printStackTrace();
 
@@ -115,10 +115,10 @@ public class MergeCentralSubrepositoryUtil {
 			}
 		}
 
-		if (!failedGitRepos.isEmpty()) {
+		if (!failedGitrepoPaths.isEmpty()) {
 			String message = JenkinsResultsParserUtil.combine(
 				"Unable to create a pull to merge these subrepositories:\n",
-				StringUtils.join(failedGitRepos, "\n"));
+				StringUtils.join(failedGitrepoPaths, "\n"));
 
 			Properties buildProperties =
 				JenkinsResultsParserUtil.getBuildProperties();


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40772

This was made in response to BChan's [comment](https://github.com/brianchandotcom/liferay-portal/pull/58419#issuecomment-388998486):

> @michaelhashimoto
> 
>  do we ever call it just "String gitrepo?" Or do we call it gitrepoName or anything like that? Whatever we have done in the past, please keep it consistent with a follow up pull. Thx.
> 
> We also have a lot of "gitRepo" vs. "gitrepo"
> 
> Please clean that up. Thx.
