### PR TITLE
LRQA-41001 Include service builder and allow specifying required junit tests that will always run in ci:test:relevant

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
@@ -620,10 +620,10 @@ public class JUnitBatchTestClassGroup extends BatchTestClassGroup {
 
 		if ((testBatchClassNamesIncludesRequiredPropertyValue != null) &&
 			!testBatchClassNamesIncludesRequiredPropertyValue.isEmpty()) {
-			testClassNamesIncludesRelativeGlobs.addAll(
-				Arrays.asList(
-					testBatchClassNamesIncludesRequiredPropertyValue.split(
-						",")));
+
+			Collections.addAll(
+				testClassNamesIncludesRelativeGlobs,
+				testBatchClassNamesIncludesRequiredPropertyValue.split(","));
 		}
 
 		testClassNamesIncludesPathMatchers.addAll(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
@@ -615,6 +615,17 @@ public class JUnitBatchTestClassGroup extends BatchTestClassGroup {
 					testClassNamesIncludesRelativeGlobs);
 		}
 
+		String testBatchClassNamesIncludesRequiredPropertyValue =
+			getFirstPropertyValue("test.batch.class.names.includes.required");
+
+		if ((testBatchClassNamesIncludesRequiredPropertyValue != null) &&
+			!testBatchClassNamesIncludesRequiredPropertyValue.isEmpty()) {
+			testClassNamesIncludesRelativeGlobs.addAll(
+				Arrays.asList(
+					testBatchClassNamesIncludesRequiredPropertyValue.split(
+						",")));
+		}
+
 		testClassNamesIncludesPathMatchers.addAll(
 			_getTestClassNamesPathMatchers(
 				testClassNamesIncludesRelativeGlobs));

--- a/test.properties
+++ b/test.properties
@@ -1100,6 +1100,10 @@
     test.batch.class.names.includes[tck-jdk8]=**/com/sun/ts/tests/**/*.war,deploy/target/deploy-files/tck-V2*.war
     test.batch.class.names.includes[unit-jdk8]=**/test/unit/**/*Test.java
 
+    test.batch.class.names.includes.required[modules-integration-*-jdk8]=\
+        **/src/testIntegration/**/DeclarativeServiceDependencyManagerTest.java,\
+        **/src/testIntegration/**/SpringExtenderDependencyManagerTest.java
+
     test.batch.code.coverage=false
 
     test.batch.dist.app.servers=\

--- a/test.properties
+++ b/test.properties
@@ -1407,6 +1407,7 @@
         modules-unit-jdk8,\
         portal-frontend-js-jdk8,\
         semantic-versioning-jdk8,\
+        service-builder-jdk8,\
         unit-jdk8
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=false


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-41001

I tested these changes with a jenkins-results-parser.jar made from these changes in a pull to myself here:
https://github.com/yichenroy/liferay-portal/pull/58
same failure as an upstream build that hasn't finished running
https://test-1-1.liferay.com//userContent/jobs/test-portal-acceptance-upstream%28master%29/builds/3909/jenkins-report.html