### PR TITLE
LRQA-41001 Avoid Arrays.asList because Collections.addAll is trying to add more entries

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
@@ -606,7 +606,10 @@ public class JUnitBatchTestClassGroup extends BatchTestClassGroup {
 			return;
 		}
 
-		List<String> testClassNamesIncludesRelativeGlobs = Arrays.asList(
+		List<String> testClassNamesIncludesRelativeGlobs = new ArrayList<>();
+
+		Collections.addAll(
+			testClassNamesIncludesRelativeGlobs,
 			testClassNamesIncludesPropertyValue.split(","));
 
 		if (testRelevantChanges) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-41001

@yichenroy @kenjiheigel