### PR TITLE
LRQA-41190 Add class for PortalReleaseJob to handle test class groups

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
@@ -14,7 +14,12 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.Collections;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Michael Hashimoto
@@ -33,6 +38,24 @@ public abstract class BaseJob implements Job {
 
 	protected BaseJob(String jobName) {
 		this.jobName = jobName;
+	}
+
+	protected Set<String> getSetFromString(String string) {
+		if (string == null) {
+			return Collections.emptySet();
+		}
+
+		Set<String> set = new TreeSet<>();
+
+		for (String item : StringUtils.split(string, ",")) {
+			if (item.startsWith("#")) {
+				continue;
+			}
+
+			set.add(item.trim());
+		}
+
+		return set;
 	}
 
 	protected String jobName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -731,6 +731,17 @@ public class JenkinsResultsParserUtil {
 		return Float.parseFloat(matcher.group(1));
 	}
 
+	public static GitWorkingDirectory getJenkinsGitWorkingDirectory()
+		throws IOException {
+
+		Properties buildProperties = getBuildProperties();
+
+		String workingDirectoryPath = buildProperties.getProperty(
+			"base.repository.dir") + "/liferay-jenkins-ee";
+
+		return new GitWorkingDirectory("master", workingDirectoryPath);
+	}
+
 	public static List<JenkinsMaster> getJenkinsMasters(
 		Properties buildProperties, String prefix) {
 
@@ -918,6 +929,24 @@ public class JenkinsResultsParserUtil {
 		catch (IOException ioe) {
 			throw new RuntimeException("Unable to get relative path", ioe);
 		}
+	}
+
+	public static PortalGitWorkingDirectory getPortalGitWorkingDirectory(
+			String portalBranchName)
+		throws IOException {
+
+		Properties buildProperties = getBuildProperties();
+
+		String workingDirectoryPath = buildProperties.getProperty(
+			"base.repository.dir") + "/liferay-portal";
+
+		if (!portalBranchName.equals("master")) {
+			workingDirectoryPath = combine(
+				workingDirectoryPath, "-", portalBranchName);
+		}
+
+		return new PortalGitWorkingDirectory(
+			portalBranchName, workingDirectoryPath);
 	}
 
 	public static Properties getProperties(File... propertiesFiles) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
@@ -28,10 +28,16 @@ import java.util.Properties;
 public class JobFactory {
 
 	public static Job newJob(String jobName) {
-		return newJob(jobName, "default");
+		return newJob(jobName, null, null);
 	}
 
 	public static Job newJob(String jobName, String testSuiteName) {
+		return newJob(jobName, testSuiteName, null);
+	}
+
+	public static Job newJob(
+		String jobName, String testSuiteName, String portalBranchName) {
+
 		Job job = _jobs.get(jobName);
 
 		if (job != null) {
@@ -82,6 +88,12 @@ public class JobFactory {
 
 		if (jobName.contains("test-portal-acceptance-upstream(")) {
 			_jobs.put(jobName, new PortalAcceptanceUpstreamJob(jobName));
+
+			return _jobs.get(jobName);
+		}
+
+		if (jobName.equals("test-portal-release")) {
+			_jobs.put(jobName, new PortalReleaseJob(jobName, portalBranchName));
 
 			return _jobs.get(jobName);
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptancePullRequestJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptancePullRequestJob.java
@@ -23,7 +23,7 @@ import java.util.TreeSet;
  * @author Michael Hashimoto
  */
 public class PortalAcceptancePullRequestJob
-	extends PortalRepositoryJob implements PortalTestClassJob, TestSuiteJob {
+	extends PortalRepositoryJob implements TestSuiteJob {
 
 	public PortalAcceptancePullRequestJob(String url) {
 		this(url, "default");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptanceUpstreamJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptanceUpstreamJob.java
@@ -17,8 +17,7 @@ package com.liferay.jenkins.results.parser;
 /**
  * @author Michael Hashimoto
  */
-public class PortalAcceptanceUpstreamJob
-	extends PortalRepositoryJob implements PortalTestClassJob {
+public class PortalAcceptanceUpstreamJob extends PortalRepositoryJob {
 
 	public PortalAcceptanceUpstreamJob(String jobName) {
 		super(jobName);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class PortalReleaseJob
+	extends BaseJob implements PortalTestClassJob, SmokeDependentJob {
+
+	public PortalReleaseJob(String jobName, String portalBranchName) {
+		super(jobName);
+
+		_portalBranchName = portalBranchName;
+
+		try {
+			_jenkinsGitWorkingDirectory =
+				JenkinsResultsParserUtil.getJenkinsGitWorkingDirectory();
+
+			_portalGitWorkingDirectory =
+				JenkinsResultsParserUtil.getPortalGitWorkingDirectory(
+					portalBranchName);
+		}
+		catch (IOException ioe) {
+			throw new RuntimeException(
+				"Could not create a git working directory", ioe);
+		}
+
+		jobProperties = JenkinsResultsParserUtil.getProperties(
+			new File(
+				_jenkinsGitWorkingDirectory.getWorkingDirectory(),
+				"commands/dependencies/test-portal-release.properties"));
+
+		jobProperties.putAll(
+			JenkinsResultsParserUtil.getProperties(
+				new File(
+					_portalGitWorkingDirectory.getWorkingDirectory(),
+					"test.properties")));
+	}
+
+	@Override
+	public Set<String> getBatchNames() {
+		String testBatchNames = JenkinsResultsParserUtil.getProperty(
+			jobProperties, "test.batch.names[" + _portalBranchName + "]");
+
+		return getSetFromString(testBatchNames);
+	}
+
+	@Override
+	public Set<String> getDistTypes() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public PortalGitWorkingDirectory getPortalGitWorkingDirectory() {
+		return _portalGitWorkingDirectory;
+	}
+
+	@Override
+	public Set<String> getSmokeBatchNames() {
+		String testBatchNames = JenkinsResultsParserUtil.getProperty(
+			jobProperties, "test.batch.names.smoke[" + _portalBranchName + "]");
+
+		return getSetFromString(testBatchNames);
+	}
+
+	private final GitWorkingDirectory _jenkinsGitWorkingDirectory;
+	private final String _portalBranchName;
+	private final PortalGitWorkingDirectory _portalGitWorkingDirectory;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalRepositoryJob.java
@@ -17,12 +17,8 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 import java.io.IOException;
 
-import java.util.Collections;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeSet;
-
-import org.apache.commons.lang.StringUtils;
 
 /**
  * @author Michael Hashimoto
@@ -106,24 +102,6 @@ public abstract class PortalRepositoryJob extends RepositoryJob {
 
 		jobProperties = JenkinsResultsParserUtil.getProperties(
 			new File(repositoryDir, "test.properties"));
-	}
-
-	protected Set<String> getSetFromString(String string) {
-		if (string == null) {
-			return Collections.emptySet();
-		}
-
-		Set<String> set = new TreeSet<>();
-
-		for (String item : StringUtils.split(string, ",")) {
-			if (item.startsWith("#")) {
-				continue;
-			}
-
-			set.add(item.trim());
-		}
-
-		return set;
 	}
 
 	private void _findRepositoryDir() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SmokeDependentJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SmokeDependentJob.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Set;
+
+/**
+ * @author Michael Hashimoto
+ */
+public interface SmokeDependentJob {
+
+	public Set<String> getSmokeBatchNames();
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-41190

@pyoo47 - One thing that might be weird about this is that I chose not to make a "GitWorkingDirectoryFactory" because we are using the constructor directly within "liferay-jenkins-ee".
https://github.com/liferay/liferay-jenkins-ee/blob/aed5ac9/commands/build-common.xml#L7901

If you think we can make both public constructors and a factory, then I can change this.  But let me know what you think.

Thanks!