### PR TITLE
LRQA-42800 Remove stacktrace printout for failing to find an MD5 file

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -336,8 +336,6 @@ public class MirrorsGetTask extends Task {
 		catch (Exception e) {
 			if (_verbose) {
 				System.out.println("Unable to access MD5 file");
-
-				e.printStackTrace();
 			}
 
 			return true;


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42800

@pyoo47 - We've ran into so many issues where people will send use this stacktrace as the reason for a test failing.  So I'd prefer that we just avoid it altogether.  However, I think all the other "verbose" information is pretty useful.

See this example ticket:
https://issues.liferay.com/browse/LRQA-42758