### PR TITLE
LRQA-42701 Use base excludes property in modules unit excludes property (Resend)

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1037,7 +1037,10 @@
     test.batch.axis.max.size[tck-jdk8]=50
     test.batch.axis.max.size[unit-jdk8]=5000
 
-    test.batch.class.names.excludes[modules-unit-jdk8]=**/project-templates/**/src/test/**/*Test.java
+    test.batch.class.names.excludes[modules-unit-jdk8]=\
+        ${test.class.names.excludes},\
+        **/project-templates/**/src/test/**/*Test.java
+
     test.batch.class.names.excludes[tck-jdk8]=**/com/sun/ts/tests/**/PortletSessionSecondapp/*.war
 
     test.batch.class.names.includes[integration-*-jdk8]=**/test/integration/**/*Test.java


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42701
Backports:
https://github.com/pyoo47/liferay-portal-ee/pull/393 (7.0.x)
https://github.com/pyoo47/liferay-portal-ee/pull/392 (7.1.x)