### PR TITLE
LRQA-44852 Allow curly brace expansion in glob properties

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -861,7 +861,7 @@ public class JenkinsResultsParserUtil {
 
 		final List<PathMatcher> pathMatchers = toPathMatchers(
 			rootDir.getAbsolutePath() + File.separator,
-			resourceIncludesRelativeGlobs);
+			toGlobPatternArray(resourceIncludesRelativeGlobs));
 
 		final List<URL> includedResourceURLs = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1735,6 +1735,35 @@ public class JenkinsResultsParserUtil {
 		return durationString;
 	}
 
+	public static String[] toGlobPatternArray(String... globPatterns) {
+		List<String> globPatternList = new ArrayList<>();
+
+		for (int i = 0; i < globPatterns.length; i++) {
+			String globPattern = globPatterns[i];
+
+			if (globPattern.contains("{") && !globPattern.contains("}")) {
+				StringBuilder sb = new StringBuilder();
+
+				while (globPatterns[i].contains("{") ||
+					   !globPatterns[i].contains("}")) {
+
+					sb.append(globPatterns[i]);
+					sb.append(",");
+
+					i++;
+				}
+
+				sb.append(globPatterns[i]);
+
+				globPattern = sb.toString();
+			}
+
+			globPatternList.add(globPattern);
+		}
+
+		return globPatternList.toArray(new String[globPatternList.size()]);
+	}
+
 	public static JSONArray toJSONArray(String url) throws IOException {
 		return toJSONArray(
 			url, true, _MAX_RETRIES_DEFAULT, null, _RETRY_PERIOD_DEFAULT,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -240,7 +240,8 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 
 		return JenkinsResultsParserUtil.toPathMatchers(
 			workingDirectory.getAbsolutePath() + File.separator,
-			relativeGlobs.split(","));
+			JenkinsResultsParserUtil.toGlobPatternArray(
+				relativeGlobs.split(",")));
 	}
 
 	protected void setAxisTestClassGroups() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
@@ -673,7 +673,8 @@ public class JUnitBatchTestClassGroup extends BatchTestClassGroup {
 
 		Collections.addAll(
 			testClassNamesIncludesRelativeGlobs,
-			testClassNamesIncludesPropertyValue.split(","));
+			JenkinsResultsParserUtil.toGlobPatternArray(
+				testClassNamesIncludesPropertyValue.split(",")));
 
 		if (testReleaseBundle) {
 			testClassNamesIncludesRelativeGlobs =
@@ -694,7 +695,9 @@ public class JUnitBatchTestClassGroup extends BatchTestClassGroup {
 
 			Collections.addAll(
 				testClassNamesIncludesRelativeGlobs,
-				testBatchClassNamesIncludesRequiredPropertyValue.split(","));
+				JenkinsResultsParserUtil.toGlobPatternArray(
+					testBatchClassNamesIncludesRequiredPropertyValue.split(
+						",")));
 		}
 
 		File workingDirectory = portalGitWorkingDirectory.getWorkingDirectory();


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-44852

Tested here: (using jar created from these changes, and using curly brace expansion to exclude adaptive-media module)
https://github.com/yichenroy/liferay-portal/pull/109