### PR TITLE
LRCI-261 Catch null JSON objects when getting test results for build object model

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -396,6 +396,13 @@ public class AxisBuild extends BaseBuild {
 
 		JSONObject testReportJSONObject = getTestReportJSONObject();
 
+		if (testReportJSONObject == null) {
+			System.out.println(
+				"Unable to get test results for: " + getBuildURL());
+
+			return Collections.emptyList();
+		}
+
 		return getTestResults(
 			this, testReportJSONObject.getJSONArray("suites"), testStatus);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-261