### PR TITLE
LRQA-50293 Do not include redundant test report from node_modules (master)

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6512,6 +6512,7 @@ go</echo>
 					erroronmissingdir="false"
 				>
 					<include name="**/TEST-*.xml" />
+					<exclude name="**/node_modules/**/TEST-*.xml" />
 				</fileset>
 				<fileset
 					dir="portal-impl/test-results"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Permissions.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Permissions.macro
@@ -514,6 +514,8 @@ definition {
 			panel = "Site Administration",
 			portlet = "Memberships");
 
+		Pause(locator1 = "5000");
+
 		Site.assignSiteRoleCP(
 			resourceName = "${userFirstName} ${userLastName}",
 			roleTitle = "${roleTitle}");


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-50293

Related:
https://github.com/pyoo47/liferay-portal-ee/pull/570 (7.2.x)
https://github.com/pyoo47/liferay-portal-ee/pull/571 (7.1.x)
https://github.com/pyoo47/liferay-portal-ee/pull/572 (7.0.x)