### PR TITLE
LRCI-180 Use ant task for portal-license-jdk8 batch (requires backports)

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -4718,11 +4718,9 @@ ${output.content}</echo>
 		<run-batch-test>
 			<test-action>
 				<sequential>
-					<execute dir="${release.tool.dir}">
-						<![CDATA[
-							ant dist
-						]]>
-					</execute>
+					<ant dir="${release.tool.dir}" inheritAll="false" target="dist" useNativeBasedir="true">
+						<property name="project.release.dir.native" value="${release.tool.dir}" />
+					</ant>
 				</sequential>
 			</test-action>
 		</run-batch-test>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-180

This will need to be backported to 7.2.x, 7.1.x, 7.0.x

Tested here:
https://test-5-2.liferay.com/userContent/jobs/test-portal-acceptance-pullrequest(master)/builds/273/jenkins-report.html