### PR TITLE
LRCI-266 Add a method to determine if a build has generic CI failure (resend)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -480,8 +480,8 @@ public class AxisBuild extends BaseBuild {
 	protected static final Pattern buildURLPattern = Pattern.compile(
 		JenkinsResultsParserUtil.combine(
 			"\\w+://(?<master>[^/]+)/+job/+(?<jobName>[^/]+)/",
-			"(?<axisVariable>AXIS_VARIABLE=[^,]+,[^/]+)/",
-			"(?<buildNumber>\\d+)/?"));
+			"(?<buildNumber>\\d+)/",
+			"(?<axisVariable>AXIS_VARIABLE=[^,]+,[^/]+)/?"));
 	protected static final String defaultLogBaseURL =
 		"https://testray.liferay.com/reports/production/logs";
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1235,6 +1235,22 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
+	public boolean hasGenericCIFailure() {
+		for (FailureMessageGenerator failureMessageGenerator :
+				getFailureMessageGenerators()) {
+
+			Element failureMessage = failureMessageGenerator.getMessageElement(
+				this);
+
+			if (failureMessage != null) {
+				return failureMessageGenerator.isGenericCIFailure();
+			}
+		}
+
+		return false;
+	}
+
+	@Override
 	public int hashCode() {
 		String key = getBuildURL();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -162,6 +162,8 @@ public interface Build {
 
 	public boolean hasBuildURL(String buildURL);
 
+	public boolean hasGenericCIFailure();
+
 	public boolean hasModifiedDownstreamBuilds();
 
 	public boolean isBuildModified();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/BaseFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/BaseFailureMessageGenerator.java
@@ -43,6 +43,11 @@ public abstract class BaseFailureMessageGenerator
 		return null;
 	}
 
+	@Override
+	public boolean isGenericCIFailure() {
+		return false;
+	}
+
 	protected Element getBaseBranchAnchorElement(TopLevelBuild topLevelBuild) {
 		StringBuilder sb = new StringBuilder();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/CIFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/CIFailureMessageGenerator.java
@@ -37,6 +37,11 @@ public class CIFailureMessageGenerator extends BaseFailureMessageGenerator {
 		return Dom4JUtil.toCodeSnippetElement(snippet);
 	}
 
+	@Override
+	public boolean isGenericCIFailure() {
+		return true;
+	}
+
 	private static final String _TOKEN_CI_ERROR = "A CI failure has occurred.";
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/FailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/FailureMessageGenerator.java
@@ -27,4 +27,6 @@ public interface FailureMessageGenerator {
 
 	public Element getMessageElement(String consoleText);
 
+	public boolean isGenericCIFailure();
+
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/GenericFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/GenericFailureMessageGenerator.java
@@ -45,6 +45,11 @@ public class GenericFailureMessageGenerator
 		return getConsoleTextSnippetElementByEnd(consoleText, true, -1);
 	}
 
+	@Override
+	public boolean isGenericCIFailure() {
+		return true;
+	}
+
 	protected String getBuildFailedSnippet(String consoleText) {
 		int end = consoleText.indexOf("BUILD FAILED");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-266

Resend of:
https://github.com/pyoo47/liferay-portal/pull/1087

Reference:
axis build: 
https://test-1-3.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/330384/AXIS_VARIABLE=0,label_exp=!master/

archived axis Build:
https://github.com/liferay/liferay-jenkins-results-parser-samples-ee/tree/master/1/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_passed/test-1-1/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE%3D0%2Clabel_exp%3D!master/79045