### PR TITLE
LRCI-528 Update portal build scripts to use binaries-cache-2020 (master)

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -59,7 +59,7 @@
 ##
 
     build.binaries.cache.dir=../${build.binaries.cache.repository.name}
-    build.binaries.cache.repository.name=liferay-binaries-cache-2017
+    build.binaries.cache.repository.name=liferay-binaries-cache-2020
     build.binaries.cache.url=https://github.com/liferay/${build.binaries.cache.repository.name}.git
     build.binaries.gradle.file=gradle-4.10.2.LIFERAY-PATCHED-3-bin.zip
     build.binaries.gradle.url=https://github.com/liferay/${build.binaries.cache.repository.name}/raw/master/${build.binaries.gradle.file}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-528

Will need to backport to ee-6.1.x, ee-6.1.30, ee-6.2.x, ee-6.2.10, 7.0.x, 7.1.x, and 7.2.x

Tested here:
master: https://github.com/yichenroy/liferay-portal/pull/161
7.0.x: https://github.com/yichenroy/liferay-portal-ee/pull/77
7.1.x: https://github.com/yichenroy/liferay-portal-ee/pull/78
7.2.x: https://github.com/yichenroy/liferay-portal-ee/pull/79
ee-6.1.x: https://github.com/yichenroy/liferay-portal-ee/pull/81
ee-6.2.x: https://github.com/yichenroy/liferay-portal-ee/pull/80