### PR TITLE
LRCI-699 Unzip *.profile-dxp.properties files from source zip in sem ver, use correct build.profile when deploying osgi apps

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -4740,13 +4740,16 @@ log.sanitizer.enabled=false</echo>
 
 						<antcall inheritAll="false" target="install-portal-snapshots" />
 
-						<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf</echo>
+						<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf
+tar -zxvf liferay-portal-source.tar.gz --wildcards '*.profile-dxp.properties'</echo>
 
 						<execute>
 							<![CDATA[
 								mkdir -p modules/core/portal-bootstrap
 
 								tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --to-stdout --verbose > modules/core/portal-bootstrap/system.packages.extra.mf
+
+								tar -zxvf liferay-portal-source.tar.gz --wildcards '*.profile-dxp.properties'
 							]]>
 						</execute>
 					</then>
@@ -5430,12 +5433,15 @@ ${output.content}</echo>
 
 			<test-set-up>
 				<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --verbose
-tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/lib/biz.aQute.bnd.annotation.jar --gzip --verbose</echo>
+tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/lib/biz.aQute.bnd.annotation.jar --gzip --verbose
+tar -zxvf liferay-portal-source.tar.gz --wildcards '*.profile-dxp.properties'
+</echo>
 
 				<execute>
 					<![CDATA[
 						tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --verbose
 						tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/lib/biz.aQute.bnd.annotation.jar --gzip --verbose
+						tar -zxvf liferay-portal-source.tar.gz --wildcards '*.profile-dxp.properties'
 					]]>
 				</execute>
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -5435,7 +5435,7 @@ ${output.content}</echo>
 				<echo>tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/build/system.packages.extra.mf --gzip --verbose
 tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/lib/biz.aQute.bnd.annotation.jar --gzip --verbose
 tar -zxvf liferay-portal-source.tar.gz --wildcards '*.profile-dxp.properties'
-</echo>
+				</echo>
 
 				<execute>
 					<![CDATA[

--- a/build-test.xml
+++ b/build-test.xml
@@ -5923,7 +5923,6 @@ go</echo>
 
 										<gradle-execute dir="@{app.dir}" task="deploy">
 											<arg value="clean" />
-											<arg value="-Dbuild.profile=portal" />
 										</gradle-execute>
 
 										<for param="module.dir.path">

--- a/build-test.xml
+++ b/build-test.xml
@@ -5841,7 +5841,6 @@ go</echo>
 								>
 									<include name="apps/${osgi.app.name}" />
 									<include name="dxp/apps/${osgi.app.name}" />
-									<include name="private/apps/${osgi.app.name}" />
 								</dirset>
 							</path>
 							<sequential>

--- a/build-test.xml
+++ b/build-test.xml
@@ -5921,8 +5921,15 @@ go</echo>
 											</sequential>
 										</for>
 
+										<local name="deploy.build.profile" />
+
+										<condition else="portal" property="deploy.build.profile" value="${build.profile}">
+											<equals arg1="${build.profile}" arg2="dxp" />
+										</condition>
+
 										<gradle-execute dir="@{app.dir}" task="deploy">
 											<arg value="clean" />
+											<arg value="-Dbuild.profile=${deploy.build.profile}" />
 										</gradle-execute>
 
 										<for param="module.dir.path">

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/contributor/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/contributor/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-699

Backports are needed for 7.2.x, 7.1.x, and 7.0.x for the LRCI-699 commits, 
@petershin, I am not sure if this commit needs to be backported as well: https://github.com/pyoo47/liferay-portal/pull/1138/commits/da1e3a2bc6d44fda65dd4e31573df30addf462d6   

Tested here:
https://github.com/yichenroy/liferay-portal/pull/194#issuecomment-545698607

Sem ver failure on the test run is real, see comment:
https://github.com/yichenroy/liferay-portal/pull/192#issuecomment-545685507

cc @xbrianlee