### PR TITLE
LRCI-1100 Include build profile if specified when starting portal testsuite upstream jobs

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerBuildRunner.java
@@ -138,6 +138,8 @@ public class PortalTestSuiteUpstreamControllerBuildRunner
 			sb.append("/buildWithParameters?");
 			sb.append("token=");
 			sb.append(jenkinsAuthenticationToken);
+			sb.append("&CI_TEST_SUITE=");
+			sb.append(testSuiteName);
 			sb.append("&JENKINS_GITHUB_BRANCH_NAME=");
 			sb.append(buildData.getJenkinsGitHubBranchName());
 			sb.append("&JENKINS_GITHUB_BRANCH_USERNAME=");
@@ -146,8 +148,14 @@ public class PortalTestSuiteUpstreamControllerBuildRunner
 			sb.append(buildData.getPortalBranchSHA());
 			sb.append("&PORTAL_GITHUB_URL=");
 			sb.append(buildData.getPortalGitHubURL());
-			sb.append("&CI_TEST_SUITE=");
-			sb.append(testSuiteName);
+
+			String testPortalBuildProfile = getTestPortalBuildProfile(
+				testSuiteName);
+
+			if (testPortalBuildProfile != null) {
+				sb.append("&TEST_PORTAL_BUILD_PROFILE=");
+				sb.append(testPortalBuildProfile);
+			}
 
 			String testrayProjectName = _getTestrayProjectName(testSuiteName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerBuildRunner.java
@@ -75,6 +75,31 @@ public class PortalTestSuiteUpstreamControllerBuildRunner
 			buildData.getPortalUpstreamBranchName(), ")");
 	}
 
+	protected String getTestPortalBuildProfile(String testSuite) {
+		try {
+			Properties buildProperties =
+				JenkinsResultsParserUtil.getBuildProperties();
+
+			S buildData = getBuildData();
+
+			String buildProfile = buildProperties.getProperty(
+				JenkinsResultsParserUtil.combine(
+					"portal.testsuite.upstream.test.portal.build.profile[",
+					buildData.getPortalUpstreamBranchName(), "][", testSuite,
+					"]"));
+
+			if (buildProfile == null) {
+				buildProfile = buildProperties.getProperty(
+					"portal.testsuite.upstream.test.portal.build.profile");
+			}
+
+			return buildProfile;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
 	@Override
 	protected void initWorkspace() {
 		setWorkspace(WorkspaceFactory.newSimpleWorkspace());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerSingleSuiteBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerSingleSuiteBuildRunner.java
@@ -110,7 +110,11 @@ public class PortalTestSuiteUpstreamControllerSingleSuiteBuildRunner
 		S buildData = getBuildData();
 
 		sb.append("&CI_TEST_SUITE=");
-		sb.append(buildData.getTestSuiteName());
+
+		String testSuiteName = buildData.getTestSuiteName();
+
+		sb.append(testSuiteName);
+
 		sb.append("&CONTROLLER_BUILD_URL=");
 		sb.append(buildData.getBuildURL());
 		sb.append("&JENKINS_GITHUB_BRANCH_NAME=");
@@ -129,6 +133,14 @@ public class PortalTestSuiteUpstreamControllerSingleSuiteBuildRunner
 
 		sb.append("&PORTAL_GITHUB_URL=");
 		sb.append(buildData.getPortalGitHubURL());
+
+		String testPortalBuildProfile = getTestPortalBuildProfile(
+			testSuiteName);
+
+		if (testPortalBuildProfile != null) {
+			sb.append("&TEST_PORTAL_BUILD_PROFILE=");
+			sb.append(testPortalBuildProfile);
+		}
 
 		String testrayProjectName = buildData.getTestrayProjectName();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1100

Tested here:
https://test-1-0.liferay.com/job/test-portal-testsuite-upstream-controller(7.1.x)/2094/
-> https://test-1-7.liferay.com/job/test-portal-testsuite-upstream(7.1.x)/30/

https://test-1-0.liferay.com/job/test-portal-testsuite-upstream-controller(master)/6332/
 -> https://test-1-11.liferay.com/job/test-portal-testsuite-upstream(master)/177/

Tested with these properties that will be sent with the new jar:
https://github.com/yichenroy/liferay-jenkins-ee/commit/0b7f44f26356175cf24e3e264f8ff57f5c2c876a