### PR TITLE
LRCI-1136 Add allowed sender names property to ci.properties

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -1,3 +1,6 @@
+allowed.sender.names[brianchandotcom]=\
+    liferay-continuous-integration
+
 ci.test.available.suites=\
     acceptance,\
     acceptance-upstream,\

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/Depot.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/Depot.testcase
@@ -197,6 +197,8 @@ definition {
 	@description = "This ensures that a depot with multiple files can be deleted."
 	@priority = "4"
 	test DeleteDepotWithMultipleFiles {
+		property portal.acceptance = "quarantine";
+
 		JSONDepot.addDepot(
 			depotDescription = "This is the description of a depot",
 			depotName = "Test Depot Name");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotApplication.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotApplication.testcase
@@ -266,6 +266,8 @@ definition {
 	@description = "This ensures that a depot web content persists in WCD as previously and it's not appeared in the item selector on a connected site when WC application is disabled."
 	@priority = "5"
 	test ViewDisabledAssetViaWCD {
+		property portal.acceptance = "quarantine";
+
 		JSONGroup.addGroup(groupName = "Test Site Name");
 
 		JSONLayout.addPublicLayout(

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotContentSets.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotContentSets.testcase
@@ -181,6 +181,8 @@ definition {
 	@description = "This ensures that content sets from a site can select the basic web content stored in a depot."
 	@priority = "5"
 	test CreateSetOnSiteUsingDepotWC {
+		property portal.acceptance = "quarantine";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Content",
 			groupName = "Test Depot Name",
@@ -405,6 +407,8 @@ definition {
 	@description = "This ensures that the image is displayed by AP through Content Sets in a depot."
 	@priority = "5"
 	test DisplayImageInAP {
+		property portal.acceptance = "quarantine";
+
 		DepotNavigator.openDepotAdmin();
 
 		DepotNavigator.gotoDepot(
@@ -902,6 +906,8 @@ definition {
 	@description = "This ensures that multiple web content can be selected through Content Sets in a depot."
 	@priority = "5"
 	test SelectMultipleWebContentManually {
+		property portal.acceptance = "quarantine";
+
 		for (var i : list "1,2,3") {
 			JSONWebcontent.addWebContent(
 				content = "WC WebContent Content",

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentIntegration.testcase
@@ -88,6 +88,8 @@ definition {
 	@description = "This ensures that a depot image can be used through page creation on a connected site."
 	@priority = "5"
 	test AddImageViaContentPage {
+		property portal.acceptance = "quarantine";
+
 		DepotNavigator.openDepotAdmin();
 
 		DepotNavigator.gotoDepot(

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotIntegration.testcase
@@ -165,6 +165,8 @@ definition {
 	@description = "This ensures that a depot web content can be searched on a connected site when searching is reenabled."
 	@priority = "5"
 	test ReenableSearchability {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addWidgetToPublicLayout(
 			groupName = "Site Name",
 			layoutName = "Page Name",
@@ -640,6 +642,8 @@ definition {
 	@description = "This ensures that a connected site can access the depot document."
 	@priority = "5"
 	test ViewDocumentFromAnotherSite {
+		property portal.acceptance = "quarantine";
+
 		JSONDepot.addDepot(
 			depotDescription = "This is the description of a depot",
 			depotName = "Test Depot Name");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotPermission.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotPermission.testcase
@@ -533,6 +533,11 @@ definition {
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "VIEW_SITE_ADMINISTRATION",
+			resourceName = "com.liferay.depot.model.DepotEntry",
+			roleTitle = "Depot Regrole Name");
+
+		Permissions.definePermissionViaJSONAPI(
+			resourceAction = "VIEW_SITE_ADMINISTRATION",
 			resourceName = "com.liferay.portal.kernel.model.Group",
 			roleTitle = "Depot Regrole Name");
 

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRecycleBin.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRecycleBin.testcase
@@ -30,6 +30,7 @@ definition {
 	@priority = "5"
 	test CheckExpiredEntries {
 		property custom.properties = "trash.entry.check.interval=1${line.separator}trash.entries.max.age=1";
+		property portal.acceptance = "quarantine";
 
 		JSONDocument.addFile(
 			dmDocumentDescription = "DM Document Description",
@@ -122,6 +123,8 @@ definition {
 	@description = "This ensures that the web content can be deleted after the recycle bin is disabled."
 	@priority = "5"
 	test DeleteWCAfterDisabling {
+		property portal.acceptance = "quarantine";
+
 		DepotNavigator.openDepotAdmin();
 
 		DepotNavigator.gotoDepot(

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRecycleBin.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotRecycleBin.testcase
@@ -131,6 +131,8 @@ definition {
 			depotName = "Test Depot Name",
 			portlet = "Web Content");
 
+		ProductMenuHelper.openProductMenu();
+
 		AssertVisible(
 			key_category = "Recycle Bin",
 			locator1 = "ProductMenu#CATEGORY_COLLAPSED");

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotSettings.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotSettings.testcase
@@ -56,6 +56,8 @@ definition {
 	@description = "This ensures that a user can set the depot site connection via settings."
 	@priority = "4"
 	test SearchForDocument {
+		property portal.acceptance = "quarantine";
+
 		JSONGroup.addGroup(groupName = "Site Name");
 
 		JSONLayout.addPublicLayout(

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotSharing.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotSharing.testcase
@@ -45,6 +45,8 @@ definition {
 	@description = "This test asserts that users get the proper notification based on depot sharing permissions granted to him."
 	@priority = "5"
 	test AssertNotifications {
+		property portal.acceptance = "quarantine";
+
 		DepotNavigator.openDepotAdmin();
 
 		DepotNavigator.gotoDepot(

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotWCIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotWCIntegration.testcase
@@ -167,6 +167,8 @@ definition {
 	@description = "This ensures that a depot web content can be selected through the fragment in a content page on a connected site."
 	@priority = "5"
 	test SelectFromFragmentInContentPage {
+		property portal.acceptance = "quarantine";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Depot",
 			groupName = "Test Depot Name",
@@ -206,6 +208,8 @@ definition {
 	@description = "This ensures that a depot web content can be selected through the fragment in a display page template on a connected site."
 	@priority = "5"
 	test SelectFromFragmentInDisplayPageTemplate {
+		property portal.acceptance = "quarantine";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Depot",
 			groupName = "Test Depot Name",
@@ -332,6 +336,8 @@ definition {
 	@description = "This ensures that a depot web content can be selected through WCD in a display page template on a connected site."
 	@priority = "4"
 	test SelectFromWidgetInDisplayPageTemplate {
+		property portal.acceptance = "quarantine";
+
 		JSONWebcontent.addWebContent(
 			content = "WC WebContent Depot",
 			groupName = "Test Depot Name",

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ImageSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/tests/ImageSelector.testcase
@@ -29,6 +29,8 @@ definition {
 	@description = "This makes sure that multiple blog images can be previewed by using the keyboard."
 	@priority = "5"
 	test PreviewMultipleImagesInBlogsImages {
+		property portal.acceptance = "quarantine";
+
 		for (var i : list "1,2,3") {
 			BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 

--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/macros/OpenGraph.macro
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/macros/OpenGraph.macro
@@ -51,7 +51,7 @@ definition {
 				locator1 = "TextInput#FILE",
 				value1 = "${uploadFileName}");
 
-			Pause(locator1 = "3000");
+			Pause(locator1 = "5000");
 
 			AssertElementPresent.pauseAssertVisible(
 				locator1 = "ItemSelector#ADD_BUTTON",

--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/macros/OpenGraph.macro
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/macros/OpenGraph.macro
@@ -39,9 +39,9 @@ definition {
 		if (isSet(customImage)) {
 			var key_uploadFileName = "${uploadFileName}";
 
-			AssertElementPresent.assertVisible(locator1 = "Button#SELECT_OPEN_GRAPH_IMAGE");
+			AssertElementPresent.pauseAssertVisible(locator1 = "Button#SELECT_OPEN_GRAPH_IMAGE");
 
-			Click(locator1 = "Button#SELECT_OPEN_GRAPH_IMAGE");
+			Click.pauseClickAt(locator1 = "Button#SELECT_OPEN_GRAPH_IMAGE");
 
 			SelectFrame(locator1 = "ItemSelector#ITEM_SELECTOR_IFRAME");
 

--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/OpenGraphImages.testcase
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/OpenGraphImages.testcase
@@ -288,6 +288,8 @@ definition {
 	@description = "This makes sure that it will apply the OG image of the page when images are set at both the site level and the page level."
 	@priority = "5"
 	test ConfigurePageSpecificImage {
+		property portal.acceptance = "quarantine";
+
 		var portalURL = PropsUtil.get("portal.url");
 
 		SitePages.openPagesAdmin(siteURLKey = "test-site-name");
@@ -394,6 +396,8 @@ definition {
 	@description = "This ensures that users can introduce an alternative text for the image."
 	@priority = "5"
 	test EditAltDescription {
+		property portal.acceptance = "quarantine";
+
 		var portalURL = PropsUtil.get("portal.url");
 
 		SitePages.openPagesAdmin(siteURLKey = "test-site-name");

--- a/modules/apps/ratings/ratings-test/src/testFunctional/Ratings.testcase
+++ b/modules/apps/ratings/ratings-test/src/testFunctional/Ratings.testcase
@@ -471,6 +471,8 @@ definition {
 
 	@priority = "4"
 	test RateBlogsEntry {
+		property portal.acceptance = "quarantine";
+
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",
 			layoutName = "Blogs Page");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
@@ -87,9 +87,9 @@ definition {
 			}
 
 			while (((contains("${elasticsearchTasks}", "indices:data/write/bulk")) || IsElementPresent(locator1 = "ControlMenu#RELOAD_TOOLTIP")) && ("${reindexElapsedTime}" != "120")) {
-				Pause.pauseNoSPARefresh(locator1 = "5000");
+				Pause.pauseNoSPARefresh(locator1 = "10000");
 
-				var reindexElapsedTime = ${reindexElapsedTime} + 5;
+				var reindexElapsedTime = ${reindexElapsedTime} + 10;
 
 				echo("Current Elasticsearch Tasks:");
 
@@ -111,9 +111,9 @@ definition {
 			}
 
 			while ((IsElementPresent(locator1 = "ControlMenu#RELOAD_TOOLTIP")) && ("${reindexElapsedTime}" != "120")) {
-				Pause.pauseNoSPARefresh(locator1 = "5000");
+				Pause.pauseNoSPARefresh(locator1 = "10000");
 
-				var reindexElapsedTime = ${reindexElapsedTime} + 5;
+				var reindexElapsedTime = ${reindexElapsedTime} + 10;
 			}
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
@@ -97,6 +97,19 @@ definition {
 			}
 		}
 		else if (contains("${searchEngineVendor}", "Solr")) {
+			while ((IsElementNotPresent(locator1 = "ControlMenu#RELOAD_TOOLTIP")) && ("${reindexStartTime}" != "60")) {
+				Pause.pauseNoSPARefresh(locator1 = "5000");
+
+				var reindexStartTime = ${reindexStartTime} + 5;
+			}
+
+			if ("${reindexStartTime}" == "60") {
+				echo("Solr failed to receive reindex request after 60 seconds.");
+			}
+			else {
+				echo("Started reindexing ${reindexStartTime} second(s) after clicking 'Execute'.");
+			}
+
 			while ((IsElementPresent(locator1 = "ControlMenu#RELOAD_TOOLTIP")) && ("${reindexElapsedTime}" != "120")) {
 				Pause.pauseNoSPARefresh(locator1 = "5000");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SocialBookmarks.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SocialBookmarks.macro
@@ -9,7 +9,7 @@ definition {
 	}
 
 	macro viewBookmarkMenuItems {
-		Click(locator1 = "Icon#SHARE");
+		Click.pauseClickAt(locator1 = "Icon#SHARE");
 
 		for (var socialBookmark : list "${socialBookmarks}") {
 			MenuItem.viewPresent(menuItem = "${socialBookmark}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1179,6 +1179,8 @@ definition {
 
 		SelectFrame(locator1 = "IFrame#DIALOG");
 
+		Pause(locator1 = "3000");
+
 		WebContentFolder.selectFolderTreeNode(nodeName = "${folderName}");
 
 		SelectFrame(value1 = "relative=top");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/webcontentdisplay/WebContentDisplayPortlet.macro
@@ -375,7 +375,7 @@ definition {
 
 			AssertClick(
 				key_listEntry = "${webContentTitle}",
-				locator1 = "LexiconList#LIST_ENTRY_TITLE",
+				locator1 = "LexiconList#LIST_ENTRY_TITLE_LINK",
 				value1 = "${webContentTitle}");
 
 			SelectFrame(locator1 = "IFrame#DIALOG");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/SharingUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/assetsharing/SharingUsecase.testcase
@@ -298,6 +298,7 @@ definition {
 	@description = "This test ensures that users can Order By Shared Date in the Shared Content app."
 	@priority = "3"
 	test OrderBySharedDate {
+		property portal.acceptance = "quarantine";
 		property test.name.skip.portal.instance = "SharingUsecase#OrderBySharedDate";
 
 		JSONLayout.addWidgetToPublicLayout(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsUsecase.testcase
@@ -306,11 +306,8 @@ definition {
 		BlogsEntry.viewDefaultCP(entryTitle = "Blogs Entry Title");
 	}
 
-	// This is not an acceptance test and is temporarily quarantined.
-
 	@priority = "4"
 	test DemoTrackbackURL {
-		property portal.acceptance = "quarantine";
 		property custom.properties = "blogs.trackback.enabled=true";
 		property dummy.socket.proxy.disabled = "true";
 		property test.name.skip.portal.instance = "BlogsUsecase#DemoTrackbackURL";
@@ -1265,11 +1262,8 @@ definition {
 		SikuliAssertElementPresent(locator1 = "BlogsEntry#CONTENT_INLINE_IMAGE_PREVIEW");
 	}
 
-	// This is not an acceptance test and is temporarily quarantined.
-
 	@priority = "3"
 	test ViewBlogsEntryWithSpecialCharactersOnPrivateVirtualHost {
-		property portal.acceptance = "quarantine";
 		property test.name.skip.portal.instance = "BlogsUsecase#ViewBlogsEntriesWithSpecialCharactersOnPublicAndPrivateVirtualHostPages";
 
 		ProductMenu.gotoPortlet(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsUsecase.testcase
@@ -1194,6 +1194,8 @@ definition {
 
 	@priority = "4"
 	test ViewBlogsEntryWithImageEditedViaItemSelector {
+		property portal.acceptance = "quarantine";
+
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 
 		DMDocument.addCP(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/CPBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/CPBlogs.testcase
@@ -482,6 +482,8 @@ definition {
 
 	@priority = "3"
 	test SearchDMImagesViaItemSelector {
+		property portal.acceptance = "quarantine";
+
 		BlogsNavigator.openBlogsAdmin(siteURLKey = "guest");
 
 		Blogs.addEntryWithUploadedCoverImage(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
@@ -1044,6 +1044,7 @@ definition {
 
 	@priority = "4"
 	test UserFlagsEntryAndAdminViewsNotificationInMockMock {
+		property portal.acceptance = "quarantine";
 		property test.smtp.server.enabled = "true";
 
 		var siteName = TestCase.getSiteName(siteName = "${siteName}");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/RemoteStagingBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/RemoteStagingBlogs.testcase
@@ -183,6 +183,8 @@ definition {
 	@description = "This test covers LPS-83426 and LPS-92488. It views management bar details in the staging site and asserts that a replaced image displays in remote site."
 	@priority = "5"
 	test StagingRemoteLiveChangeBlogsEntryCoverImage {
+		property portal.acceptance = "quarantine";
+
 		property custom.properties = "tunneling.servlet.shared.secret=1234567890123456${line.separator}auth.verifier.TunnelAuthVerifier.hosts.allowed=";
 		property test.name.skip.portal.instance = "Staging#StagingRemoteLiveChangeBlogsEntryCoverImage";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/PGMessageboards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/PGMessageboards.testcase
@@ -374,10 +374,16 @@ definition {
 				locator1 = "TextInput#FILE",
 				value1 = "${mbThreadAttachment}");
 
+			Pause(locator1 = "3000");
+
 			AssertTextEquals(
 				key_attachmentName = "${mbThreadAttachment}",
 				locator1 = "MessageBoardsEditMessage#ATTACHMENTS_SELECTED_FILE",
 				value1 = "${mbThreadAttachment}");
+
+			AssertChecked.assertCheckedNotVisible(
+				checkboxName = "${mbThreadAttachment}",
+				locator1 = "Checkbox#ANY_CHECKBOX");
 		}
 
 		PortletEntry.publish();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/PGMessageboards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/PGMessageboards.testcase
@@ -349,6 +349,8 @@ definition {
 
 	@priority = "4"
 	test AddMBThreadWithMultipleAttachments {
+		property portal.acceptance = "quarantine";
+
 		Navigator.gotoPage(pageName = "Message Boards Page");
 
 		AssertClick(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/socialbookmarks/SocialBookmarks.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/socialbookmarks/SocialBookmarks.testcase
@@ -113,6 +113,8 @@ definition {
 			entryContent = "Blogs Entry Content",
 			entryTitle = "Blogs Entry Title");
 
+		Pause(locator1 = "3000");
+
 		SocialBookmarks.viewDefaultSharableBookmarks();
 
 		Blogs.disableSocialBookmarkSites(disableSocialBookmarkSites = "AddThis,Delicious,Digg,Evernote,Reddit,Slashdot");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/PGWiki.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/PGWiki.testcase
@@ -290,6 +290,8 @@ definition {
 
 	@priority = "4"
 	test AddFrontPageWithAttachments {
+		property portal.acceptance = "quarantine";
+
 		Navigator.gotoPage(pageName = "Wiki Test Page");
 
 		WikiPage.addFrontPagePG(wikiPageContent = "Wiki FrontPage Content");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/BulkEditing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/BulkEditing.testcase
@@ -338,6 +338,8 @@ definition {
 	@description = "This test covers LPS-94994. It ensures that users can edit category tags by using the bulk append action."
 	@priority = "5"
 	test ReplaceUncommonCategoryTags {
+		property portal.acceptance = "quarantine";
+
 		DMDocument.addMultiplePG(dmDocumentFileList = "Document_1.doc,Document_2.jpg");
 
 		for (var categoryName : list "Books,Plants,Pets,Furniture") {
@@ -391,6 +393,8 @@ definition {
 	@description = "This test covers LPS-89636. It saves tags without clicking Enter or adding a Comma."
 	@priority = "4"
 	test SaveTags {
+		property portal.acceptance = "quarantine";
+
 		DMDocument.addMultiplePG(dmDocumentFileList = "Document_1.doc,Document_2.jpg,Document_3.xls,Document_4.txt");
 
 		for (var key_dmDocumentTitle : list "Document_1.doc,Document_2.jpg,Document_3.xls,Document_4.txt") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/adaptivemedia/AdaptiveMedia.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/adaptivemedia/AdaptiveMedia.testcase
@@ -682,11 +682,8 @@ definition {
 		AdaptiveMedia.viewImageVariantID(imageVariantID = "custom-id");
 	}
 
-	// This is not an acceptance test and is temporarily quarantined.
-
 	@priority = "4"
 	test ViewNoImageResolutionInNewVirtualInstance {
-		property portal.acceptance = "quarantine";
 		property test.name.skip.portal.instance = "AdaptiveMedia#ViewNoImageResolutionInNewVirtualInstance";
 
 		ProductMenu.gotoPortlet(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/OneDrive.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/OneDrive.testcase
@@ -448,10 +448,9 @@ definition {
 			dmDocumentVersionNumber = "2.0");
 	}
 
-	@description = "This is not an acceptance test and is temporarily quarantined. This test ensures that a Word document title can be changed via the OneDrive editor."
+	@description = "This test ensures that a Word document title can be changed via the OneDrive editor."
 	@priority = "4"
 	test EditWordDocument {
-		property portal.acceptance = "quarantine";
 		property test.name.skip.portal.instance = "OneDrive#EditWordDocument";
 
 		for (var documentTitle : list "Document_3,Word Doc Title Edited") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/experiencemanagement/ContentPageReview.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/experiencemanagement/ContentPageReview.testcase
@@ -527,6 +527,8 @@ definition {
 	@description = "This test covers LPS-100024. It ensures that comments from different experiences are independent from one another."
 	@priority = "4"
 	test ViewCommentOnDifferentExperience {
+		property portal.acceptance = "quarantine";
+
 		SitePages.openPagesAdmin(siteURLKey = "test-site-name");
 
 		ProductMenu.gotoPortlet(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPagesUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPagesUseCase.testcase
@@ -440,8 +440,7 @@ definition {
 
 			AssertElementPresent(
 				key_imageName = "Document_2.jpeg",
-				key_position = "1",
-				locator1 = "PageEditor#SECTION_CONFIGURATION_BACKGROUND_IMAGE");
+				locator1 = "Fragment#FRAGMENT_SECTION_BACKGROUND_IMAGE");
 		}
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1136

@pyoo47 This will automatically allow webhook to reject pull requests sent to BChan on master, I'm working on the webhook changes for the message to print when rejected on master.

EDIT: after talking to Peter we've decided to hardcode this behavior in the webhook for now so we can control when this goes into effect without relying on the master stable job to sync.

This is a long-term approach that will be explored later, leaving pr open for now.