### PR TITLE
LRCI-1212 Use tomcat major version in tomcat zip url

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3515,7 +3515,16 @@ go</echo>
 			<var name="app.server.tomcat.lib.global.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/lib/ext" />
 			<var name="app.server.tomcat.lib.portal.dir" value="${app.server.parent.dir}/tomcat-${app.server.tomcat.version}/webapps/ROOT/WEB-INF/lib" />
 			<var name="app.server.tomcat.zip.name" value="apache-tomcat-${app.server.tomcat.version}.zip" />
-			<var name="app.server.tomcat.zip.url" value="http://archive.apache.org/dist/tomcat/tomcat-9/v${app.server.tomcat.version}/bin/${app.server.tomcat.zip.name}" />
+
+			<propertyregex
+				input="${app.server.tomcat.version}"
+				override="true"
+				property="app.server.tomcat.major.version"
+				regexp="(\d+)\..*"
+				replace="\1"
+			/>
+
+			<var name="app.server.tomcat.zip.url" value="http://archive.apache.org/dist/tomcat/tomcat-${app.server.tomcat.major.version}/v${app.server.tomcat.version}/bin/${app.server.tomcat.zip.name}" />
 
 			<echo append="true" file="app.server.${user.name}.properties">
 				app.server.tomcat.dir=${app.server.tomcat.dir}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1212

This will need to be backported to 7.0.x, 7.1.x, and 7.2.x (I've already prepared the branches).

Tested here (w/ 7.0.x):
https://test-5-1.liferay.com//userContent/jobs/legacy-database-dump/builds/389/jenkins-report.html