### PR TITLE
LRCI-1318 Add unique failure detection into Build/TestResult classes in the build object model

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -656,29 +656,10 @@ public class AutoCloseUtil {
 						continue;
 					}
 
-					List<TestResult> testResults = new ArrayList<>();
+					List<TestResult> uniqueFailureTestResults =
+						downstreamBuild.getUniqueFailureTestResults();
 
-					testResults.addAll(
-						downstreamBuild.getTestResults("FAILED"));
-					testResults.addAll(
-						downstreamBuild.getTestResults("REGRESSION"));
-
-					boolean containsUniqueTestFailure = false;
-
-					if (testResults.isEmpty()) {
-						containsUniqueTestFailure = true;
-					}
-					else {
-						for (TestResult testResult : testResults) {
-							if (testResult.isUniqueFailure()) {
-								containsUniqueTestFailure = true;
-
-								break;
-							}
-						}
-					}
-
-					if (!containsUniqueTestFailure) {
+					if (uniqueFailureTestResults.isEmpty()) {
 						failingInUpstreamJobDownstreamBuilds.add(
 							downstreamBuild);
 					}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseUtil.java
@@ -363,9 +363,7 @@ public class AutoCloseUtil {
 					downstreamBuild.getTestResults("REGRESSION"));
 
 				for (TestResult testResult : testResults) {
-					if (UpstreamFailureUtil.isTestFailingInUpstreamJob(
-							testResult)) {
-
+					if (!testResult.isUniqueFailure()) {
 						continue;
 					}
 
@@ -672,9 +670,7 @@ public class AutoCloseUtil {
 					}
 					else {
 						for (TestResult testResult : testResults) {
-							if (!UpstreamFailureUtil.isTestFailingInUpstreamJob(
-									testResult)) {
-
+							if (testResult.isUniqueFailure()) {
 								containsUniqueTestFailure = true;
 
 								break;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -413,7 +413,7 @@ public class AxisBuild extends BaseBuild {
 			return Collections.emptyList();
 		}
 
-		JSONObject testReportJSONObject = getTestReportJSONObject(false);
+		JSONObject testReportJSONObject = getTestReportJSONObject(true);
 
 		if (testReportJSONObject == null) {
 			System.out.println(
@@ -424,6 +424,38 @@ public class AxisBuild extends BaseBuild {
 
 		return getTestResults(
 			this, testReportJSONObject.getJSONArray("suites"), testStatus);
+	}
+
+	public List<TestResult> getUniqueFailureTestResults() {
+		List<TestResult> uniqueFailureTestResults = new ArrayList<>();
+
+		for (TestResult testResult : getTestResults(null)) {
+			if (!testResult.isFailing()) {
+				continue;
+			}
+
+			if (!UpstreamFailureUtil.isTestFailingInUpstreamJob(testResult)) {
+				uniqueFailureTestResults.add(testResult);
+			}
+		}
+
+		return uniqueFailureTestResults;
+	}
+
+	public List<TestResult> getUpstreamJobFailureTestResults() {
+		List<TestResult> upstreamFailureTestResults = new ArrayList<>();
+
+		for (TestResult testResult : getTestResults(null)) {
+			if (!testResult.isFailing()) {
+				continue;
+			}
+
+			if (UpstreamFailureUtil.isTestFailingInUpstreamJob(testResult)) {
+				upstreamFailureTestResults.add(testResult);
+			}
+		}
+
+		return upstreamFailureTestResults;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -285,25 +285,10 @@ public class AxisBuild extends BaseBuild {
 		}
 
 		if (result.equals("UNSTABLE")) {
-			List<Element> failureElements = new ArrayList<>();
-			List<Element> upstreamJobFailureElements = new ArrayList<>();
-
-			for (TestResult testResult : getTestResults(null)) {
-				if (!testResult.isFailing()) {
-					continue;
-				}
-
-				if (UpstreamFailureUtil.isTestFailingInUpstreamJob(
-						testResult)) {
-
-					upstreamJobFailureElements.add(
-						testResult.getGitHubElement());
-
-					continue;
-				}
-
-				failureElements.add(testResult.getGitHubElement());
-			}
+			List<Element> failureElements = getTestResultGitHubElements(
+				getUniqueFailureTestResults());
+			List<Element> upstreamJobFailureElements =
+				getTestResultGitHubElements(getUpstreamJobFailureTestResults());
 
 			if (!upstreamJobFailureElements.isEmpty()) {
 				upstreamJobFailureMessageElement = messageElement.createCopy();
@@ -519,6 +504,18 @@ public class AxisBuild extends BaseBuild {
 			String.valueOf(topLevelBuild.getBuildNumber()), "/", getJobName(),
 			"/", getAxisVariable(), "/", getParameterValue("JOB_VARIANT"), "/",
 			"stop.properties");
+	}
+
+	protected List<Element> getTestResultGitHubElements(
+		List<TestResult> testResults) {
+
+		List<Element> testResultGitHubElements = new ArrayList<>();
+
+		for (TestResult testResult : testResults) {
+			testResultGitHubElements.add(testResult.getGitHubElement());
+		}
+
+		return testResultGitHubElements;
 	}
 
 	protected static final Pattern archiveBuildURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -412,6 +412,7 @@ public class AxisBuild extends BaseBuild {
 			this, testReportJSONObject.getJSONArray("suites"), testStatus);
 	}
 
+	@Override
 	public List<TestResult> getUniqueFailureTestResults() {
 		List<TestResult> uniqueFailureTestResults = new ArrayList<>();
 
@@ -424,6 +425,7 @@ public class AxisBuild extends BaseBuild {
 		return uniqueFailureTestResults;
 	}
 
+	@Override
 	public List<TestResult> getUpstreamJobFailureTestResults() {
 		List<TestResult> upstreamFailureTestResults = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -413,7 +413,7 @@ public class AxisBuild extends BaseBuild {
 			return Collections.emptyList();
 		}
 
-		JSONObject testReportJSONObject = getTestReportJSONObject();
+		JSONObject testReportJSONObject = getTestReportJSONObject(false);
 
 		if (testReportJSONObject == null) {
 			System.out.println(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -417,6 +417,10 @@ public class AxisBuild extends BaseBuild {
 		List<TestResult> uniqueFailureTestResults = new ArrayList<>();
 
 		for (TestResult testResult : getTestResults(null)) {
+			if (!testResult.isFailing()) {
+				continue;
+			}
+
 			if (testResult.isUniqueFailure()) {
 				uniqueFailureTestResults.add(testResult);
 			}
@@ -430,6 +434,10 @@ public class AxisBuild extends BaseBuild {
 		List<TestResult> upstreamFailureTestResults = new ArrayList<>();
 
 		for (TestResult testResult : getTestResults(null)) {
+			if (!testResult.isFailing()) {
+				continue;
+			}
+
 			if (!testResult.isUniqueFailure()) {
 				upstreamFailureTestResults.add(testResult);
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AxisBuild.java
@@ -287,6 +287,7 @@ public class AxisBuild extends BaseBuild {
 		if (result.equals("UNSTABLE")) {
 			List<Element> failureElements = getTestResultGitHubElements(
 				getUniqueFailureTestResults());
+
 			List<Element> upstreamJobFailureElements =
 				getTestResultGitHubElements(getUpstreamJobFailureTestResults());
 
@@ -415,11 +416,7 @@ public class AxisBuild extends BaseBuild {
 		List<TestResult> uniqueFailureTestResults = new ArrayList<>();
 
 		for (TestResult testResult : getTestResults(null)) {
-			if (!testResult.isFailing()) {
-				continue;
-			}
-
-			if (!UpstreamFailureUtil.isTestFailingInUpstreamJob(testResult)) {
+			if (testResult.isUniqueFailure()) {
 				uniqueFailureTestResults.add(testResult);
 			}
 		}
@@ -431,11 +428,7 @@ public class AxisBuild extends BaseBuild {
 		List<TestResult> upstreamFailureTestResults = new ArrayList<>();
 
 		for (TestResult testResult : getTestResults(null)) {
-			if (!testResult.isFailing()) {
-				continue;
-			}
-
-			if (UpstreamFailureUtil.isTestFailingInUpstreamJob(testResult)) {
+			if (!testResult.isUniqueFailure()) {
 				upstreamFailureTestResults.add(testResult);
 			}
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1246,6 +1246,30 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
+	public List<TestResult> getUniqueFailureTestResults() {
+		List<TestResult> uniqueFailureTestResults = new ArrayList<>();
+
+		for (Build downstreamBuild : getDownstreamBuildFailures()) {
+			uniqueFailureTestResults.addAll(
+				downstreamBuild.getUniqueFailureTestResults());
+		}
+
+		return uniqueFailureTestResults;
+	}
+
+	@Override
+	public List<TestResult> getUpstreamJobFailureTestResults() {
+		List<TestResult> upstreamFailureTestResults = new ArrayList<>();
+
+		for (Build downstreamBuild : getDownstreamBuildFailures()) {
+			upstreamFailureTestResults.addAll(
+				downstreamBuild.getUpstreamJobFailureTestResults());
+		}
+
+		return upstreamFailureTestResults;
+	}
+
+	@Override
 	public boolean hasBuildURL(String buildURL) {
 		try {
 			buildURL = JenkinsResultsParserUtil.decode(buildURL);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1343,6 +1343,11 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
+	public boolean isUniqueFailure() {
+		return !UpstreamFailureUtil.isBuildFailingInUpstreamJob(this);
+	}
+
+	@Override
 	public void reinvoke() {
 		reinvoke(null);
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -29,7 +29,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -2297,29 +2296,31 @@ public abstract class BaseBuild implements Build {
 		return count;
 	}
 
-	protected Map<Build, Element> getDownstreamBuildMessages(
-		String... results) {
+	protected List<Build> getDownstreamBuildFailures() {
+		List<Build> downstreamBuildFailures = new ArrayList<>();
 
-		List<String> resultList = Arrays.asList(results);
-		List<Build> matchingBuilds = new ArrayList<>();
+		downstreamBuildFailures.addAll(getDownstreamBuilds("ABORTED", null));
+		downstreamBuildFailures.addAll(getDownstreamBuilds("FAILURE", null));
+		downstreamBuildFailures.addAll(getDownstreamBuilds("UNSTABLE", null));
+
+		return downstreamBuildFailures;
+	}
+
+	protected Map<Build, Element> getDownstreamBuildMessages(
+		List<Build> downstreamBuilds) {
+
 		List<Callable<Element>> callables = new ArrayList<>();
 
-		for (final Build downstreamBuild : getDownstreamBuilds(null)) {
-			String downstreamBuildResult = downstreamBuild.getResult();
+		for (final Build downstreamBuild : downstreamBuilds) {
+			Callable<Element> callable = new Callable<Element>() {
 
-			if (resultList.contains(downstreamBuildResult)) {
-				matchingBuilds.add(downstreamBuild);
+				public Element call() {
+					return downstreamBuild.getGitHubMessageElement();
+				}
 
-				Callable<Element> callable = new Callable<Element>() {
+			};
 
-					public Element call() {
-						return downstreamBuild.getGitHubMessageElement();
-					}
-
-				};
-
-				callables.add(callable);
-			}
+			callables.add(callable);
 		}
 
 		ParallelExecutor<Element> parallelExecutor = new ParallelExecutor<>(
@@ -2330,7 +2331,7 @@ public abstract class BaseBuild implements Build {
 		Map<Build, Element> elementsMap = new LinkedHashMap<>();
 
 		for (int i = 0; i < elements.size(); i++) {
-			elementsMap.put(matchingBuilds.get(i), elements.get(i));
+			elementsMap.put(downstreamBuilds.get(i), elements.get(i));
 		}
 
 		return elementsMap;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1105,12 +1105,23 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
-	public JSONObject getTestReportJSONObject() {
+	public JSONObject getTestReportJSONObject(boolean cache) {
 		try {
-			return JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.getLocalURL(
-					getBuildURL() + "testReport/api/json"),
-				false);
+			JSONObject testReportJSONObject =
+				JenkinsResultsParserUtil.toJSONObject(
+					JenkinsResultsParserUtil.getLocalURL(
+						getBuildURL() + "testReport/api/json"),
+					false);
+
+			if (cache) {
+				if (_testReportJSONObject == null) {
+					_testReportJSONObject = testReportJSONObject;
+				}
+
+				return _testReportJSONObject;
+			}
+
+			return testReportJSONObject;
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(
@@ -2895,7 +2906,7 @@ public abstract class BaseBuild implements Build {
 	}
 
 	protected int getTestCountByStatus(String status) {
-		JSONObject testReportJSONObject = getTestReportJSONObject();
+		JSONObject testReportJSONObject = getTestReportJSONObject(false);
 
 		if (testReportJSONObject == null) {
 			return 0;
@@ -3501,5 +3512,6 @@ public abstract class BaseBuild implements Build {
 	private String _previousStatus;
 	private String _result;
 	private String _status;
+	private JSONObject _testReportJSONObject;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1104,23 +1104,12 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
-	public JSONObject getTestReportJSONObject(boolean cache) {
+	public JSONObject getTestReportJSONObject(boolean checkCache) {
 		try {
-			JSONObject testReportJSONObject =
-				JenkinsResultsParserUtil.toJSONObject(
-					JenkinsResultsParserUtil.getLocalURL(
-						getBuildURL() + "testReport/api/json"),
-					false);
-
-			if (cache) {
-				if (_testReportJSONObject == null) {
-					_testReportJSONObject = testReportJSONObject;
-				}
-
-				return _testReportJSONObject;
-			}
-
-			return testReportJSONObject;
+			return JenkinsResultsParserUtil.toJSONObject(
+				JenkinsResultsParserUtil.getLocalURL(
+					getBuildURL() + "testReport/api/json"),
+				checkCache);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(
@@ -3542,6 +3531,5 @@ public abstract class BaseBuild implements Build {
 	private String _previousStatus;
 	private String _result;
 	private String _status;
-	private JSONObject _testReportJSONObject;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTestResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTestResult.java
@@ -203,10 +203,6 @@ public class BaseTestResult implements TestResult {
 
 	@Override
 	public boolean isUniqueFailure() {
-		if (!isFailing()) {
-			return false;
-		}
-
 		return !UpstreamFailureUtil.isTestFailingInUpstreamJob(this);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTestResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTestResult.java
@@ -201,6 +201,15 @@ public class BaseTestResult implements TestResult {
 		return true;
 	}
 
+	@Override
+	public boolean isUniqueFailure() {
+		if (!isFailing()) {
+			return false;
+		}
+
+		return !UpstreamFailureUtil.isTestFailingInUpstreamJob(this);
+	}
+
 	protected BaseTestResult(Build build, JSONObject caseJSONObject) {
 		if (build == null) {
 			throw new IllegalArgumentException("Build is null");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
@@ -466,13 +466,7 @@ public class BatchBuild extends BaseBuild {
 
 			if (isCompareToUpstream()) {
 				for (TestResult testResult : getTestResults(null)) {
-					if (!testResult.isFailing()) {
-						continue;
-					}
-
-					if (UpstreamFailureUtil.isTestFailingInUpstreamJob(
-							testResult)) {
-
+					if (!testResult.isUniqueFailure()) {
 						upstreamFailCount++;
 					}
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
@@ -242,7 +242,7 @@ public class BatchBuild extends BaseBuild {
 			return Collections.emptyList();
 		}
 
-		JSONObject testReportJSONObject = getTestReportJSONObject();
+		JSONObject testReportJSONObject = getTestReportJSONObject(false);
 
 		JSONArray childReportsJSONArray = testReportJSONObject.optJSONArray(
 			"childReports");
@@ -535,7 +535,7 @@ public class BatchBuild extends BaseBuild {
 
 	@Override
 	protected int getTestCountByStatus(String status) {
-		JSONObject testReportJSONObject = getTestReportJSONObject();
+		JSONObject testReportJSONObject = getTestReportJSONObject(false);
 
 		int failCount = testReportJSONObject.getInt("failCount");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
@@ -465,10 +465,10 @@ public class BatchBuild extends BaseBuild {
 			successCount = getTestCountByStatus("SUCCESS");
 
 			if (isCompareToUpstream()) {
-				List<TestResult> uniqueFailureTestResults =
-					getUniqueFailureTestResults();
+				List<TestResult> upstreamJobFailureTestResults =
+					getUpstreamJobFailureTestResults();
 
-				upstreamFailCount = uniqueFailureTestResults.size();
+				upstreamFailCount = upstreamJobFailureTestResults.size();
 
 				if (showCommonFailuresCount) {
 					failCount = upstreamFailCount;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
@@ -465,11 +465,10 @@ public class BatchBuild extends BaseBuild {
 			successCount = getTestCountByStatus("SUCCESS");
 
 			if (isCompareToUpstream()) {
-				for (TestResult testResult : getTestResults(null)) {
-					if (!testResult.isUniqueFailure()) {
-						upstreamFailCount++;
-					}
-				}
+				List<TestResult> uniqueFailureTestResults =
+					getUniqueFailureTestResults();
+
+				upstreamFailCount = uniqueFailureTestResults.size();
 
 				if (showCommonFailuresCount) {
 					failCount = upstreamFailCount;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BatchBuild.java
@@ -83,7 +83,7 @@ public class BatchBuild extends BaseBuild {
 		}
 
 		Map<Build, Element> downstreamBuildFailureMessages =
-			getDownstreamBuildMessages("ABORTED", "FAILURE", "UNSTABLE");
+			getDownstreamBuildMessages(getDownstreamBuildFailures());
 
 		List<Element> failureElements = new ArrayList<>();
 		List<Element> upstreamJobFailureElements = new ArrayList<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -181,6 +181,8 @@ public interface Build {
 
 	public boolean isFromCompletedBuild();
 
+	public boolean isUniqueFailure();
+
 	public void reinvoke();
 
 	public void reinvoke(ReinvokeRule reinvokeRule);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -169,6 +169,10 @@ public interface Build {
 	public int getTotalSlavesUsedCount(
 		String status, boolean modifiedBuildsOnly, boolean ignoreCurrentBuild);
 
+	public List<TestResult> getUniqueFailureTestResults();
+
+	public List<TestResult> getUpstreamJobFailureTestResults();
+
 	public boolean hasBuildURL(String buildURL);
 
 	public boolean hasGenericCIFailure();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -151,7 +151,7 @@ public interface Build {
 
 	public Map<String, String> getStopPropertiesTempMap();
 
-	public JSONObject getTestReportJSONObject(boolean cache);
+	public JSONObject getTestReportJSONObject(boolean checkCache);
 
 	public List<TestResult> getTestResults(String testStatus);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -151,7 +151,7 @@ public interface Build {
 
 	public Map<String, String> getStopPropertiesTempMap();
 
-	public JSONObject getTestReportJSONObject();
+	public JSONObject getTestReportJSONObject(boolean cache);
 
 	public List<TestResult> getTestResults(String testStatus);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalPullRequestTesterTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalPullRequestTesterTopLevelBuild.java
@@ -90,6 +90,17 @@ public class PortalPullRequestTesterTopLevelBuild extends DefaultTopLevelBuild {
 		return _stableJobResult;
 	}
 
+	@Override
+	public boolean isUniqueFailure() {
+		for (Build downstreamBuild : getDownstreamBuildFailures()) {
+			if (downstreamBuild.isUniqueFailure()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	protected Element getFailedStableJobSummaryElement() {
 		List<String> stableJobBatchNames = new ArrayList<>(
 			_stableJob.getBatchNames());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceBuild.java
@@ -49,7 +49,7 @@ public class SourceBuild extends BaseBuild {
 	}
 
 	@Override
-	public JSONObject getTestReportJSONObject() {
+	public JSONObject getTestReportJSONObject(boolean cache) {
 		return null;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResult.java
@@ -47,4 +47,6 @@ public interface TestResult {
 
 	public boolean isFailing();
 
+	public boolean isUniqueFailure();
+
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -303,7 +303,7 @@ public abstract class TopLevelBuild extends BaseBuild {
 	}
 
 	@Override
-	public JSONObject getTestReportJSONObject() {
+	public JSONObject getTestReportJSONObject(boolean cache) {
 		return null;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -606,9 +606,7 @@ public abstract class TopLevelBuild extends BaseBuild {
 			Element failureElement = entry.getValue();
 
 			if (failureElement != null) {
-				if (UpstreamFailureUtil.isBuildFailingInUpstreamJob(
-						failedDownstreamBuild)) {
-
+				if (!failedDownstreamBuild.isUniqueFailure()) {
 					upstreamBuildFailureElements.add(failureElement);
 
 					continue;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -586,7 +586,7 @@ public abstract class TopLevelBuild extends BaseBuild {
 
 	protected Element[] getBuildFailureElements() {
 		Map<Build, Element> downstreamBuildFailureMessages =
-			getDownstreamBuildMessages("ABORTED", "FAILURE", "UNSTABLE");
+			getDownstreamBuildMessages(getDownstreamBuildFailures());
 
 		List<Element> allCurrentBuildFailureElements = new ArrayList<>();
 		List<Element> upstreamBuildFailureElements = new ArrayList<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -339,6 +339,11 @@ public abstract class TopLevelBuild extends BaseBuild {
 	}
 
 	@Override
+	public boolean isUniqueFailure() {
+		return true;
+	}
+
+	@Override
 	public void setCompareToUpstream(boolean compareToUpstream) {
 		_compareToUpstream = compareToUpstream;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -38,7 +38,11 @@ public class UpstreamFailureUtil {
 			getUpstreamJobFailuresJSONObject(topLevelBuild);
 
 		JSONArray failedBatchesJSONArray =
-			upstreamJobFailuresJSONObject.getJSONArray("failedBatches");
+			upstreamJobFailuresJSONObject.optJSONArray("failedBatches");
+
+		if (failedBatchesJSONArray == null) {
+			return upstreamFailures;
+		}
 
 		for (int i = 0; i < failedBatchesJSONArray.length(); i++) {
 			JSONObject failedBatchJSONObject =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -55,17 +55,16 @@ public class UpstreamFailureUtil {
 
 			if (type.equals("build")) {
 				upstreamFailures.add(
-					JenkinsResultsParserUtil.combine(
-						jobVariant, ",",
-						failedBatchJSONObject.getString("result")));
+					_formatUpstreamBuildFailure(
+						jobVariant, failedBatchJSONObject.getString("result")));
 			}
 			else if (type.equals("test")) {
 				for (int j = 0; j < failedTestsJSONArray.length(); j++) {
 					Object object = failedTestsJSONArray.get(j);
 
 					upstreamFailures.add(
-						JenkinsResultsParserUtil.combine(
-							object.toString(), ",", jobVariant));
+						_formatUpstreamTestFailure(
+							jobVariant, object.toString()));
 				}
 			}
 		}
@@ -155,8 +154,9 @@ public class UpstreamFailureUtil {
 			for (String failure :
 					getUpstreamJobFailures("test", topLevelBuild)) {
 
-				if (failure.contains(jobVariant) &&
-					failure.contains(testResult.getDisplayName())) {
+				if (failure.equals(
+						_formatUpstreamTestFailure(
+							jobVariant, testResult.getDisplayName()))) {
 
 					return true;
 				}
@@ -237,6 +237,18 @@ public class UpstreamFailureUtil {
 		}
 	}
 
+	private static String _formatUpstreamBuildFailure(
+		String jobVariant, String testResult) {
+
+		return JenkinsResultsParserUtil.combine(jobVariant, ",", testResult);
+	}
+
+	private static String _formatUpstreamTestFailure(
+		String jobVariant, String testName) {
+
+		return JenkinsResultsParserUtil.combine(testName, ",", jobVariant);
+	}
+
 	private static boolean _isBuildFailingInUpstreamJob(Build build) {
 		String jobVariant = build.getJobVariant();
 
@@ -261,8 +273,8 @@ public class UpstreamFailureUtil {
 		for (String upstreamJobFailure :
 				getUpstreamJobFailures("build", topLevelBuild)) {
 
-			if (upstreamJobFailure.contains(jobVariant) &&
-				upstreamJobFailure.contains(result)) {
+			if (upstreamJobFailure.equals(
+					_formatUpstreamBuildFailure(jobVariant, result))) {
 
 				return true;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -50,12 +50,10 @@ public class UpstreamFailureUtil {
 			String jobVariant = failedBatchJSONObject.getString("jobVariant");
 
 			if (type.equals("build")) {
-				if (failedTestsJSONArray.length() == 0) {
-					upstreamFailures.add(
-						JenkinsResultsParserUtil.combine(
-							jobVariant, ",",
-							failedBatchJSONObject.getString("result")));
-				}
+				upstreamFailures.add(
+					JenkinsResultsParserUtil.combine(
+						jobVariant, ",",
+						failedBatchJSONObject.getString("result")));
 			}
 			else if (type.equals("test")) {
 				for (int j = 0; j < failedTestsJSONArray.length(); j++) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -145,11 +145,7 @@ public class UpstreamFailureUtil {
 		try {
 			String jobVariant = build.getJobVariant();
 
-			if (jobVariant.contains("/")) {
-				int index = jobVariant.lastIndexOf("/");
-
-				jobVariant = jobVariant.substring(0, index);
-			}
+			jobVariant = jobVariant.replaceAll("(.*)/.*", "$1");
 
 			for (String failure :
 					getUpstreamJobFailures("test", topLevelBuild)) {
@@ -262,11 +258,7 @@ public class UpstreamFailureUtil {
 			return false;
 		}
 
-		if (jobVariant.contains("/")) {
-			int index = jobVariant.lastIndexOf("/");
-
-			jobVariant = jobVariant.substring(0, index);
-		}
+		jobVariant = jobVariant.replaceAll("(.*)/.*", "$1");
 
 		TopLevelBuild topLevelBuild = build.getTopLevelBuild();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -165,16 +165,16 @@ public class UpstreamFailureUtil {
 		TopLevelBuild topLevelBuild = build.getTopLevelBuild();
 
 		try {
+			String jobVariant = build.getJobVariant();
+
+			if (jobVariant.contains("/")) {
+				int index = jobVariant.lastIndexOf("/");
+
+				jobVariant = jobVariant.substring(0, index);
+			}
+
 			for (String failure :
 					getUpstreamJobFailures("test", topLevelBuild)) {
-
-				String jobVariant = build.getJobVariant();
-
-				if (jobVariant.contains("/")) {
-					int index = jobVariant.lastIndexOf("/");
-
-					jobVariant = jobVariant.substring(0, index);
-				}
 
 				if (failure.contains(jobVariant) &&
 					failure.contains(testResult.getDisplayName())) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ValidationBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ValidationBuild.java
@@ -126,7 +126,7 @@ public class ValidationBuild extends BaseBuild {
 			return Collections.emptyList();
 		}
 
-		JSONObject testReportJSONObject = getTestReportJSONObject();
+		JSONObject testReportJSONObject = getTestReportJSONObject(false);
 
 		return getTestResults(
 			this, testReportJSONObject.getJSONArray("suites"), testStatus);

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/expected-github-message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/expected-github-message.html
@@ -448,6 +448,77 @@
       <li>
         <div>
           <h5>
+            <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-17/test-portal-acceptance-pullrequest-batch(master)/142497/">test-portal-acceptance-pullrequest-batch(master)/lpkg-release-jdk8</a>
+          </h5>
+          <div>
+            <h6>Job Results:</h6>
+            <p>0 Tests Passed.
+              <br/>0 Tests Failed.
+            </p>
+          </div>
+          <ol>
+            <li>
+              <div>
+                <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-17/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/142497//consoleText">AXIS_VARIABLE=0,label_exp=!master #142497</a>
+                <pre>
+                  <code>Build was aborted</code>
+                </pre>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </li>
+      <li>
+        <div>
+          <h5>
+            <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-20/test-portal-acceptance-pullrequest-batch(master)/151990/">test-portal-acceptance-pullrequest-batch(master)/modules-compile-jdk8</a>
+          </h5>
+          <div>
+            <h6>Job Results:</h6>
+            <p>0 Tests Passed.
+              <br/>1 Test Failed.
+            </p>
+          </div>
+          <ol>
+            <li>
+              <div>
+                <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-20/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/151990//consoleText">AXIS_VARIABLE=0,label_exp=!master #151990</a>
+                <pre>
+                  <code>     [exec] * Where:
+     [exec] Build file '/opt/dev/projects/github/liferay-portal/modules/util/portal-tools-sample-sql-builder/build.gradle' line: 49
+     [exec]
+     [exec] * What went wrong:
+     [exec] Execution failed for task ':util:portal-tools-sample-sql-builder:writeReleases'.
+     [exec] &gt; /opt/dev/projects/github/liferay-portal/tools/sdk/dist/com.liferay.subscription.service-1.0.0.jar (No such file or directory)
+     [exec]
+     [exec] * Try:
+     [exec] Run with --info or --debug option to get more log output.
+     [exec]
+     [exec] * Exception is:
+     [exec] org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':util:portal-tools-sample-sql-builder:writeReleases'.
+     [exec] 	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:84)
+     [exec] 	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:55)
+     [exec] 	at org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter.execute(SkipUpToDateTaskExecuter.java:62)
+     [exec] 	at org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter.execute(ValidatingTaskExecuter.java:58)
+     [exec] 	at org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter.execute(SkipEmptySourceFilesTaskExecuter.java:88)
+     [exec] 	at org.gradle.api.internal.tasks.execution.ResolveTaskArtifactStateTaskExecuter.execute(ResolveTaskArtifactStateTaskExecuter.java:46)
+     [exec] 	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:51)
+     [exec] 	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:54)
+     [exec] 	at org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter.execute(ExecuteAtMostOnceTaskExecuter.java:43)
+     [exec] 	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:34)
+     [exec] 	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:236)
+     [exec] 	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:228)
+     [exec] 	at org.gradle.internal.Transformers$4.transform(Transformers.java:169)
+     [exec] 	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:106)</code>
+                </pre>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </li>
+      <li>
+        <div>
+          <h5>
             <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-23/test-portal-acceptance-pullrequest-batch(master)/7862/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat80-mysql56-jdk8/11</a>
           </h5>
           <div>
@@ -566,77 +637,6 @@
           <strong>Click
             <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-13/test-portal-acceptance-pullrequest-batch(master)/131031/testReport">here</a> for more failures.
           </strong>
-        </div>
-      </li>
-      <li>
-        <div>
-          <h5>
-            <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-17/test-portal-acceptance-pullrequest-batch(master)/142497/">test-portal-acceptance-pullrequest-batch(master)/lpkg-release-jdk8</a>
-          </h5>
-          <div>
-            <h6>Job Results:</h6>
-            <p>0 Tests Passed.
-              <br/>0 Tests Failed.
-            </p>
-          </div>
-          <ol>
-            <li>
-              <div>
-                <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-17/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/142497//consoleText">AXIS_VARIABLE=0,label_exp=!master #142497</a>
-                <pre>
-                  <code>Build was aborted</code>
-                </pre>
-              </div>
-            </li>
-          </ol>
-        </div>
-      </li>
-      <li>
-        <div>
-          <h5>
-            <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-20/test-portal-acceptance-pullrequest-batch(master)/151990/">test-portal-acceptance-pullrequest-batch(master)/modules-compile-jdk8</a>
-          </h5>
-          <div>
-            <h6>Job Results:</h6>
-            <p>0 Tests Passed.
-              <br/>1 Test Failed.
-            </p>
-          </div>
-          <ol>
-            <li>
-              <div>
-                <a href="${dependencies.url}/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_modules-compile-failure/test-1-20/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/151990//consoleText">AXIS_VARIABLE=0,label_exp=!master #151990</a>
-                <pre>
-                  <code>     [exec] * Where:
-     [exec] Build file '/opt/dev/projects/github/liferay-portal/modules/util/portal-tools-sample-sql-builder/build.gradle' line: 49
-     [exec]
-     [exec] * What went wrong:
-     [exec] Execution failed for task ':util:portal-tools-sample-sql-builder:writeReleases'.
-     [exec] &gt; /opt/dev/projects/github/liferay-portal/tools/sdk/dist/com.liferay.subscription.service-1.0.0.jar (No such file or directory)
-     [exec]
-     [exec] * Try:
-     [exec] Run with --info or --debug option to get more log output.
-     [exec]
-     [exec] * Exception is:
-     [exec] org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':util:portal-tools-sample-sql-builder:writeReleases'.
-     [exec] 	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:84)
-     [exec] 	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:55)
-     [exec] 	at org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter.execute(SkipUpToDateTaskExecuter.java:62)
-     [exec] 	at org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter.execute(ValidatingTaskExecuter.java:58)
-     [exec] 	at org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter.execute(SkipEmptySourceFilesTaskExecuter.java:88)
-     [exec] 	at org.gradle.api.internal.tasks.execution.ResolveTaskArtifactStateTaskExecuter.execute(ResolveTaskArtifactStateTaskExecuter.java:46)
-     [exec] 	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:51)
-     [exec] 	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:54)
-     [exec] 	at org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter.execute(ExecuteAtMostOnceTaskExecuter.java:43)
-     [exec] 	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:34)
-     [exec] 	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:236)
-     [exec] 	at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:228)
-     [exec] 	at org.gradle.internal.Transformers$4.transform(Transformers.java:169)
-     [exec] 	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:106)</code>
-                </pre>
-              </div>
-            </li>
-          </ol>
         </div>
       </li>
       <li>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1318

Only contains code reorganization and minor logic changes. Changes include:
* Addition of `isUniqueFailure` methods to `Build` and `TestResult` classes. This means we're using 'upstream failure' and 'unique failure' terminology. It can be assumed that if it's not an upstream failure, then it is unique and vice versa. Decided to use the 'unique' terminology in the BOM interfaces because it's a little less strange having that built into the class from my understanding. Using 'upstream failure' terminology is a little confusing in retrospect since Jenkins uses 'downstream' in its concepts.
* Unique failure / upstream failure detection will propagate down using those methods. This will also apply to TopLevelBuilds and what I'll evaluate in LRCI-1208 so we can set a custom result.
* I made some minor logic changes to the upstream comparison, which didn't fully couple the batch upstream failure detection and test upstream failure detection together. Here's the explanation of how it will work now: For builds, the build will return true as an upstream failure if the build has a matching job variant and result that is in the upstream data AND if all the failing tests match (if there are no actual test failures like for semantic versioning, then it will still return true). For tests, the test will return true as an upstream failure if the test is also in the upstream failure data.