### PR TITLE
LRCI-1412 Checkout the upstream local branch if no branch is currently checked out

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -973,7 +973,9 @@ public class GitWorkingDirectory {
 		String currentBranchName = getCurrentBranchName();
 
 		if (currentBranchName == null) {
-			return null;
+			checkoutUpstreamLocalGitBranch();
+
+			return getUpstreamLocalGitBranch();
 		}
 
 		return getLocalGitBranch(currentBranchName);


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1412

@petershin - Here's the fix for the stack overflow error.  It occurs when there is no branch checked out for a particular repository.

For example in this server's `com-lilferay-osb-asah-private` repository there is no currently checked out branch:
```[root@cloud-10-0-16-49 com-liferay-osb-asah-private]# git branch
  7.0.x
  7.0.x-private
  hotfix```

This is likely due to some random Git GC running that purged it.