### PR TITLE
LRCI-1452 Add parameter to send release build creation time to Spira

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/SpiraReleaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/SpiraReleaseBuild.java
@@ -37,7 +37,7 @@ public class SpiraReleaseBuild extends BaseSpiraArtifact {
 	public static SpiraReleaseBuild createSpiraReleaseBuild(
 		SpiraProject spiraProject, SpiraRelease spiraRelease,
 		String releaseBuildName, String releaseBuildDescription,
-		Status releaseBuildStatus) {
+		Status releaseBuildStatus, long releaseBuildStartTime) {
 
 		List<SpiraReleaseBuild> spiraReleaseBuilds = getSpiraReleaseBuilds(
 			spiraProject, spiraRelease,
@@ -61,6 +61,9 @@ public class SpiraReleaseBuild extends BaseSpiraArtifact {
 		requestJSONObject.put(SpiraProject.ID_KEY, spiraProject.getID());
 		requestJSONObject.put(SpiraRelease.ID_KEY, spiraRelease.getID());
 		requestJSONObject.put("BuildStatusId", releaseBuildStatus.getID());
+		requestJSONObject.put(
+			"CreationDate",
+			SpiraRestAPIUtil.getDateString(releaseBuildStartTime));
 		requestJSONObject.put("Name", releaseBuildName);
 
 		if (releaseBuildDescription != null) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/SpiraRestAPIUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/SpiraRestAPIUtil.java
@@ -19,9 +19,13 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMe
 
 import java.io.IOException;
 
+import java.text.SimpleDateFormat;
+
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -30,6 +34,12 @@ import org.json.JSONObject;
  * @author Michael Hashimoto
  */
 public class SpiraRestAPIUtil {
+
+	protected static String getDateString(long timestamp) {
+		Date date = new Date(timestamp);
+
+		return _UtcIso8601SimpleDateFormat.format(date);
+	}
 
 	protected static String request(
 			String urlPath, Map<String, String> urlParameters,
@@ -125,6 +135,17 @@ public class SpiraRestAPIUtil {
 		}
 
 		return "?" + JenkinsResultsParserUtil.join("&", urlParameterStrings);
+	}
+
+	private static final SimpleDateFormat _UtcIso8601SimpleDateFormat;
+
+	static {
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss");
+
+		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		_UtcIso8601SimpleDateFormat = simpleDateFormat;
 	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1452

Tested here:
https://test-5-1.liferay.com/job/publish-spira-report/441/


Regarding the date/time format we should send in (we should send in as UTC):
```
Default Timezone – SpiraTeam stores all dates and times internally in Universal Coordinated Time (UTC) and can therefore display dates/times adjusted for different timezones. By default, SpiraTeam will display dates in the timezone specified in the operating system it has been installed on. However, you can override this default by choosing the appropriate display timezone from the list of options displayed in the drop-down list.
```

Source: https://www.inflectra.com/HelpViewer/?name=Spira-5-3-Administration-Guide&section=3.10.1.%20General%20Settings