### PR TITLE
LPS-117490 Do not use mirrors.hostname in case it is an empty string

### DIFF
--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentIntegration.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotDocumentIntegration.testcase
@@ -115,9 +115,8 @@ definition {
 			backgroundImage = "Manual Selection",
 			depotName = "Test Depot Name",
 			imageFileName = "Document_1.jpeg",
-			padding = "true",
-			panel = "Styles",
-			top = "2");
+			paddingTop = "2",
+			panel = "Styles");
 
 		PageEditor.clickPublish();
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/init.jsp" %>
 
 <%
+String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_dynamic_data_lists_view_records") + StringPool.UNDERLINE;
+
 long formDDMTemplateId = ParamUtil.getLong(request, "formDDMTemplateId");
 
 DDLViewRecordsDisplayContext ddlViewRecordsDisplayContext = new DDLViewRecordsDisplayContext(liferayPortletRequest, liferayPortletResponse, formDDMTemplateId);
@@ -28,8 +30,6 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 
 	renderResponse.setTitle(recordSet.getName(locale));
 }
-
-String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_dynamic_data_lists_view_records") + StringPool.UNDERLINE;
 %>
 
 <c:if test="<%= ddlViewRecordsDisplayContext.isAdminPortlet() %>">

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_records.jsp
@@ -28,6 +28,8 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 
 	renderResponse.setTitle(recordSet.getName(locale));
 }
+
+String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_dynamic_data_lists_view_records") + StringPool.UNDERLINE;
 %>
 
 <c:if test="<%= ddlViewRecordsDisplayContext.isAdminPortlet() %>">
@@ -40,7 +42,7 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 <clay:management-toolbar
 	actionDropdownItems="<%= ddlViewRecordsDisplayContext.getActionItemsDropdownItems() %>"
 	clearResultsURL="<%= ddlViewRecordsDisplayContext.getClearResultsURL() %>"
-	componentId="ddlViewRecordsManagementToolbar"
+	componentId='<%= randomNamespace + "ddlViewRecordsManagementToolbar" %>'
 	creationMenu="<%= ddlViewRecordsDisplayContext.getCreationMenu() %>"
 	disabled="<%= ddlViewRecordsDisplayContext.isDisabledManagementBar() %>"
 	filterDropdownItems="<%= ddlViewRecordsDisplayContext.getFilterItemsDropdownItems() %>"
@@ -199,7 +201,7 @@ if (!ddlDisplayContext.isAdminPortlet()) {
 		deleteRecords: deleteRecords,
 	};
 
-	Liferay.componentReady('ddlViewRecordsManagementToolbar').then(function (
+	Liferay.componentReady('<%= randomNamespace + "ddlViewRecordsManagementToolbar" %>').then(function (
 		managementToolbar
 	) {
 		managementToolbar.on('actionItemClicked', function (event) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/FieldsToDDMFormValuesConverterImpl.java
@@ -211,19 +211,18 @@ public class FieldsToDDMFormValuesConverterImpl
 
 			fieldValue = valueDate.getTime();
 		}
-		else if (fieldValue instanceof Number) {
+		else if ((fieldValue instanceof Number) &&
+				 !(fieldValue instanceof Integer)) {
+
 			NumberFormat numberFormat = NumberFormat.getInstance(locale);
 
 			Number number = (Number)fieldValue;
 
 			if (number instanceof Double || number instanceof Float) {
 				numberFormat.setMinimumFractionDigits(1);
+			}
 
-				return numberFormat.format(number.doubleValue());
-			}
-			else if (fieldValue instanceof Integer) {
-				return numberFormat.format(number.intValue());
-			}
+			return numberFormat.format(number.doubleValue());
 		}
 
 		return String.valueOf(fieldValue);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -180,6 +180,13 @@ public class FriendlyURLServlet extends HttpServlet {
 		if ((pos != -1) && ((pos + 1) != path.length())) {
 			friendlyURL = path.substring(pos);
 
+			if (friendlyURL.charAt(friendlyURL.length() - 1) ==
+					CharPool.SLASH) {
+
+				friendlyURL = friendlyURL.substring(
+					0, friendlyURL.length() - 1);
+			}
+
 			RedirectEntry redirectEntry =
 				redirectEntryLocalService.fetchRedirectEntry(
 					group.getGroupId(), _normalizeFriendlyURL(friendlyURL),

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -180,9 +180,7 @@ public class FriendlyURLServlet extends HttpServlet {
 		if ((pos != -1) && ((pos + 1) != path.length())) {
 			friendlyURL = path.substring(pos);
 
-			if (friendlyURL.charAt(friendlyURL.length() - 1) ==
-					CharPool.SLASH) {
-
+			if (StringUtil.endsWith(friendlyURL, CharPool.SLASH)) {
 				friendlyURL = friendlyURL.substring(
 					0, friendlyURL.length() - 1);
 			}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
@@ -137,6 +137,13 @@ AUI.add(
 					});
 				},
 
+				_onChange(event) {
+					var instance = this;
+
+					instance._toggleBtnMove(event);
+					instance._toggleBtnSort(event);
+				},
+
 				_onSelectFocus(event, box) {
 					var instance = this;
 
@@ -283,6 +290,10 @@ AUI.add(
 					var moveBtnRight = contentBox.one('.move-right');
 
 					var target = event.target;
+					var selectedOptions = target
+						.get('options')
+						.getDOMNodes()
+						.filter((option) => option.selected).length;
 
 					if (moveBtnLeft && moveBtnRight && target) {
 						var btnDisabledLeft = true;
@@ -292,7 +303,8 @@ AUI.add(
 							if (target === instance._rightBox) {
 								if (
 									leftBoxMaxItems === -1 ||
-									instance._leftBox.get('length') <
+									instance._leftBox.get('length') +
+										selectedOptions <=
 										leftBoxMaxItems
 								) {
 									btnDisabledLeft = false;
@@ -301,7 +313,8 @@ AUI.add(
 							else if (target === instance._leftBox) {
 								if (
 									rightBoxMaxItems === -1 ||
-									instance._rightBox.get('length') <
+									instance._rightBox.get('length') +
+										selectedOptions <=
 										rightBoxMaxItems
 								) {
 									btnDisabledRight = false;
@@ -425,18 +438,20 @@ AUI.add(
 					);
 
 					instance._leftBox.after(
-						'valuechange',
-						A.bind('_toggleBtnSort', instance)
+						'change',
+						A.bind('_onChange', instance)
 					);
+
 					instance._leftBox.on(
 						'focus',
 						A.rbind('_onSelectFocus', instance, instance._rightBox)
 					);
 
 					instance._rightBox.after(
-						'valuechange',
-						A.bind('_toggleBtnSort', instance)
+						'change',
+						A.bind('_onChange', instance)
 					);
+
 					instance._rightBox.on(
 						'focus',
 						A.rbind('_onSelectFocus', instance, instance._leftBox)

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
@@ -25,7 +25,11 @@ AUI.add(
 
 		var InputMoveBoxes = A.Component.create({
 			ATTRS: {
+				leftBoxMaxItems: -1,
+
 				leftReorder: {},
+
+				rightBoxMaxItems: -1,
 
 				rightReorder: {},
 
@@ -272,6 +276,8 @@ AUI.add(
 					var instance = this;
 
 					var contentBox = instance.get('contentBox');
+					var leftBoxMaxItems = instance.get('leftBoxMaxItems');
+					var rightBoxMaxItems = instance.get('rightBoxMaxItems');
 
 					var moveBtnLeft = contentBox.one('.move-left');
 					var moveBtnRight = contentBox.one('.move-right');
@@ -283,11 +289,23 @@ AUI.add(
 						var btnDisabledRight = true;
 
 						if (target.get('length') > 0) {
-							if (target == instance._rightBox) {
-								btnDisabledLeft = false;
+							if (target === instance._rightBox) {
+								if (
+									leftBoxMaxItems === -1 ||
+									instance._leftBox.get('length') <
+										leftBoxMaxItems
+								) {
+									btnDisabledLeft = false;
+								}
 							}
-							else if (target == instance._leftBox) {
-								btnDisabledRight = false;
+							else if (target === instance._leftBox) {
+								if (
+									rightBoxMaxItems === -1 ||
+									instance._rightBox.get('length') <
+										rightBoxMaxItems
+								) {
+									btnDisabledRight = false;
+								}
 							}
 						}
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes.js
@@ -25,11 +25,11 @@ AUI.add(
 
 		var InputMoveBoxes = A.Component.create({
 			ATTRS: {
-				leftBoxMaxItems: -1,
+				leftBoxMaxItems: Infinity,
 
 				leftReorder: {},
 
-				rightBoxMaxItems: -1,
+				rightBoxMaxItems: Infinity,
 
 				rightReorder: {},
 
@@ -137,7 +137,7 @@ AUI.add(
 					});
 				},
 
-				_onChange(event) {
+				_onSelectChange(event) {
 					var instance = this;
 
 					instance._toggleBtnMove(event);
@@ -282,52 +282,28 @@ AUI.add(
 				_toggleBtnMove(event) {
 					var instance = this;
 
-					var contentBox = instance.get('contentBox');
-					var leftBoxMaxItems = instance.get('leftBoxMaxItems');
-					var rightBoxMaxItems = instance.get('rightBoxMaxItems');
+					var sourceBox = event.target;
 
-					var moveBtnLeft = contentBox.one('.move-left');
-					var moveBtnRight = contentBox.one('.move-right');
-
-					var target = event.target;
-					var selectedOptions = target
+					var selectedOptions = sourceBox
 						.get('options')
 						.getDOMNodes()
-						.filter((option) => option.selected).length;
+						.filter((option) => option.selected);
 
-					if (moveBtnLeft && moveBtnRight && target) {
-						var btnDisabledLeft = true;
-						var btnDisabledRight = true;
+					var direction =
+						sourceBox === instance._rightBox ? 'left' : 'right';
 
-						if (target.get('length') > 0) {
-							if (target === instance._rightBox) {
-								if (
-									leftBoxMaxItems === -1 ||
-									instance._leftBox.get('length') +
-										selectedOptions <=
-										leftBoxMaxItems
-								) {
-									btnDisabledLeft = false;
-								}
-							}
-							else if (target === instance._leftBox) {
-								if (
-									rightBoxMaxItems === -1 ||
-									instance._rightBox.get('length') +
-										selectedOptions <=
-										rightBoxMaxItems
-								) {
-									btnDisabledRight = false;
-								}
-							}
-						}
+					var destinationBox = instance[`_${direction}Box`];
+					var destinationBoxMaxItems = instance.get(
+						`${direction}BoxMaxItems`
+					);
 
-						instance._toggleBtnState(moveBtnLeft, btnDisabledLeft);
-						instance._toggleBtnState(
-							moveBtnRight,
-							btnDisabledRight
-						);
-					}
+					var contentBox = instance.get('contentBox');
+
+					instance._toggleBtnState(
+						contentBox.one(`.move-${direction}`),
+						destinationBox.get('length') + selectedOptions.length >
+							destinationBoxMaxItems
+					);
 				},
 
 				_toggleBtnSort(event) {
@@ -439,7 +415,7 @@ AUI.add(
 
 					instance._leftBox.after(
 						'change',
-						A.bind('_onChange', instance)
+						A.bind('_onSelectChange', instance)
 					);
 
 					instance._leftBox.on(
@@ -449,7 +425,7 @@ AUI.add(
 
 					instance._rightBox.after(
 						'change',
-						A.bind('_onChange', instance)
+						A.bind('_onSelectChange', instance)
 					);
 
 					instance._rightBox.on(

--- a/modules/apps/item-selector/item-selector-test/src/testFunctional/ItemSelector.testcase
+++ b/modules/apps/item-selector/item-selector-test/src/testFunctional/ItemSelector.testcase
@@ -96,9 +96,8 @@ definition {
 			backgroundImage = "Manual Selection",
 			entryTitle = "Document_1.svg",
 			navItem = "Documents and Media",
-			padding = "true",
-			panel = "Styles",
-			top = "2");
+			paddingTop = "2",
+			panel = "Styles");
 
 		PageEditor.clickPublish();
 
@@ -160,9 +159,8 @@ definition {
 			backgroundImage = "Manual Selection",
 			entryTitle = "Document_1.jpeg",
 			navItem = "Documents and Media",
-			padding = "true",
-			panel = "Styles",
-			top = "2");
+			paddingTop = "2",
+			panel = "Styles");
 
 		PageEditor.clickPublish();
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.js
@@ -38,9 +38,9 @@ export default function App({state}) {
 			<LanguageDirection />
 			<URLParser />
 			<ControlsProvider>
-				<Toolbar />
 				<DragAndDropContextProvider>
 					<DragPreview />
+					<Toolbar />
 					<LayoutViewport />
 					<Sidebar />
 				</DragAndDropContextProvider>

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -268,16 +268,19 @@ public class ConfigurationHandler {
 		if (code == -1) {
 			return null;
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_STRING) {
+
+		code = Character.toUpperCase(code);
+
+		if (code == _TOKEN_SIMPLE_STRING) {
 			return _readQuoted(pushbackReader);
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_INTEGER) {
+		else if (code == _TOKEN_SIMPLE_INTEGER) {
 			return Integer.valueOf(_readQuoted(pushbackReader));
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_LONG) {
+		else if (code == _TOKEN_SIMPLE_LONG) {
 			return Long.valueOf(_readQuoted(pushbackReader));
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_FLOAT) {
+		else if (code == _TOKEN_SIMPLE_FLOAT) {
 			String floatString = _readQuoted(pushbackReader);
 
 			if (floatString.indexOf(CharPool.PERIOD) >= 0) {
@@ -287,7 +290,7 @@ public class ConfigurationHandler {
 			return Float.intBitsToFloat(
 				GetterUtil.getIntegerStrict(floatString));
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_DOUBLE) {
+		else if (code == _TOKEN_SIMPLE_DOUBLE) {
 			String doubleString = _readQuoted(pushbackReader);
 
 			if (doubleString.indexOf(CharPool.PERIOD) >= 0) {
@@ -297,13 +300,13 @@ public class ConfigurationHandler {
 			return Double.longBitsToDouble(
 				GetterUtil.getLongStrict(doubleString));
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_BYTE) {
+		else if (code == _TOKEN_SIMPLE_BYTE) {
 			return Byte.valueOf(_readQuoted(pushbackReader));
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_SHORT) {
+		else if (code == _TOKEN_SIMPLE_SHORT) {
 			return Short.valueOf(_readQuoted(pushbackReader));
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_CHARACTER) {
+		else if (code == _TOKEN_SIMPLE_CHARACTER) {
 			String charString = _readQuoted(pushbackReader);
 
 			if ((charString != null) && (charString.length() > 0)) {
@@ -312,7 +315,7 @@ public class ConfigurationHandler {
 
 			return null;
 		}
-		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_BOOLEAN) {
+		else if (code == _TOKEN_SIMPLE_BOOLEAN) {
 			return Boolean.valueOf(_readQuoted(pushbackReader));
 		}
 		else {

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -19,6 +19,7 @@ import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.io.IOException;
 import java.io.PushbackReader;
@@ -261,30 +262,22 @@ public class ConfigurationHandler {
 		}
 	}
 
-	// simple types (string & primitive wrappers)
-
 	private static Object _readSimple(int code, PushbackReader pushbackReader)
 		throws IOException {
 
 		if (code == -1) {
 			return null;
 		}
-		else if (code == _TOKEN_SIMPLE_STRING) {
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_STRING) {
 			return _readQuoted(pushbackReader);
 		}
-		else if ((code == _TOKEN_SIMPLE_INTEGER) ||
-				 (code == _TOKEN_PRIMITIVE_INT)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_INTEGER) {
 			return Integer.valueOf(_readQuoted(pushbackReader));
 		}
-		else if ((code == _TOKEN_SIMPLE_LONG) ||
-				 (code == _TOKEN_PRIMITIVE_LONG)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_LONG) {
 			return Long.valueOf(_readQuoted(pushbackReader));
 		}
-		else if ((code == _TOKEN_SIMPLE_FLOAT) ||
-				 (code == _TOKEN_PRIMITIVE_FLOAT)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_FLOAT) {
 			String floatString = _readQuoted(pushbackReader);
 
 			if (floatString.indexOf(CharPool.PERIOD) >= 0) {
@@ -294,9 +287,7 @@ public class ConfigurationHandler {
 			return Float.intBitsToFloat(
 				GetterUtil.getIntegerStrict(floatString));
 		}
-		else if ((code == _TOKEN_SIMPLE_DOUBLE) ||
-				 (code == _TOKEN_PRIMITIVE_DOUBLE)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_DOUBLE) {
 			String doubleString = _readQuoted(pushbackReader);
 
 			if (doubleString.indexOf(CharPool.PERIOD) >= 0) {
@@ -306,19 +297,13 @@ public class ConfigurationHandler {
 			return Double.longBitsToDouble(
 				GetterUtil.getLongStrict(doubleString));
 		}
-		else if ((code == _TOKEN_SIMPLE_BYTE) ||
-				 (code == _TOKEN_PRIMITIVE_BYTE)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_BYTE) {
 			return Byte.valueOf(_readQuoted(pushbackReader));
 		}
-		else if ((code == _TOKEN_SIMPLE_SHORT) ||
-				 (code == _TOKEN_PRIMITIVE_SHORT)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_SHORT) {
 			return Short.valueOf(_readQuoted(pushbackReader));
 		}
-		else if ((code == _TOKEN_SIMPLE_CHARACTER) ||
-				 (code == _TOKEN_PRIMITIVE_CHAR)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_CHARACTER) {
 			String charString = _readQuoted(pushbackReader);
 
 			if ((charString != null) && (charString.length() > 0)) {
@@ -327,9 +312,7 @@ public class ConfigurationHandler {
 
 			return null;
 		}
-		else if ((code == _TOKEN_SIMPLE_BOOLEAN) ||
-				 (code == _TOKEN_PRIMITIVE_BOOLEAN)) {
-
+		else if (Character.toUpperCase(code) == _TOKEN_SIMPLE_BOOLEAN) {
 			return Boolean.valueOf(_readQuoted(pushbackReader));
 		}
 		else {
@@ -348,7 +331,7 @@ public class ConfigurationHandler {
 
 		int code = type;
 
-		if (_codeToType.containsKey(type)) {
+		if (_codeToType.containsKey(Character.toUpperCase(type))) {
 			code = _read(pushbackReader);
 		}
 		else {
@@ -482,8 +465,6 @@ public class ConfigurationHandler {
 		}
 	}
 
-	// primitives
-
 	private static void _writeSimple(Writer writer, Object value)
 		throws IOException {
 
@@ -537,27 +518,6 @@ public class ConfigurationHandler {
 
 	private static final int _TOKEN_EQ = '=';
 
-	private static final int _TOKEN_PRIMITIVE_BOOLEAN = 'b';
-
-	private static final int _TOKEN_PRIMITIVE_BYTE = 'x';
-
-	// private constructor, this class is not to be instantiated from the
-	// outside
-
-	private static final int _TOKEN_PRIMITIVE_CHAR = 'c';
-
-	// ---------- Configuration Input Implementation ---------------------------
-
-	private static final int _TOKEN_PRIMITIVE_DOUBLE = 'd';
-
-	private static final int _TOKEN_PRIMITIVE_FLOAT = 'f';
-
-	private static final int _TOKEN_PRIMITIVE_INT = 'i';
-
-	private static final int _TOKEN_PRIMITIVE_LONG = 'l';
-
-	private static final int _TOKEN_PRIMITIVE_SHORT = 's';
-
 	private static final int _TOKEN_SIMPLE_BOOLEAN = 'B';
 
 	private static final int _TOKEN_SIMPLE_BYTE = 'X';
@@ -582,36 +542,27 @@ public class ConfigurationHandler {
 
 	private static final int _TOKEN_VEC_CLOS = ')';
 
-	// ---------- Configuration Output Implementation --------------------------
-
 	private static final int _TOKEN_VEC_OPEN = '(';
 
 	private static final Map<Object, Object> _codeToType = new HashMap<>();
-
 	private static final Map<Object, Object> _typeToCode =
-		new HashMap<Object, Object>() {
-			{
-				put(Boolean.class, _TOKEN_SIMPLE_BOOLEAN);
-				put(Byte.class, _TOKEN_SIMPLE_BYTE);
-				put(Character.class, _TOKEN_SIMPLE_CHARACTER);
-				put(Double.class, _TOKEN_SIMPLE_DOUBLE);
-				put(Float.class, _TOKEN_SIMPLE_FLOAT);
-				put(Integer.class, _TOKEN_SIMPLE_INTEGER);
-				put(Long.class, _TOKEN_SIMPLE_LONG);
-				put(Short.class, _TOKEN_SIMPLE_SHORT);
-
-				// primitives
-
-				put(Boolean.TYPE, _TOKEN_PRIMITIVE_BOOLEAN);
-				put(Byte.TYPE, _TOKEN_PRIMITIVE_BYTE);
-				put(Character.TYPE, _TOKEN_PRIMITIVE_CHAR);
-				put(Double.TYPE, _TOKEN_PRIMITIVE_DOUBLE);
-				put(Float.TYPE, _TOKEN_PRIMITIVE_FLOAT);
-				put(Integer.TYPE, _TOKEN_PRIMITIVE_INT);
-				put(Long.TYPE, _TOKEN_PRIMITIVE_LONG);
-				put(Short.TYPE, _TOKEN_PRIMITIVE_SHORT);
-			}
-		};
+		HashMapBuilder.<Object, Object>put(
+			Boolean.class, _TOKEN_SIMPLE_BOOLEAN
+		).put(
+			Byte.class, _TOKEN_SIMPLE_BYTE
+		).put(
+			Character.class, _TOKEN_SIMPLE_CHARACTER
+		).put(
+			Double.class, _TOKEN_SIMPLE_DOUBLE
+		).put(
+			Float.class, _TOKEN_SIMPLE_FLOAT
+		).put(
+			Integer.class, _TOKEN_SIMPLE_INTEGER
+		).put(
+			Long.class, _TOKEN_SIMPLE_LONG
+		).put(
+			Short.class, _TOKEN_SIMPLE_SHORT
+		).build();
 
 	static {
 		for (Map.Entry<Object, Object> entry : _typeToCode.entrySet()) {

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -420,7 +420,7 @@ public class ConfigurationHandler {
 	private static void _writeQuoted(Writer writer, String simple)
 		throws IOException {
 
-		if ((simple == null) || (simple.length() == 0)) {
+		if (simple.isEmpty()) {
 			return;
 		}
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -482,7 +482,7 @@ public class ConfigurationHandler {
 	private static void _writeType(Writer writer, Class<?> valueType)
 		throws IOException {
 
-		Integer code = (Integer)_typeToCode.get(valueType);
+		Integer code = _typeToCode.get(valueType);
 
 		if (code != null) {
 			writer.write((char)code.intValue());
@@ -532,9 +532,9 @@ public class ConfigurationHandler {
 
 	private static final int _TOKEN_VAL_OPEN = '"'; // '{';
 
-	private static final Map<Object, Class<?>> _codeToType = new HashMap<>();
-	private static final Map<Class<?>, Object> _typeToCode =
-		HashMapBuilder.<Class<?>, Object>put(
+	private static final Map<Integer, Class<?>> _codeToType = new HashMap<>();
+	private static final Map<Class<?>, Integer> _typeToCode =
+		HashMapBuilder.<Class<?>, Integer>put(
 			Boolean.class, _TOKEN_SIMPLE_BOOLEAN
 		).put(
 			Byte.class, _TOKEN_SIMPLE_BYTE
@@ -553,7 +553,7 @@ public class ConfigurationHandler {
 		).build();
 
 	static {
-		for (Map.Entry<Class<?>, Object> entry : _typeToCode.entrySet()) {
+		for (Map.Entry<Class<?>, Integer> entry : _typeToCode.entrySet()) {
 			_codeToType.put(entry.getValue(), entry.getKey());
 		}
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -70,7 +70,7 @@ public class ConfigurationHandler {
 
 			int c2 = pushbackReader.read();
 
-			if ((c2 == CharPool.RETURN) || (c2 == CharPool.NEW_LINE)) {
+			if ((c2 == CharPool.NEW_LINE) || (c2 == CharPool.RETURN)) {
 				c1 = _ignorableWhiteSpace(pushbackReader);
 			}
 			else {

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -155,7 +155,7 @@ public class ConfigurationHandler {
 			}
 
 			if (spaces == CharPool.CLOSE_BRACKET) {
-				Class<?> type = (Class)_codeToType.get(typeCode);
+				Class<?> type = _codeToType.get(typeCode);
 
 				Object array = Array.newInstance(type, list.size());
 
@@ -529,9 +529,9 @@ public class ConfigurationHandler {
 
 	private static final int _TOKEN_VAL_OPEN = '"'; // '{';
 
-	private static final Map<Object, Object> _codeToType = new HashMap<>();
-	private static final Map<Object, Object> _typeToCode =
-		HashMapBuilder.<Object, Object>put(
+	private static final Map<Object, Class<?>> _codeToType = new HashMap<>();
+	private static final Map<Class<?>, Object> _typeToCode =
+		HashMapBuilder.<Class<?>, Object>put(
 			Boolean.class, _TOKEN_SIMPLE_BOOLEAN
 		).put(
 			Byte.class, _TOKEN_SIMPLE_BYTE
@@ -550,7 +550,7 @@ public class ConfigurationHandler {
 		).build();
 
 	static {
-		for (Map.Entry<Object, Object> entry : _typeToCode.entrySet()) {
+		for (Map.Entry<Class<?>, Object> entry : _typeToCode.entrySet()) {
 			_codeToType.put(entry.getValue(), entry.getKey());
 		}
 

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -307,7 +307,7 @@ public class ConfigurationHandler {
 			String charString = _readQuoted(pushbackReader);
 
 			if ((charString != null) && (charString.length() > 0)) {
-				return Character.valueOf(charString.charAt(0));
+				return charString.charAt(0);
 			}
 
 			return null;

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandler.java
@@ -64,13 +64,13 @@ public class ConfigurationHandler {
 		int c1 = _ignorableWhiteSpace(pushbackReader);
 
 		while (true) {
-			if (c1 != '\\') {
+			if (c1 != CharPool.BACK_SLASH) {
 				break;
 			}
 
 			int c2 = pushbackReader.read();
 
-			if ((c2 == '\r') || (c2 == '\n')) {
+			if ((c2 == CharPool.RETURN) || (c2 == CharPool.NEW_LINE)) {
 				c1 = _ignorableWhiteSpace(pushbackReader);
 			}
 			else {
@@ -98,14 +98,14 @@ public class ConfigurationHandler {
 	private static int _read(PushbackReader pushbackReader) throws IOException {
 		int c = pushbackReader.read();
 
-		if (c == '\r') {
+		if (c == CharPool.RETURN) {
 			int c1 = pushbackReader.read();
 
-			if (c1 != '\n') {
+			if (c1 != CharPool.NEW_LINE) {
 				pushbackReader.unread(c1);
 			}
 
-			c = '\n';
+			c = CharPool.NEW_LINE;
 		}
 
 		return c;
@@ -154,7 +154,7 @@ public class ConfigurationHandler {
 				spaces = _ignorablePageBreakAndWhiteSpace(pushbackReader);
 			}
 
-			if (spaces == _TOKEN_ARR_CLOS) {
+			if (spaces == CharPool.CLOSE_BRACKET) {
 				Class<?> type = (Class)_codeToType.get(typeCode);
 
 				Object array = Array.newInstance(type, list.size());
@@ -168,7 +168,7 @@ public class ConfigurationHandler {
 			else if (spaces < 0) {
 				return null;
 			}
-			else if (spaces != _TOKEN_COMMA) {
+			else if (spaces != CharPool.COMMA) {
 				return null;
 			}
 		}
@@ -200,13 +200,13 @@ public class ConfigurationHandler {
 				spaces = _ignorablePageBreakAndWhiteSpace(pushbackReader);
 			}
 
-			if (spaces == _TOKEN_VEC_CLOS) {
+			if (spaces == CharPool.CLOSE_PARENTHESIS) {
 				return collection;
 			}
 			else if (spaces < 0) {
 				return null;
 			}
-			else if (spaces != _TOKEN_COMMA) {
+			else if (spaces != CharPool.COMMA) {
 				return null;
 			}
 		}
@@ -220,23 +220,23 @@ public class ConfigurationHandler {
 		while (true) {
 			int c = _read(pushbackReader);
 
-			if (c == '\\') {
+			if (c == CharPool.BACK_SLASH) {
 				c = _read(pushbackReader);
 
 				if (c == 'b') {
 					sb.append('\b');
 				}
 				else if (c == 't') {
-					sb.append('\t');
+					sb.append(CharPool.TAB);
 				}
 				else if (c == 'n') {
-					sb.append('\n');
+					sb.append(CharPool.NEW_LINE);
 				}
 				else if (c == 'f') {
 					sb.append('\f');
 				}
 				else if (c == 'r') {
-					sb.append('\r');
+					sb.append(CharPool.RETURN);
 				}
 				else if (c == 'u') {
 					char[] charBuffer = new char[4];
@@ -338,10 +338,10 @@ public class ConfigurationHandler {
 			type = _TOKEN_SIMPLE_STRING;
 		}
 
-		if (code == _TOKEN_ARR_OPEN) {
+		if (code == CharPool.OPEN_BRACKET) {
 			return _readArray(type, pushbackReader);
 		}
-		else if (code == _TOKEN_VEC_OPEN) {
+		else if (code == CharPool.OPEN_PARENTHESIS) {
 			return _readCollection(type, pushbackReader);
 		}
 		else if (code == _TOKEN_VAL_OPEN) {
@@ -365,7 +365,7 @@ public class ConfigurationHandler {
 
 		_writeType(writer, clazz.getComponentType());
 
-		writer.write(_TOKEN_ARR_OPEN);
+		writer.write(CharPool.OPEN_BRACKET);
 
 		writer.write(_COLLECTION_LINE_BREAK);
 
@@ -374,7 +374,7 @@ public class ConfigurationHandler {
 		}
 
 		writer.write(_INDENT);
-		writer.write(_TOKEN_ARR_CLOS);
+		writer.write(CharPool.CLOSE_BRACKET);
 	}
 
 	private static void _writeCollection(
@@ -382,9 +382,9 @@ public class ConfigurationHandler {
 		throws IOException {
 
 		if (collection.isEmpty()) {
-			writer.write(_TOKEN_VEC_OPEN);
+			writer.write(CharPool.OPEN_PARENTHESIS);
 			writer.write(_COLLECTION_LINE_BREAK);
-			writer.write(_TOKEN_VEC_CLOS);
+			writer.write(CharPool.CLOSE_PARENTHESIS);
 		}
 		else {
 			Iterator<?> iterator = collection.iterator();
@@ -393,7 +393,7 @@ public class ConfigurationHandler {
 
 			_writeType(writer, firstElement.getClass());
 
-			writer.write(_TOKEN_VEC_OPEN);
+			writer.write(CharPool.OPEN_PARENTHESIS);
 			writer.write(_COLLECTION_LINE_BREAK);
 
 			_writeCollectionElement(writer, firstElement);
@@ -402,7 +402,7 @@ public class ConfigurationHandler {
 				_writeCollectionElement(writer, iterator.next());
 			}
 
-			writer.write(_TOKEN_VEC_CLOS);
+			writer.write(CharPool.CLOSE_PARENTHESIS);
 		}
 	}
 
@@ -413,7 +413,7 @@ public class ConfigurationHandler {
 
 		_writeSimple(writer, element);
 
-		writer.write(_TOKEN_COMMA);
+		writer.write(CharPool.COMMA);
 		writer.write(_COLLECTION_LINE_BREAK);
 	}
 
@@ -432,25 +432,26 @@ public class ConfigurationHandler {
 			c = simple.charAt(i);
 
 			if ((c == '\\') || (c == _TOKEN_VAL_CLOS) ||
-				(c == CharPool.SPACE) || (c == _TOKEN_EQ) ||
-				(c == _TOKEN_BRACE_OPEN) || (c == _TOKEN_BRACE_CLOS)) {
+				(c == CharPool.SPACE) || (c == CharPool.EQUAL) ||
+				(c == CharPool.OPEN_CURLY_BRACE) ||
+				(c == CharPool.CLOSE_CURLY_BRACE)) {
 
-				writer.write('\\');
+				writer.write(CharPool.BACK_SLASH);
 				writer.write(c);
 			}
 			else if (c == '\b') {
 				writer.write("\\b");
 			}
-			else if (c == '\t') {
+			else if (c == CharPool.TAB) {
 				writer.write("\\t");
 			}
-			else if (c == '\n') {
+			else if (c == CharPool.NEW_LINE) {
 				writer.write("\\n");
 			}
 			else if (c == '\f') {
 				writer.write("\\f");
 			}
-			else if (c == '\r') {
+			else if (c == CharPool.RETURN) {
 				writer.write("\\r");
 			}
 			else if (c < CharPool.SPACE) {
@@ -506,18 +507,6 @@ public class ConfigurationHandler {
 
 	private static final String _INDENT = "  ";
 
-	private static final int _TOKEN_ARR_CLOS = ']';
-
-	private static final int _TOKEN_ARR_OPEN = '[';
-
-	private static final int _TOKEN_BRACE_CLOS = '}';
-
-	private static final int _TOKEN_BRACE_OPEN = '{';
-
-	private static final int _TOKEN_COMMA = ',';
-
-	private static final int _TOKEN_EQ = '=';
-
 	private static final int _TOKEN_SIMPLE_BOOLEAN = 'B';
 
 	private static final int _TOKEN_SIMPLE_BYTE = 'X';
@@ -539,10 +528,6 @@ public class ConfigurationHandler {
 	private static final int _TOKEN_VAL_CLOS = '"'; // '}';
 
 	private static final int _TOKEN_VAL_OPEN = '"'; // '{';
-
-	private static final int _TOKEN_VEC_CLOS = ')';
-
-	private static final int _TOKEN_VEC_OPEN = '(';
 
 	private static final Map<Object, Object> _codeToType = new HashMap<>();
 	private static final Map<Object, Object> _typeToCode =

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/test/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandlerTest.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/test/java/com/liferay/portal/file/install/internal/properties/ConfigurationHandlerTest.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.file.install.internal.properties;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Matthew Tambara
+ */
+public class ConfigurationHandlerTest {
+
+	@Test
+	public void testReadArray() throws IOException {
+		Assert.assertArrayEquals(
+			new String[] {"test1", "test2"},
+			(String[])ConfigurationHandler.read(
+				"[ \\\r\n  \"test1\", \\\r\n  \"test2\", \\\r\n  ]"));
+	}
+
+	@Test
+	public void testReadArrayNoLineBreaks() throws IOException {
+		Assert.assertArrayEquals(
+			new String[] {"test1", "test2"},
+			(String[])ConfigurationHandler.read("[\"test1\", \"test2\"]"));
+	}
+
+	@Test
+	public void testReadBoolean() throws IOException {
+		Assert.assertEquals(true, ConfigurationHandler.read("B\"true\""));
+		Assert.assertEquals(true, ConfigurationHandler.read("b\"true\""));
+	}
+
+	@Test
+	public void testReadByte() throws IOException {
+		Assert.assertEquals((byte)1, ConfigurationHandler.read("X\"1\""));
+		Assert.assertEquals((byte)1, ConfigurationHandler.read("x\"1\""));
+	}
+
+	@Test
+	public void testReadChar() throws IOException {
+		Assert.assertEquals('A', ConfigurationHandler.read("C\"A\""));
+		Assert.assertEquals('A', ConfigurationHandler.read("c\"A\""));
+	}
+
+	@Test
+	public void testReadCollection() throws IOException {
+		Assert.assertEquals(
+			new ArrayList<String>() {
+				{
+					add("test1");
+					add("test2");
+				}
+			},
+			ConfigurationHandler.read(
+				"( \\\r\n  \"test1\", \\\r\n  \"test2\", \\\r\n)"));
+	}
+
+	@Test
+	public void testReadCollectionNoLineBreaks() throws IOException {
+		Assert.assertEquals(
+			new ArrayList<String>() {
+				{
+					add("test1");
+					add("test2");
+				}
+			},
+			ConfigurationHandler.read("(\"test1\", \"test2\",)"));
+	}
+
+	@Test
+	public void testReadDouble() throws IOException {
+		Assert.assertEquals(12.2D, ConfigurationHandler.read("D\"12.2\""));
+		Assert.assertEquals(12.2D, ConfigurationHandler.read("d\"12.2\""));
+		Assert.assertEquals(
+			12.2D, ConfigurationHandler.read("D\"4623057607486498406\""));
+	}
+
+	@Test
+	public void testReadEmptyCollection() throws IOException {
+		Assert.assertEquals(
+			new ArrayList<String>(), ConfigurationHandler.read("( \\\r\n)"));
+	}
+
+	@Test
+	public void testReadFloat() throws IOException {
+		Assert.assertEquals(12.2F, ConfigurationHandler.read("F\"12.2\""));
+		Assert.assertEquals(12.2F, ConfigurationHandler.read("f\"12.2\""));
+		Assert.assertEquals(
+			12.2F, ConfigurationHandler.read("F\"1094923059\""));
+	}
+
+	@Test
+	public void testReadInteger() throws IOException {
+		Assert.assertEquals(20, ConfigurationHandler.read("I\"20\""));
+		Assert.assertEquals(20, ConfigurationHandler.read("i\"20\""));
+	}
+
+	@Test
+	public void testReadInvalidCollection() throws IOException {
+		Assert.assertEquals(null, ConfigurationHandler.read("(test)"));
+	}
+
+	@Test
+	public void testReadInvalidType() throws IOException {
+		Assert.assertEquals(null, ConfigurationHandler.read("Z\"test\""));
+	}
+
+	@Test
+	public void testReadLong() throws IOException {
+		Assert.assertEquals(30L, ConfigurationHandler.read("L\"30\""));
+		Assert.assertEquals(30L, ConfigurationHandler.read("l\"30\""));
+	}
+
+	@Test
+	public void testReadShort() throws IOException {
+		Assert.assertEquals((short)2, ConfigurationHandler.read("S\"2\""));
+		Assert.assertEquals((short)2, ConfigurationHandler.read("s\"2\""));
+	}
+
+	@Test
+	public void testReadSimpleString() throws IOException {
+		Assert.assertEquals("test", ConfigurationHandler.read("\"test\""));
+	}
+
+	@Test
+	public void testReadSpecial() throws IOException {
+		Assert.assertEquals(
+			"\b\t\n\f\r+a",
+			ConfigurationHandler.read("\"\\b\\t\\n\\f\\r\\u002B\\a\""));
+	}
+
+	@Test
+	public void testReadString() throws IOException {
+		Assert.assertEquals("test", ConfigurationHandler.read("T\"test\""));
+	}
+
+	@Test
+	public void testReadStringWithWhitespace() throws IOException {
+		Assert.assertEquals(
+			"test", ConfigurationHandler.read(" \r\n\r\"test\""));
+	}
+
+	@Test
+	public void testReadTypedArray() throws IOException {
+		Assert.assertArrayEquals(
+			new Integer[] {1, 2},
+			(Integer[])ConfigurationHandler.read(
+				"I[ \\\r\n  \"1\", \\\r\n  \"2\", \\\r\n  ]"));
+	}
+
+	@Test
+	public void testReadTypedCollection() throws IOException {
+		Assert.assertEquals(
+			new ArrayList<Integer>() {
+				{
+					add(1);
+					add(2);
+				}
+			},
+			ConfigurationHandler.read(
+				"I( \\\r\n  \"1\", \\\r\n  \"2\", \\\r\n)"));
+	}
+
+	@Test
+	public void testWriteArray() throws IOException {
+		Assert.assertEquals(
+			"[ \\\r\n  \"test1\", \\\r\n  \"test2\", \\\r\n  ]",
+			ConfigurationHandler.write(new String[] {"test1", "test2"}));
+	}
+
+	@Test
+	public void testWriteBlank() throws IOException {
+		Assert.assertEquals(
+			"\"\"", ConfigurationHandler.write(StringPool.BLANK));
+	}
+
+	@Test
+	public void testWriteBoolean() throws IOException {
+		Assert.assertEquals("B\"true\"", ConfigurationHandler.write(true));
+	}
+
+	@Test
+	public void testWriteByte() throws IOException {
+		Assert.assertEquals(
+			"X\"1\"", ConfigurationHandler.write(Byte.valueOf("1")));
+	}
+
+	@Test
+	public void testWriteChar() throws IOException {
+		Assert.assertEquals("C\"A\"", ConfigurationHandler.write('A'));
+	}
+
+	@Test
+	public void testWriteCollection() throws IOException {
+		Assert.assertEquals(
+			"( \\\r\n  \"test1\", \\\r\n  \"test2\", \\\r\n)",
+			ConfigurationHandler.write(
+				new ArrayList<String>() {
+					{
+						add("test1");
+						add("test2");
+					}
+				}));
+	}
+
+	@Test
+	public void testWriteDouble() throws IOException {
+		Assert.assertEquals("D\"12.2\"", ConfigurationHandler.write(12.2D));
+	}
+
+	@Test
+	public void testWriteEmptyArray() throws IOException {
+		Assert.assertEquals(
+			"[ \\\r\n  ]", ConfigurationHandler.write(new String[0]));
+	}
+
+	@Test
+	public void testWriteEmptyCollection() throws IOException {
+		Assert.assertEquals(
+			"( \\\r\n)", ConfigurationHandler.write(new ArrayList()));
+	}
+
+	@Test
+	public void testWriteEscaped() throws IOException {
+		Assert.assertEquals(
+			"\"\\{\"", ConfigurationHandler.write(StringPool.OPEN_CURLY_BRACE));
+		Assert.assertEquals(
+			"\"\\\\\"", ConfigurationHandler.write(StringPool.BACK_SLASH));
+		Assert.assertEquals(
+			"\"\\=\"", ConfigurationHandler.write(StringPool.EQUAL));
+		Assert.assertEquals(
+			"\"\\\"\"", ConfigurationHandler.write(StringPool.QUOTE));
+		Assert.assertEquals(
+			"\"\\ \"", ConfigurationHandler.write(StringPool.SPACE));
+		Assert.assertEquals(
+			"\"\\}\"",
+			ConfigurationHandler.write(StringPool.CLOSE_CURLY_BRACE));
+		Assert.assertEquals("\"\\b\"", ConfigurationHandler.write("\b"));
+		Assert.assertEquals(
+			"\"\\t\"", ConfigurationHandler.write(StringPool.TAB));
+		Assert.assertEquals(
+			"\"\\n\"", ConfigurationHandler.write(StringPool.NEW_LINE));
+		Assert.assertEquals("\"\\f\"", ConfigurationHandler.write("\f"));
+		Assert.assertEquals(
+			"\"\\r\"", ConfigurationHandler.write(StringPool.RETURN));
+
+		char c = CharPool.SPACE - 1;
+
+		Assert.assertEquals("C\"\\u001f\"", ConfigurationHandler.write(c));
+	}
+
+	@Test
+	public void testWriteFloat() throws IOException {
+		Assert.assertEquals("F\"12.2\"", ConfigurationHandler.write(12.2F));
+	}
+
+	@Test
+	public void testWriteInteger() throws IOException {
+		Assert.assertEquals("I\"20\"", ConfigurationHandler.write(20));
+	}
+
+	@Test
+	public void testWriteLong() throws IOException {
+		Assert.assertEquals("L\"30\"", ConfigurationHandler.write(30L));
+	}
+
+	@Test
+	public void testWriteObject() throws IOException {
+		Assert.assertEquals(
+			"\"testValue\"",
+			ConfigurationHandler.write(
+				new Object() {
+
+					@Override
+					public String toString() {
+						return "testValue";
+					}
+
+				}));
+	}
+
+	@Test
+	public void testWriteShort() throws IOException {
+		Assert.assertEquals("S\"2\"", ConfigurationHandler.write((short)2));
+	}
+
+	@Test
+	public void testWriteString() throws IOException {
+		Assert.assertEquals("\"test\"", ConfigurationHandler.write("test"));
+	}
+
+	@Test
+	public void testWriteTypedArray() throws IOException {
+		Assert.assertEquals(
+			"B[ \\\r\n  \"true\", \\\r\n  ]",
+			ConfigurationHandler.write(new Boolean[] {true}));
+	}
+
+	@Test
+	public void testWriteTypedCollection() throws IOException {
+		Assert.assertEquals(
+			"I( \\\r\n  \"1\", \\\r\n  \"2\", \\\r\n)",
+			ConfigurationHandler.write(
+				new ArrayList<Integer>() {
+					{
+						add(1);
+						add(2);
+					}
+				}));
+	}
+
+}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/TrafficSources.js
@@ -125,9 +125,7 @@ export default function TrafficSources({
 												)
 											}
 										>
-											{!entry.countryKeywords.length ? (
-												<span>{entry.title}</span>
-											) : (
+											{entry.value > 0 ? (
 												<ClayButton
 													className="font-weight-semi-bold px-0 py-1 text-primary"
 													displayType="link"
@@ -140,6 +138,8 @@ export default function TrafficSources({
 												>
 													{entry.title}
 												</ClayButton>
+											) : (
+												<span>{entry.title}</span>
 											)}
 										</td>
 										<td className="text-secondary">

--- a/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/test/js/components/TrafficSources.js
@@ -18,7 +18,7 @@ import TrafficSources from '../../../src/main/resources/META-INF/resources/js/co
 describe('TrafficSources', () => {
 	afterEach(cleanup);
 
-	it('displays the sources according to API', () => {
+	it('displays the traffic sources with buttons to view keywords', () => {
 		const mockTrafficSources = [
 			{
 				countryKeywords: [
@@ -68,11 +68,147 @@ describe('TrafficSources', () => {
 			/>
 		);
 
-		expect(getByText('Testing')).toBeInTheDocument();
+		const button1 = getByText('Testing');
+
+		expect(button1).toBeInTheDocument();
+		expect(button1).not.toBeDisabled();
+		expect(button1).toHaveAttribute('type', 'button');
 		expect(getByText('32,178')).toBeInTheDocument();
 
-		expect(getByText('Second Testing')).toBeInTheDocument();
+		const button2 = getByText('Second Testing');
+
+		expect(button2).toBeInTheDocument();
+		expect(button2).not.toBeDisabled();
+		expect(button2).toHaveAttribute('type', 'button');
 		expect(getByText('278,256')).toBeInTheDocument();
+	});
+
+	it('displays the traffic sources without buttons to view keywords when the value is 0', () => {
+		const mockTrafficSources = [
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Testing Help Message',
+				name: 'testing',
+				share: 0,
+				title: 'Testing',
+				value: 0,
+			},
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Second Testing Help Message',
+				name: 'second-testing',
+				share: 0,
+				title: 'Second Testing',
+				value: 0,
+			},
+		];
+
+		const {getAllByText, getByText} = render(
+			<TrafficSources
+				languageTag="en-US"
+				onTrafficSourceClick={() => {}}
+				trafficSources={mockTrafficSources}
+			/>
+		);
+
+		const text1 = getByText('Testing');
+
+		expect(text1).toBeInTheDocument();
+		expect(text1).not.toHaveAttribute('type', 'button');
+
+		const text2 = getByText('Second Testing');
+
+		expect(text2).toBeInTheDocument();
+		expect(text2).not.toHaveAttribute('type', 'button');
+
+		const zeroValues = getAllByText('0');
+
+		expect(zeroValues.length).toBe(2);
+	});
+
+	it('displays the traffic sources without buttons to view keywords when the value is missing', () => {
+		const mockTrafficSources = [
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Testing Help Message',
+				name: 'testing',
+				share: 0,
+				title: 'Testing',
+			},
+			{
+				countryKeywords: [
+					{
+						countryCode: 'us',
+						countryName: 'United States',
+						keywords: [],
+					},
+					{
+						countryCode: 'es',
+						countryName: 'Spain',
+						keywords: [],
+					},
+				],
+				helpMessage: 'Second Testing Help Message',
+				name: 'second-testing',
+				share: 0,
+				title: 'Second Testing',
+			},
+		];
+
+		const {getAllByText, getByText} = render(
+			<TrafficSources
+				languageTag="en-US"
+				onTrafficSourceClick={() => {}}
+				trafficSources={mockTrafficSources}
+			/>
+		);
+
+		const text1 = getByText('Testing');
+
+		expect(text1).toBeInTheDocument();
+		expect(text1).not.toHaveAttribute('type', 'button');
+
+		const text2 = getByText('Second Testing');
+
+		expect(text2).toBeInTheDocument();
+		expect(text2).not.toHaveAttribute('type', 'button');
+
+		const dashValues = getAllByText('-');
+
+		expect(dashValues.length).toBe(2);
 	});
 
 	it('displays a dash instead of value when the value is missing', () => {

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -21,6 +21,9 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_input_
 
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-move-boxes:cssClass"));
 
+int leftBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems"));
+int rightBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems"));
+
 String leftTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:leftTitle"));
 String rightTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:rightTitle"));
 
@@ -87,6 +90,8 @@ Map<String, Object> data = new HashMap<String, Object>();
 	new Liferay.InputMoveBoxes(
 		{
 			contentBox: '#<%= randomNamespace + "input-move-boxes" %>',
+			leftBoxMaxItems: <%= leftBoxMaxItems %>,
+			rightBoxMaxItems: <%= rightBoxMaxItems %>,
 			strings: {
 				LEFT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-down", leftTitle, false) %>',
 				LEFT_MOVE_UP: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-up", leftTitle, false) %>',

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -25,7 +25,7 @@ String leftTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute
 String rightTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:rightTitle"));
 
 Integer leftBoxMaxItems = (Integer)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems");
-Integer rightBoxMaxItems =(Integer)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems");
+Integer rightBoxMaxItems = (Integer)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems");
 
 String leftBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxName");
 String rightBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxName");

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -21,11 +21,11 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_input_
 
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-move-boxes:cssClass"));
 
-int leftBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems"));
-int rightBoxMaxItems = GetterUtil.getInteger((String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems"));
-
 String leftTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:leftTitle"));
 String rightTitle = LanguageUtil.get(resourceBundle, (String)request.getAttribute("liferay-ui:input-move-boxes:rightTitle"));
+
+Integer leftBoxMaxItems = (Integer)request.getAttribute("liferay-ui:input-move-boxes:leftBoxMaxItems");
+Integer rightBoxMaxItems =(Integer)request.getAttribute("liferay-ui:input-move-boxes:rightBoxMaxItems");
 
 String leftBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:leftBoxName");
 String rightBoxName = (String)request.getAttribute("liferay-ui:input-move-boxes:rightBoxName");
@@ -90,8 +90,15 @@ Map<String, Object> data = new HashMap<String, Object>();
 	new Liferay.InputMoveBoxes(
 		{
 			contentBox: '#<%= randomNamespace + "input-move-boxes" %>',
-			leftBoxMaxItems: <%= leftBoxMaxItems %>,
-			rightBoxMaxItems: <%= rightBoxMaxItems %>,
+
+			<c:if test="<%= leftBoxMaxItems != null %>">
+				leftBoxMaxItems: <%= leftBoxMaxItems %>,
+			</c:if>
+
+			<c:if test="<%= rightBoxMaxItems != null %>">
+				rightBoxMaxItems: <%= rightBoxMaxItems %>,
+			</c:if>
+
 			strings: {
 				LEFT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-down", leftTitle, false) %>',
 				LEFT_MOVE_UP: '<%= UnicodeLanguageUtil.format(request, "move-selected-item-in-x-one-position-up", leftTitle, false) %>',

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
@@ -998,6 +998,40 @@ definition {
 				Pause(locator1 = "3000");
 			}
 
+			if (isSet(borderColor)) {
+				Click(
+					key_borderBottom = "Border Color",
+					key_paletteItem = "${borderColor}",
+					locator1 = "Button#BORDER_BOTTOM_PALETTE_ITEM");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(borderRadius)) {
+				Select(
+					key_fieldLabel = "Border Radius",
+					locator1 = "Select#GENERIC_SELECT_FIELD",
+					value1 = "${borderRadius}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(borderWidth)) {
+				Type(
+					key_fieldLabel = "Border Width",
+					locator1 = "FormFields#NUMBER_FIELD",
+					value1 = "${borderWidth}");
+
+				AssertTextEquals(
+					key_fieldLabel = "Border Width",
+					locator1 = "FormFields#NUMBER_FIELD",
+					value1 = "${borderWidth}");
+
+				Click(locator1 = "PageEditor#FRAGMENT_BODY_FLOATING_TOOLBAR_PANEL");
+
+				Pause(locator1 = "3000");
+			}
+
 			if (isSet(containerWidth)) {
 				Select(
 					key_fieldLabel = "Container Width",
@@ -1007,50 +1041,143 @@ definition {
 				Pause(locator1 = "3000");
 			}
 
-			if (isSet(padding)) {
-				if (isSet(bottom)) {
-					Select(
-						key_borderBottom = "Padding",
-						key_fieldLabel = "Bottom",
-						locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
-						value1 = "${bottom}");
+			if (isSet(contentDisplay)) {
+				Select(
+					key_fieldLabel = "Content Display",
+					locator1 = "Select#GENERIC_SELECT_FIELD",
+					value1 = "${contentDisplay}");
 
-					Pause(locator1 = "3000");
-				}
+				Pause(locator1 = "3000");
 
-				if (isSet(left)) {
-					Select(
-						key_borderBottom = "Padding",
-						key_fieldLabel = "Left",
-						locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
-						value1 = "${left}");
+				if ("${contentDisplay}" == "Flex") {
+					if (isSet(horizontalAlign)) {
+						Select(
+							key_fieldLabel = "Horizontal Align",
+							locator1 = "Select#GENERIC_SELECT_FIELD",
+							value1 = "${horizontalAlign}");
 
-					Pause(locator1 = "3000");
-				}
+						Pause(locator1 = "3000");
+					}
 
-				if (isSet(right)) {
-					Select(
-						key_borderBottom = "Padding",
-						key_fieldLabel = "Right",
-						locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
-						value1 = "${right}");
+					if (isSet(verticalAlign)) {
+						Select(
+							key_fieldLabel = "Vertical Align",
+							locator1 = "Select#GENERIC_SELECT_FIELD",
+							value1 = "${verticalAlign}");
 
-					Pause(locator1 = "3000");
-				}
-
-				if (isSet(top)) {
-					Select(
-						key_borderBottom = "Padding",
-						key_fieldLabel = "Top",
-						locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
-						value1 = "${top}");
-
-					Pause(locator1 = "3000");
+						Pause(locator1 = "3000");
+					}
 				}
 			}
-			else if ("${panel}" == "Link") {
-				Click(locator1 = "PageEditor#EDITABLE_FIELD_TOOLBAR_LINK_BUTTON");
+
+			if (isSet(dropShadow)) {
+				Select(
+					key_fieldLabel = "Drop Shadow",
+					locator1 = "Select#GENERIC_SELECT_FIELD",
+					value1 = "${dropShadow}");
+
+				Pause(locator1 = "3000");
 			}
+
+			if (isSet(marginBottom)) {
+				Select(
+					key_borderBottom = "Margin",
+					key_fieldLabel = "Bottom",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${marginBottom}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(marginLeft)) {
+				Select(
+					key_borderBottom = "Margin",
+					key_fieldLabel = "Left",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${marginLeft}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(marginRight)) {
+				Select(
+					key_borderBottom = "Margin",
+					key_fieldLabel = "Right",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${marginRight}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(marginTop)) {
+				Select(
+					key_borderBottom = "Margin",
+					key_fieldLabel = "Top",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${marginTop}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(opacity)) {
+				Type(
+					key_fieldLabel = "Opacity",
+					locator1 = "FormFields#NUMBER_FIELD",
+					value1 = "${opacity}");
+
+				AssertTextEquals(
+					key_fieldLabel = "Opacity",
+					locator1 = "FormFields#NUMBER_FIELD",
+					value1 = "${opacity}");
+
+				Click(locator1 = "PageEditor#FRAGMENT_BODY_FLOATING_TOOLBAR_PANEL");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(paddingBottom)) {
+				Select(
+					key_borderBottom = "Padding",
+					key_fieldLabel = "Bottom",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${paddingBottom}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(paddingLeft)) {
+				Select(
+					key_borderBottom = "Padding",
+					key_fieldLabel = "Left",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${paddingLeft}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(paddingRight)) {
+				Select(
+					key_borderBottom = "Padding",
+					key_fieldLabel = "Right",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${paddingRight}");
+
+				Pause(locator1 = "3000");
+			}
+
+			if (isSet(paddingTop)) {
+				Select(
+					key_borderBottom = "Padding",
+					key_fieldLabel = "Top",
+					locator1 = "Select#BORDER_BOTTOM_SELECT_FIELD",
+					value1 = "${paddingTop}");
+
+				Pause(locator1 = "3000");
+			}
+		}
+
+		if ("${panel}" == "Link") {
+			Click(locator1 = "PageEditor#EDITABLE_FIELD_TOOLBAR_LINK_BUTTON");
 		}
 
 		PageEditor.waitForAutoSave();
@@ -1568,6 +1695,27 @@ definition {
 				locator1 = "PageEditor#CONTAINER_CONFIGURATION_BACKGROUND_IMAGE");
 		}
 
+		if (isSet(borderColor)) {
+			AssertElementPresent(
+				key_paletteItem = "${borderColor}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_BORDER_COLOR");
+		}
+
+		if (isSet(borderRadius)) {
+			AssertElementPresent(
+				key_borderRadius = "${borderRadius}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_BORDER_RADIUS");
+		}
+
+		if (isSet(borderWidth)) {
+			AssertElementPresent(
+				key_borderWidth = "${borderWidth}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_BORDER_WIDTH");
+		}
+
 		if (isSet(containerWidth)) {
 			if ("${containerWidth}" == "Fixed Width") {
 				AssertElementNotPresent(
@@ -1591,6 +1739,62 @@ definition {
 					key_position = "${position}",
 					locator1 = "PageEditor#CONTAINER_CONFIGURATION_MARGIN_RIGHT");
 			}
+		}
+
+		if (isSet(contentDisplay)) {
+			AssertElementPresent(
+				key_contentDisplay = "${contentDisplay}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_CONTENT_DISPLAY");
+		}
+
+		if (isSet(dropShadow)) {
+			AssertElementPresent(
+				key_dropShadow = "${dropShadow}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_DROP_SHADOW");
+		}
+
+		if (isSet(horizontalAlign)) {
+			AssertElementPresent(
+				key_horizontalAlign = "${horizontalAlign}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_HORIZONTAL_ALIGN");
+		}
+
+		if (isSet(marginBottom)) {
+			AssertElementPresent(
+				key_marginBottom = "${marginBottom}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_MARGIN_BOTTOM");
+		}
+
+		if (isSet(marginLeft)) {
+			AssertElementPresent(
+				key_marginLeft = "${marginLeft}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_MARGIN_LEFT");
+		}
+
+		if (isSet(marginRight)) {
+			AssertElementPresent(
+				key_marginRight = "${marginRight}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_MARGIN_RIGHT");
+		}
+
+		if (isSet(marginTop)) {
+			AssertElementPresent(
+				key_marginTop = "${marginTop}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_MARGIN_TOP");
+		}
+
+		if (isSet(opacity)) {
+			AssertElementPresent(
+				key_opacity = "${opacity}",
+				key_position = "${position}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_OPACITY");
 		}
 
 		if (isSet(paddingBottom)) {
@@ -1619,6 +1823,13 @@ definition {
 				key_paddingTop = "${paddingTop}",
 				key_position = "${position}",
 				locator1 = "PageEditor#CONTAINER_CONFIGURATION_PADDING_TOP");
+		}
+
+		if (isSet(verticalAlign)) {
+			AssertElementPresent(
+				key_position = "${position}",
+				key_verticalAlign = "${verticalAlign}",
+				locator1 = "PageEditor#CONTAINER_CONFIGURATION_VERTICAL_ALIGN");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -94,6 +94,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>BORDER_BOTTOM_PALETTE_ITEM</td>
+	<td>//label[normalize-space(text())='${key_borderBottom}']/following-sibling::div[1]//li[contains(@class,'palette-item')]//button[contains(@class,'bg-${key_paletteItem}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>BROWSE_IMAGE</td>
 	<td>//button[contains(@class,'browse-image')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/pageeditor/PageEditor.path
@@ -261,6 +261,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>FRAGMENT_BODY_FLOATING_TOOLBAR_PANEL</td>
+	<td>//div[contains(@class,'page-editor__floating-toolbar__panel')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>FRAGMENT_BODY_FLOATING_TOOLBAR_PLUS_BUTTON</td>
 	<td>//div[contains(@class,'floating-toolbar')]//div[contains(@class,'form-group')]//button[*[name()='svg'][contains(@class,'plus')]]</td>
 	<td></td>
@@ -527,6 +532,36 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CONTAINER_CONFIGURATION_BORDER_COLOR</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'border-${key_paletteItem}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CONTAINER_CONFIGURATION_BORDER_RADIUS</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'rounded-${key_borderRadius}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CONTAINER_CONFIGURATION_BORDER_WIDTH</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@style,'border-width: ${key_borderWidth}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CONTAINER_CONFIGURATION_CONTENT_DISPLAY</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'d-${key_contentDisplay}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CONTAINER_CONFIGURATION_DROP_SHADOW</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'shadow-${key_dropShadow}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CONTAINER_CONFIGURATION_HORIZONTAL_ALIGN</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'justify-content-${key_horizontalAlign}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>CONTAINER_CONFIGURATION_MARGIN_BOTTOM</td>
 	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'mb-${key_marginBottom}')]</td>
 	<td></td>
@@ -547,6 +582,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CONTAINER_CONFIGURATION_OPACITY</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@style,'opacity: ${key_opacity}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>CONTAINER_CONFIGURATION_PADDING_BOTTOM</td>
 	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'pb-${key_paddingBottom}')]</td>
 	<td></td>
@@ -564,6 +604,11 @@
 <tr>
 	<td>CONTAINER_CONFIGURATION_PADDING_TOP</td>
 	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'pt-${key_paddingTop}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CONTAINER_CONFIGURATION_VERTICAL_ALIGN</td>
+	<td>//div[contains(@class,'page-editor__topper')]/div[contains(.,'Container')][${key_position}]//div[contains(@class,'page-editor__container')][contains(@class,'align-items-${key_verticalAlign}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/Fragments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/Fragments.testcase
@@ -73,6 +73,58 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-111657. Can add the Container to a column of Row or another Container."
+	@priority = "4"
+	test AddContainerToLayoutElements {
+		task ("Add a content page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Test Site Name",
+				layoutName = "Test Content Page Name",
+				type = "content");
+
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Test Content Page Name",
+				siteName = "Test Site Name");
+		}
+
+		task ("Assert add a Container to another Container") {
+			PageEditor.addFragment(
+				collectionName = "Layout Elements",
+				fragmentName = "Container");
+
+			Click(
+				key_elementType = "Container",
+				key_position = "1",
+				locator1 = "PageEditor#LAYOUT_ELEMENTS_HEADER");
+
+			DragAndDrop.javaScriptDragAndDropToObject(
+				key_collectionName = "Layout Elements",
+				key_fragmentName = "Container",
+				key_position = "1",
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_TAB_FRAGMENT",
+				locator2 = "PageEditor#CONTAINER_CONTAINER",
+				value1 = "");
+
+			AssertElementPresent(
+				key_elementHeader = "/div[contains(@class,'page-editor__topper')][1]/div[contains(.,'Container')]//li[contains(@class,'title')]",
+				key_position = "1",
+				locator1 = "PageEditor#CONTAINER_CONTAINER_NESTED_ELEMENT");
+		}
+
+		task ("Assert add a Container to module of Grid") {
+			PageEditor.addFragment(
+				collectionName = "Layout Elements",
+				fragmentName = "Grid",
+				targetFragmentName = "Container");
+
+			PageEditor.addElementToColumn(
+				collectionName = "Layout Elements",
+				columnNumber = "1",
+				fragmentName = "Container",
+				navTab = "Fragments");
+		}
+	}
+
 	@description = "This is a test for LPS-101258. Can create a fragment with multiple Drop Zone areas."
 	@priority = "4"
 	test AddFragmentWithTwoDropZones {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/Fragments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/Fragments.testcase
@@ -576,7 +576,7 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-106776 and LPS-102959. Configure the Container and Grid elements."
+	@description = "This is a test for LPS-106776, LPS-102959 and LPS-111657. Configure the Container and Grid elements."
 	@priority = "5"
 	test ConfigureLayoutElements {
 		property portal.acceptance = "true";
@@ -598,16 +598,90 @@ definition {
 				fragmentName = "Container");
 		}
 
-		task ("Configure the Container") {
-			PageEditor.editLayoutContainer(
-				backgroundColor = "warning",
-				panel = "Styles");
+		task ("Add a Card fragment to Container") {
+			Click(
+				key_elementType = "Container",
+				key_position = "1",
+				locator1 = "PageEditor#LAYOUT_ELEMENTS_HEADER");
+
+			DragAndDrop.javaScriptDragAndDropToObject(
+				key_collectionName = "Basic Components",
+				key_fragmentName = "Card",
+				key_position = "1",
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_TAB_FRAGMENT",
+				locator2 = "PageEditor#CONTAINER_CONTAINER",
+				value1 = "");
+
+			AssertElementPresent(
+				key_elementHeader = "//li[contains(@class,'topper__title') and contains(.,'Card')]",
+				key_position = "1",
+				locator1 = "PageEditor#CONTAINER_CONTAINER_NESTED_ELEMENT");
+
+			PageEditor.waitForAutoSave();
 		}
 
-		task ("View the Container style") {
+		task ("Add a Heading below Card inside the Container") {
+			DragAndDrop.javaScriptDragAndDropObjectToBottomOfNestedObject(
+				key_collectionName = "Basic Components",
+				key_fragmentName = "Heading",
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_TAB_FRAGMENT",
+				locator2 = "//div[contains(@class,'page-editor__topper__bar') and contains(.,'Card')]//following-sibling::div[contains(@class,'page-editor__topper__content')]",
+				value1 = "");
+
+			AssertElementPresent(
+				key_elementHeader = "//li[contains(@class,'topper__title') and contains(.,'Heading')]",
+				key_position = "1",
+				locator1 = "PageEditor#CONTAINER_CONTAINER_NESTED_ELEMENT");
+
+			PageEditor.waitForAutoSave();
+		}
+
+		task ("Configure the Container styles") {
+			PageEditor.viewContainerStyle(
+				contentDisplay = "block",
+				position = "1");
+
+			PageEditor.editLayoutContainer(
+				backgroundColor = "warning",
+				borderColor = "danger",
+				borderRadius = "Large",
+				borderWidth = "5",
+				contentDisplay = "Flex",
+				dropShadow = "Large",
+				horizontalAlign = "Center",
+				marginBottom = "2",
+				marginLeft = "2",
+				marginRight = "2",
+				marginTop = "2",
+				opacity = "50",
+				paddingBottom = "2",
+				paddingLeft = "2",
+				paddingRight = "2",
+				paddingTop = "2",
+				panel = "Styles",
+				verticalAlign = "Center");
+		}
+
+		task ("View the Container styles") {
 			PageEditor.viewContainerStyle(
 				backgroundColor = "warning",
-				position = "1");
+				borderColor = "danger",
+				borderRadius = "lg",
+				borderWidth = "5",
+				contentDisplay = "flex",
+				dropShadow = "lg",
+				horizontalAlign = "center",
+				marginBottom = "4",
+				marginLeft = "4",
+				marginRight = "4",
+				marginTop = "4",
+				opacity = "0.5",
+				paddingBottom = "4",
+				paddingLeft = "4",
+				paddingRight = "4",
+				paddingTop = "4",
+				position = "1",
+				verticalAlign = "center");
 		}
 
 		task ("Duplicate the Container") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/Fragments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/Fragments.testcase
@@ -1051,6 +1051,101 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-111657. Can save Container and nested elements as a new composition when the Container is inside a column of Row."
+	@priority = "5"
+	test SaveContainerAsCompositionInModuleOfGrid {
+		task ("Add a content page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Test Site Name",
+				layoutName = "Test Content Page Name",
+				type = "content");
+
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Test Content Page Name",
+				siteName = "Test Site Name");
+		}
+
+		task ("Add a Grid to page") {
+			PageEditor.addFragment(
+				collectionName = "Layout Elements",
+				fragmentName = "Grid");
+		}
+
+		task ("Add a Container to the first module of grid") {
+			PageEditor.addElementToColumn(
+				collectionName = "Layout Elements",
+				columnNumber = "1",
+				fragmentName = "Container",
+				navTab = "Fragments");
+		}
+
+		task ("Add an Image to the Container") {
+			DragAndDrop.javaScriptDragAndDropToObject(
+				key_collectionName = "Basic Components",
+				key_fragmentName = "Image",
+				key_position = "1",
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_TAB_FRAGMENT",
+				locator2 = "PageEditor#CONTAINER_CONTAINER",
+				value1 = "Image");
+
+			AssertElementPresent(
+				key_elementHeader = "//li[contains(@class,'topper__title') and contains(.,'Image')]",
+				key_position = "1",
+				locator1 = "PageEditor#CONTAINER_CONTAINER_NESTED_ELEMENT");
+
+			PageEditor.waitForAutoSave();
+		}
+
+		task ("Add an Asset Publisher below Image inside the Container") {
+			PageEditor.gotoTab(tabName = "Widgets");
+
+			Type.sendKeysApplicationSearch(
+				locator1 = "PageEditor#WIDGETS_APPLICATION_SEARCH_FIELD",
+				value1 = "Asset Publisher");
+
+			DragAndDrop.javaScriptDragAndDropObjectToBottomOfNestedObject(
+				key_portletName = "Asset Publisher",
+				key_position = "1",
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_TAB_WIDGET",
+				locator2 = "//div[contains(@class,'page-editor__topper__bar') and contains(.,'Image')]//following-sibling::div[contains(@class,'page-editor__topper__content')]",
+				value1 = "Asset Publisher");
+
+			Pause(locator1 = "5000");
+
+			AssertElementPresent(
+				key_elementHeader = "//div[contains(@class,'page-editor')]//li[contains(.,'Asset Publisher')]",
+				key_position = "1",
+				locator1 = "PageEditor#CONTAINER_CONTAINER_NESTED_ELEMENT");
+
+			PageEditor.waitForAutoSave();
+
+			PageEditor.gotoTab(tabName = "Contents");
+
+			PageEditor.gotoTab(tabName = "Fragments and Widgets");
+		}
+
+		task ("Assert save Container and nested elements as composition") {
+			PageEditor.gotoSaveAsFragment(fragmentName = "Container");
+
+			PageEditorComposition.saveAsFragment(fragmentName = "New Fragment Name");
+		}
+
+		task ("Add new composition to below Grid to page") {
+			PageEditor.addFragment(
+				collectionName = "Collection Name",
+				composition = "true",
+				fragmentName = "New Fragment Name",
+				targetFragmentName = "Grid");
+
+			for (var elementName : list "Image,Asset Publisher") {
+				AssertElementPresent(
+					key_elementHeader = "//li[contains(@class,'topper__title') and contains(.,'${elementName}')]",
+					key_position = "2",
+					locator1 = "PageEditor#CONTAINER_CONTAINER_NESTED_ELEMENT");
+			}
+		}
+	}
+
 	@description = "This is a test for LPS-101258. Can save a composition containing a fragment that has a Drop Zone area as fragment."
 	@priority = "4"
 	test SaveFragmentCompositionWithDropZoneInFrgament {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/contentpage/ContentPages.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/contentpage/ContentPages.testcase
@@ -491,11 +491,10 @@ definition {
 
 		task ("Edit the Container's properties") {
 			PageEditor.editLayoutContainer(
-				bottom = "4",
 				containerWidth = "Fixed Width",
-				padding = "true",
-				panel = "Styles",
-				top = "2");
+				paddingBottom = "4",
+				paddingTop = "2",
+				panel = "Styles");
 		}
 
 		task ("Assert the Row has exactly 3 columns and no space between columns") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPagesUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/displaypagetemplate/DisplayPagesUseCase.testcase
@@ -260,9 +260,8 @@ definition {
 			entryTitle = "Document_1.jpg",
 			fieldName = "File URL",
 			navItem = "Documents and Media",
-			padding = "true",
-			panel = "Styles",
-			top = "2");
+			paddingTop = "2",
+			panel = "Styles");
 
 		PageEditor.clickPublish();
 

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 5.1.2
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1973,6 +1973,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<name>leftBoxMaxItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>int</type>
+		</attribute>
+		<attribute>
 			<description>A name for the left box.</description>
 			<name>leftBoxName</name>
 			<required>true</required>
@@ -2003,6 +2010,13 @@
 			<name>leftTitle</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<name>rightBoxMaxItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>int</type>
 		</attribute>
 		<attribute>
 			<description>A name for the right box.</description>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1973,7 +1973,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>Infinity</code>]]> that represents unlimited items.</description>
+			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>null</code>]]> that represents unlimited items.</description>
 			<name>leftBoxMaxItems</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2012,7 +2012,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>Infinity</code>]]> that represents unlimited items.</description>
+			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>null</code>]]> that represents unlimited items.</description>
 			<name>rightBoxMaxItems</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1973,7 +1973,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<description>Sets the maximum number of items on the left box. The default value is <![CDATA[<code>Infinity</code>]]> that represents unlimited items.</description>
 			<name>leftBoxMaxItems</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -2012,7 +2012,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>-1</code>]]> that represents unlimited items.</description>
+			<description>Sets the maximum number of items on the right box. The default value is <![CDATA[<code>Infinity</code>]]> that represents unlimited items.</description>
 			<name>rightBoxMaxItems</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
@@ -30,6 +30,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 		return _cssClass;
 	}
 
+	public int getLeftBoxMaxItems() {
+		return _leftBoxMaxItems;
+	}
+
 	public String getLeftBoxName() {
 		return _leftBoxName;
 	}
@@ -48,6 +52,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 
 	public String getLeftTitle() {
 		return _leftTitle;
+	}
+
+	public int getRightBoxMaxItems() {
+		return _rightBoxMaxItems;
 	}
 
 	public String getRightBoxName() {
@@ -74,6 +82,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 		_cssClass = cssClass;
 	}
 
+	public void setLeftBoxMaxItems(int leftBoxMaxItems) {
+		_leftBoxMaxItems = leftBoxMaxItems;
+	}
+
 	public void setLeftBoxName(String leftBoxName) {
 		_leftBoxName = leftBoxName;
 	}
@@ -92,6 +104,10 @@ public class InputMoveBoxesTag extends IncludeTag {
 
 	public void setLeftTitle(String leftTitle) {
 		_leftTitle = leftTitle;
+	}
+
+	public void setRightBoxMaxItems(int rightBoxMaxItems) {
+		_rightBoxMaxItems = rightBoxMaxItems;
 	}
 
 	public void setRightBoxName(String rightBoxName) {
@@ -119,11 +135,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		super.cleanUp();
 
 		_cssClass = null;
+		_leftBoxMaxItems = -1;
 		_leftBoxName = null;
 		_leftList = null;
 		_leftOnChange = null;
 		_leftReorder = null;
 		_leftTitle = null;
+		_rightBoxMaxItems = -1;
 		_rightBoxName = null;
 		_rightList = null;
 		_rightOnChange = null;
@@ -141,6 +159,9 @@ public class InputMoveBoxesTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:cssClass", _cssClass);
 		httpServletRequest.setAttribute(
+			"liferay-ui:input-move-boxes:leftBoxMaxItems",
+			String.valueOf(_leftBoxMaxItems));
+		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftBoxName", _leftBoxName);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftList", _leftList);
@@ -150,6 +171,9 @@ public class InputMoveBoxesTag extends IncludeTag {
 			"liferay-ui:input-move-boxes:leftReorder", _leftReorder);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftTitle", _leftTitle);
+		httpServletRequest.setAttribute(
+			"liferay-ui:input-move-boxes:rightBoxMaxItems",
+			String.valueOf(_rightBoxMaxItems));
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:rightBoxName", _rightBoxName);
 		httpServletRequest.setAttribute(
@@ -166,11 +190,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		"/html/taglib/ui/input_move_boxes/page.jsp";
 
 	private String _cssClass;
+	private int _leftBoxMaxItems = -1;
 	private String _leftBoxName;
 	private List<KeyValuePair> _leftList;
 	private String _leftOnChange;
 	private String _leftReorder;
 	private String _leftTitle;
+	private int _rightBoxMaxItems = -1;
 	private String _rightBoxName;
 	private List<KeyValuePair> _rightList;
 	private String _rightOnChange;

--- a/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputMoveBoxesTag.java
@@ -135,13 +135,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		super.cleanUp();
 
 		_cssClass = null;
-		_leftBoxMaxItems = -1;
+		_leftBoxMaxItems = null;
 		_leftBoxName = null;
 		_leftList = null;
 		_leftOnChange = null;
 		_leftReorder = null;
 		_leftTitle = null;
-		_rightBoxMaxItems = -1;
+		_rightBoxMaxItems = null;
 		_rightBoxName = null;
 		_rightList = null;
 		_rightOnChange = null;
@@ -159,8 +159,7 @@ public class InputMoveBoxesTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:cssClass", _cssClass);
 		httpServletRequest.setAttribute(
-			"liferay-ui:input-move-boxes:leftBoxMaxItems",
-			String.valueOf(_leftBoxMaxItems));
+			"liferay-ui:input-move-boxes:leftBoxMaxItems", _leftBoxMaxItems);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftBoxName", _leftBoxName);
 		httpServletRequest.setAttribute(
@@ -172,8 +171,7 @@ public class InputMoveBoxesTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:leftTitle", _leftTitle);
 		httpServletRequest.setAttribute(
-			"liferay-ui:input-move-boxes:rightBoxMaxItems",
-			String.valueOf(_rightBoxMaxItems));
+			"liferay-ui:input-move-boxes:rightBoxMaxItems", _rightBoxMaxItems);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-move-boxes:rightBoxName", _rightBoxName);
 		httpServletRequest.setAttribute(
@@ -190,13 +188,13 @@ public class InputMoveBoxesTag extends IncludeTag {
 		"/html/taglib/ui/input_move_boxes/page.jsp";
 
 	private String _cssClass;
-	private int _leftBoxMaxItems = -1;
+	private Integer _leftBoxMaxItems;
 	private String _leftBoxName;
 	private List<KeyValuePair> _leftList;
 	private String _leftOnChange;
 	private String _leftReorder;
 	private String _leftTitle;
-	private int _rightBoxMaxItems = -1;
+	private Integer _rightBoxMaxItems;
 	private String _rightBoxName;
 	private List<KeyValuePair> _rightList;
 	private String _rightOnChange;

--- a/util-taglib/src/com/liferay/taglib/ui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/ui/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0


### PR DESCRIPTION
Hi @pyoo47 

I am sending this PR to you as you implemented https://issues.liferay.com/browse/LRQA-39761 and you have implemented most of the changes in MirrorsGetTask

This is a minor improvement for "ant snapshot-bundle".

Now, when we are working from home and we don't have access to the mirrors.hostname server, an error is produced and ant tries to download the file after seconds:
`[mirrors-get] Unable to connect to http://mirrors.lax.liferay.com/files.liferay.com/private/ee/portal/snapshot-master-private/latest/liferay-portal-tomcat-master-private.7z.sha256, will retry in 30 seconds.`

In order to save that 30 seconds, if you want to disable the mirror usage and you configure it with an empty value:
`mirrors.hostname=`

And you execute ant snapshot-bundle, following error is produced:
```
BUILD FAILED
/home/jorge/code/portal-master/build.xml:1045: java.lang.RuntimeException: java.lang.IllegalArgumentException: protocol = http host = null
```
To avoid this error and allow disabling the mirrors usage, I am adding a minor validation.

Thank you

/cc @lipusz