### PR TITLE
LRCI-1447 Limit liferay logs printed in to the jenkins console

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4320,15 +4320,39 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 
 							Runtime runtime = Runtime.getRuntime();
 
-							Process process = runtime.exec(sb.toString(), new String[] {"JAVA_HOME=" + project.getProperty("java.jdk.home")}, new File(project.getProperty("test.app.server.bin.dir")));
+							String javaHome = project.getProperty("java.jdk.home");
+
+							List arguments = new ArrayList();
+
+							arguments.add("JAVA_HOME=" + javaHome);
+
+							String path = project.getProperty("env.PATH");
+
+							if (JenkinsResultsParserUtil.isWindows()) {
+								path = path.replaceAll("[^;]+\\\\jdk[^\\\\]*\\\\[^;]*bin", javaHome.replaceAll("\\\\", "\\\\") + "\\\\bin");
+							}
+							else {
+								path = path.replaceAll("[^:]+/jdk[^/]*/[^:]*bin", javaHome + "/bin");
+							}
+
+							arguments.add("PATH=" + path);
+
+							String javaOpts = project.getProperty("env.JAVA_OPTS");
+
+							if ((javaOpts != null) && !javaOpts.isEmpty()) {
+								arguments.add("JAVA_OPTS=" + javaOpts);
+							}
+
+							String[] argumentsArray = new String[arguments.size()];
+
+							Process process = runtime.exec(sb.toString(), arguments.toArray(argumentsArray), new File(project.getProperty("test.app.server.bin.dir")));
 
 							InputStream inputStream = process.getInputStream();
 
 							int appServerLogByte;
+							int appServerLogSize = 0;
 
-							long appServerLogSize = 0;
-
-							Integer appServerLogMaxSize = Integer.valueOf(project.getProperty("app.server.log.max.size.in.mb")) * 1024 * 1024;
+							int appServerLogMaxSize = Integer.valueOf(project.getProperty("app.server.log.max.size.in.mb")) * 1024 * 1024;
 
 							try {
 								while ((appServerLogByte = inputStream.read()) != -1) {

--- a/build-test.xml
+++ b/build-test.xml
@@ -4225,10 +4225,7 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 										</then>
 									</elseif>
 									<else>
-										<exec dir="${test.app.server.bin.dir}" executable="${app.server.start.executable}" outputproperty="app.server.log" resolveexecutable="true">
-											<arg line="${app.server.start.executable.arg.line}" />
-											<env key="JAVA_HOME" path="${java.jdk.home}" />
-										</exec>
+										<start-app-server-cmd-bash />
 									</else>
 								</if>
 
@@ -4287,10 +4284,7 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 											</then>
 										</elseif>
 										<else>
-											<exec dir="${test.app.server.bin.dir}" executable="${app.server.start.executable}" failonerror="true" output="app.server.log" resolveexecutable="true">
-												<arg line="${app.server.start.executable.arg.line}" />
-												<env key="JAVA_HOME" path="${java.jdk.home}" />
-											</exec>
+											<start-app-server-cmd-bash />
 										</else>
 									</if>
 								</daemons>
@@ -4299,6 +4293,71 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 					</if>
 				</then>
 			</if>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="start-app-server-cmd-bash">
+		<sequential>
+			<beanshell>
+				<![CDATA[
+					import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+					Runnable runnable = new Runnable() {
+
+						public void run() {
+							StringBuilder sb = new StringBuilder();
+
+							if (JenkinsResultsParserUtil.isWindows()) {
+								sb.append("cmd.exe /c ");
+							}
+							else {
+								sb.append("/bin/bash ");
+							}
+
+							sb.append(project.getProperty("app.server.start.executable"));
+							sb.append(" ");
+							sb.append(project.getProperty("app.server.start.executable.arg.line"));
+
+							Runtime runtime = Runtime.getRuntime();
+
+							Process process = runtime.exec(sb.toString(), new String[] {"JAVA_HOME=" + project.getProperty("java.jdk.home")}, new File(project.getProperty("test.app.server.bin.dir")));
+
+							InputStream inputStream = process.getInputStream();
+
+							int appServerLogByte;
+
+							long appServerLogSize = 0;
+
+							Integer appServerLogMaxSize = Integer.valueOf(project.getProperty("app.server.log.max.size.in.mb")) * 1024 * 1024;
+
+							try {
+								while ((appServerLogByte = inputStream.read()) != -1) {
+									appServerLogSize++;
+
+									if (appServerLogSize > appServerLogMaxSize) {
+										continue;
+									}
+
+									System.out.print((char)appServerLogByte);
+								}
+							}
+							catch (IOException ioException) {
+								throw new RuntimeException(ioException);
+							}
+							finally {
+								inputStream.close();
+							}
+
+							process.waitFor();
+						}
+
+					};
+
+					Thread thread = new Thread(runnable);
+
+					thread.start();
+				]]>
+			</beanshell>
 		</sequential>
 	</macrodef>
 

--- a/test.properties
+++ b/test.properties
@@ -72,6 +72,8 @@
     app.server.jboss.stop.executable=jboss-cli${file.suffix.bat}
     app.server.jboss.stop.executable.arg.line=--connect command=:shutdown
 
+    app.server.log.max.size.in.mb=5
+
     app.server.tcserver.start.executable=startup${file.suffix.bat}
     app.server.tcserver.start.executable.arg.line=
     app.server.tcserver.stop.executable=shutdown${file.suffix.bat}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1447

@pyoo47 - If this looks okay, I can backport it to all the other branches.  I got it to work with test-2-1 jobs as well.  This can be backported to `7.2.x` only, the rest I have to do myself.  Thanks!