### PR TITLE
 LPS-117490 Do not use mirrors.hostname in case it is an empty string 

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -226,11 +226,13 @@ public class MirrorsGetTask extends Task {
 		if (!localCacheFile.exists()) {
 			URL sourceURL = null;
 
-			if (_tryLocalNetwork) {
+			String mirrorsHostname = getMirrorsHostname();
+
+			if (_tryLocalNetwork && (mirrorsHostname.length() > 0)) {
 				sb = new StringBuilder();
 
 				sb.append("http://");
-				sb.append(getMirrorsHostname());
+				sb.append(mirrorsHostname);
 				sb.append("/");
 				sb.append(_path);
 				sb.append("/");

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -228,7 +228,9 @@ public class MirrorsGetTask extends Task {
 
 			String mirrorsHostname = getMirrorsHostname();
 
-			if (_tryLocalNetwork && (mirrorsHostname.length() > 0)) {
+			if (_tryLocalNetwork && (mirrorsHostname != null) &&
+				(mirrorsHostname.length() > 0)) {
+
 				sb = new StringBuilder();
 
 				sb.append("http://");


### PR DESCRIPTION
Same pull than https://github.com/pyoo47/liferay-portal/pull/1400 but I have added an additional null check requested by Brian here: https://github.com/brianchandotcom/liferay-portal/pull/91598#issuecomment-663352081