### PR TITLE
LPS-117490 & LRCI-1523 mirrors-get changes

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -226,11 +226,13 @@ public class MirrorsGetTask extends Task {
 		if (!localCacheFile.exists()) {
 			URL sourceURL = null;
 
-			if (_tryLocalNetwork) {
+			String mirrorsHostname = getMirrorsHostname();
+
+			if (_tryLocalNetwork && (mirrorsHostname.length() > 0)) {
 				sb = new StringBuilder();
 
 				sb.append("http://");
-				sb.append(getMirrorsHostname());
+				sb.append(mirrorsHostname);
 				sb.append("/");
 				sb.append(_path);
 				sb.append("/");

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -228,7 +228,9 @@ public class MirrorsGetTask extends Task {
 
 			String mirrorsHostname = getMirrorsHostname();
 
-			if (_tryLocalNetwork && (mirrorsHostname.length() > 0)) {
+			if (_tryLocalNetwork && (mirrorsHostname != null) &&
+				(mirrorsHostname.length() > 0)) {
+
 				sb = new StringBuilder();
 
 				sb.append("http://");

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -124,6 +124,10 @@ public class MirrorsGetTask extends Task {
 		}
 	}
 
+	public void setSSL(boolean ssl) {
+		_ssl = ssl;
+	}
+
 	public void setTryLocalNetwork(boolean tryLocalNetwork) {
 		_tryLocalNetwork = tryLocalNetwork;
 	}
@@ -231,7 +235,7 @@ public class MirrorsGetTask extends Task {
 			if (_tryLocalNetwork && !mirrorsHostname.isEmpty()) {
 				sb = new StringBuilder();
 
-				sb.append("http://");
+				sb.append(getURLScheme());
 				sb.append(mirrorsHostname);
 				sb.append("/");
 				sb.append(_path);
@@ -338,6 +342,24 @@ public class MirrorsGetTask extends Task {
 		}
 
 		return path;
+	}
+
+	protected String getURLScheme() {
+		Project project = getProject();
+
+		boolean ssl = _ssl;
+
+		String mirrorsSSL = project.getProperty("mirrors.ssl");
+
+		if ((mirrorsSSL != null) && !mirrorsSSL.isEmpty()) {
+			ssl = Boolean.parseBoolean(mirrorsSSL);
+		}
+
+		if (ssl) {
+			return "https://";
+		}
+
+		return "http://";
 	}
 
 	protected String getUsername() {
@@ -642,6 +664,7 @@ public class MirrorsGetTask extends Task {
 	private int _retries = 1;
 	private boolean _skipChecksum;
 	private String _src;
+	private boolean _ssl;
 	private boolean _tryLocalNetwork = true;
 	private String _username;
 	private boolean _verbose;

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -228,9 +228,7 @@ public class MirrorsGetTask extends Task {
 
 			String mirrorsHostname = getMirrorsHostname();
 
-			if (_tryLocalNetwork && (mirrorsHostname != null) &&
-				(mirrorsHostname.length() > 0)) {
-
+			if (_tryLocalNetwork && !mirrorsHostname.isEmpty()) {
 				sb = new StringBuilder();
 
 				sb.append("http://");

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -311,6 +311,10 @@ public class MirrorsGetTask extends Task {
 
 		_mirrorsHostname = project.getProperty("mirrors.hostname");
 
+		if (_mirrorsHostname == null) {
+			_mirrorsHostname = "";
+		}
+
 		return _mirrorsHostname;
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-117490
Setting mirrors.hostname property to be empty will have the same effect as setting the task attribute tryLocalNetwork="false". This allows users to skip downloading from mirrors and download directly from the source URL.

https://issues.liferay.com/browse/LRCI-1523
Implements support for SSL enabled mirrors servers. This can be turned on in two different ways.
1. Add ssl="true" to the mirrors-get task call in the Ant build script.
2. Via the system property, "mirrors.ssl". This property will always override the value set in option 1.

@jorgediaz-lr
@lipusz