### PR TITLE
LRCI-1529 Use OrderedJSONObject in data generation

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -50,6 +50,10 @@ public class JenkinsCohort {
 		return _name;
 	}
 
+	public int getOfflineCINodeCount() {
+		return _offlineCINodeCount;
+	}
+
 	public int getOnlineCINodeCount() {
 		return _onlineCINodeCount;
 	}
@@ -107,6 +111,10 @@ public class JenkinsCohort {
 
 					jobURLs.addAll(jenkinsMaster.getRunningJobURLs());
 					jobURLs.addAll(jenkinsMaster.getQueuedJobURLs());
+
+					_offlineCINodeCount =
+						_offlineCINodeCount +
+							jenkinsMaster.getOfflineJenkinsSlavesCount();
 
 					_onlineCINodeCount =
 						_onlineCINodeCount +
@@ -241,6 +249,7 @@ public class JenkinsCohort {
 	private final Map<String, JenkinsCohortJob> _jenkinsCohortJobsMap =
 		new HashMap<>();
 	private final String _name;
+	private int _offlineCINodeCount;
 	private int _onlineCINodeCount;
 
 	private class JenkinsCohortJob {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -207,8 +207,7 @@ public class JenkinsCohort {
 
 		sb.append(";");
 
-		JenkinsResultsParserUtil.write(
-			filePath + "/ci-system-status-data.js", sb.toString());
+		JenkinsResultsParserUtil.write(filePath + "/data.js", sb.toString());
 	}
 
 	private void _loadJobURL(String jobURL) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -126,7 +126,7 @@ public class JenkinsCohort {
 		}
 
 		List<Callable<Void>> callables = new ArrayList<>();
-		final List<String> jobURLs = new ArrayList<>();
+		final List<String> buildURLs = new ArrayList<>();
 
 		for (final JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
 			Callable<Void> callable = new Callable<Void>() {
@@ -135,8 +135,8 @@ public class JenkinsCohort {
 				public Void call() {
 					jenkinsMaster.update();
 
-					jobURLs.addAll(jenkinsMaster.getRunningJobURLs());
-					jobURLs.addAll(jenkinsMaster.getQueuedJobURLs());
+					buildURLs.addAll(jenkinsMaster.getBuildURLs());
+					buildURLs.addAll(jenkinsMaster.getQueuedBuildURLs());
 
 					return null;
 				}
@@ -155,8 +155,8 @@ public class JenkinsCohort {
 
 		parallelExecutor.execute();
 
-		for (String jobURL : jobURLs) {
-			_loadJobURL(jobURL);
+		for (String buildURL : buildURLs) {
+			_loadBuildURL(buildURL);
 		}
 	}
 
@@ -226,8 +226,8 @@ public class JenkinsCohort {
 		JenkinsResultsParserUtil.write(filePath + "/data.js", sb.toString());
 	}
 
-	private void _loadJobURL(String jobURL) {
-		Matcher jobNameMatcher = _jobNamePattern.matcher(jobURL);
+	private void _loadBuildURL(String buildURL) {
+		Matcher jobNameMatcher = _jobNamePattern.matcher(buildURL);
 
 		jobNameMatcher.find();
 
@@ -247,7 +247,7 @@ public class JenkinsCohort {
 
 		JenkinsCohortJob jenkinsCohortJob = _jenkinsCohortJobsMap.get(jobName);
 
-		Matcher buildNumberMatcher = _buildNumberPattern.matcher(jobURL);
+		Matcher buildNumberMatcher = _buildNumberPattern.matcher(buildURL);
 
 		if (buildNumberMatcher.find()) {
 			jenkinsCohortJob.incrementRunningJobCount();
@@ -257,7 +257,7 @@ public class JenkinsCohort {
 		}
 
 		if (batchJobName == null) {
-			jenkinsCohortJob.addTopLevelBuildURL(jobURL);
+			jenkinsCohortJob.addTopLevelBuildURL(buildURL);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -173,11 +173,11 @@ public class JenkinsCohort {
 
 		JSONObject nodeDataJSONObject = new OrderedJSONObject();
 
-		nodeDataJSONObject.put(
-			"CI Node Capacity", getOnlineJenkinsSlaveCount());
+		nodeDataJSONObject.put("Occupied Nodes", getRunningBuildCount());
 
-		nodeDataJSONObject.put(
-			"Total CI Load", getRunningBuildCount() + getQueuedBuildCount());
+		nodeDataJSONObject.put("Online Nodes", getOnlineJenkinsSlaveCount());
+
+		nodeDataJSONObject.put("Queued Builds", getQueuedBuildCount());
 
 		nodeDataJSONObject.put("Offline Nodes", getOfflineJenkinsSlaveCount());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -126,7 +127,8 @@ public class JenkinsCohort {
 		}
 
 		List<Callable<Void>> callables = new ArrayList<>();
-		final List<String> buildURLs = new ArrayList<>();
+		final List<String> buildURLs = Collections.synchronizedList(
+			new ArrayList<String>());
 
 		for (final JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
 			Callable<Void> callable = new Callable<Void>() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -198,20 +198,20 @@ public class JenkinsCohort {
 
 			jsonObject.put("Name", jenkinsCohortJob.getJobName());
 
-			DecimalFormat decimalFormat = new DecimalFormat("###.###%");
+			jsonObject.put(
+				"Total Builds",
+				jenkinsCohortJob.getTotalBuildCount() + " (" +
+					jenkinsCohortJob.getTotalBuildPercentage() + ")");
 
 			jsonObject.put(
-				"Load %",
-				decimalFormat.format(jenkinsCohortJob.getLoadPercentage()));
+				"Current Builds",
+				jenkinsCohortJob.getRunningBuildCount() + " (" +
+					jenkinsCohortJob.getRunningBuildPercentage() + ")");
 
 			jsonObject.put(
-				"Total Builds", jenkinsCohortJob.getTotalBuildCount());
-
-			jsonObject.put(
-				"Current Builds", jenkinsCohortJob.getRunningBuildCount());
-
-			jsonObject.put(
-				"Queued Builds", jenkinsCohortJob.getQueuedBuildCount());
+				"Queued Builds",
+				jenkinsCohortJob.getQueuedBuildCount() + " (" +
+					jenkinsCohortJob.getQueuedBuildPercentage() + ")");
 
 			List<String> topLevelBuildURLs =
 				jenkinsCohortJob.getTopLevelBuildURLs();
@@ -226,6 +226,14 @@ public class JenkinsCohort {
 		sb.append(";");
 
 		JenkinsResultsParserUtil.write(filePath + "/data.js", sb.toString());
+	}
+
+	private static String _getPercentage(Integer dividend, Integer divisor) {
+		double quotient = (double)dividend / (double)divisor;
+
+		DecimalFormat decimalFormat = new DecimalFormat("###.##%");
+
+		return decimalFormat.format(quotient);
 	}
 
 	private void _loadBuildURL(String buildURL) {
@@ -287,18 +295,22 @@ public class JenkinsCohort {
 			return _jenkinsCohortJobName;
 		}
 
-		public double getLoadPercentage() {
-			return (double)getTotalBuildCount() /
-				(double)(JenkinsCohort.this.getRunningBuildCount() +
-					JenkinsCohort.this.getQueuedBuildCount());
-		}
-
 		public int getQueuedBuildCount() {
 			return _queuedBuildCount;
 		}
 
+		public String getQueuedBuildPercentage() {
+			return _getPercentage(
+				_queuedBuildCount, JenkinsCohort.this.getQueuedBuildCount());
+		}
+
 		public int getRunningBuildCount() {
 			return _runningBuildCount;
+		}
+
+		public String getRunningBuildPercentage() {
+			return _getPercentage(
+				_runningBuildCount, JenkinsCohort.this.getRunningBuildCount());
 		}
 
 		public List<String> getTopLevelBuildURLs() {
@@ -307,6 +319,13 @@ public class JenkinsCohort {
 
 		public int getTotalBuildCount() {
 			return _queuedBuildCount + _runningBuildCount;
+		}
+
+		public String getTotalBuildPercentage() {
+			return _getPercentage(
+				getTotalBuildCount(),
+				JenkinsCohort.this.getRunningBuildCount() +
+					JenkinsCohort.this.getQueuedBuildCount());
 		}
 
 		public void incrementQueuedJobCount() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -42,20 +42,40 @@ public class JenkinsCohort {
 		update();
 	}
 
-	public int getIdleCINodeCount() {
-		return _idleCINodeCount;
+	public int getIdleJenkinsSlaveCount() {
+		int idleJenkinsSlaveCount = 0;
+
+		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
+			idleJenkinsSlaveCount += jenkinsMaster.getIdleJenkinsSlavesCount();
+		}
+
+		return idleJenkinsSlaveCount;
 	}
 
 	public String getName() {
 		return _name;
 	}
 
-	public int getOfflineCINodeCount() {
-		return _offlineCINodeCount;
+	public int getOfflineJenkinsSlaveCount() {
+		int offlineJenkinsSlaveCount = 0;
+
+		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
+			offlineJenkinsSlaveCount +=
+				jenkinsMaster.getOfflineJenkinsSlavesCount();
+		}
+
+		return offlineJenkinsSlaveCount;
 	}
 
-	public int getOnlineCINodeCount() {
-		return _onlineCINodeCount;
+	public int getOnlineJenkinsSlaveCount() {
+		int onlineJenkinsSlaveCount = 0;
+
+		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
+			onlineJenkinsSlaveCount +=
+				jenkinsMaster.getOnlineJenkinsSlavesCount();
+		}
+
+		return onlineJenkinsSlaveCount;
 	}
 
 	public int getQueuedBuildCount() {
@@ -95,14 +115,20 @@ public class JenkinsCohort {
 				"Unable to get Jenkins properties", ioException);
 		}
 
+		if (_jenkinsMastersMap.isEmpty()) {
+			List<JenkinsMaster> jenkinsMasters =
+				JenkinsResultsParserUtil.getJenkinsMasters(
+					buildProperties, 16, getName());
+
+			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
+				_jenkinsMastersMap.put(jenkinsMaster.getName(), jenkinsMaster);
+			}
+		}
+
 		List<Callable<Void>> callables = new ArrayList<>();
 		final List<String> jobURLs = new ArrayList<>();
 
-		List<JenkinsMaster> jenkinsMasters =
-			JenkinsResultsParserUtil.getJenkinsMasters(
-				buildProperties, 16, getName());
-
-		for (final JenkinsMaster jenkinsMaster : jenkinsMasters) {
+		for (final JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
 			Callable<Void> callable = new Callable<Void>() {
 
 				@Override
@@ -111,17 +137,6 @@ public class JenkinsCohort {
 
 					jobURLs.addAll(jenkinsMaster.getRunningJobURLs());
 					jobURLs.addAll(jenkinsMaster.getQueuedJobURLs());
-
-					_offlineCINodeCount =
-						_offlineCINodeCount +
-							jenkinsMaster.getOfflineJenkinsSlavesCount();
-
-					_onlineCINodeCount =
-						_onlineCINodeCount +
-							jenkinsMaster.getOnlineJenkinsSlavesCount();
-
-					_idleCINodeCount =
-						_idleCINodeCount + jenkinsMaster.getIdleSlavesCount();
 
 					return null;
 				}
@@ -133,7 +148,7 @@ public class JenkinsCohort {
 
 		ThreadPoolExecutor threadPoolExecutor =
 			JenkinsResultsParserUtil.getNewThreadPoolExecutor(
-				jenkinsMasters.size(), true);
+				_jenkinsMastersMap.size(), true);
 
 		ParallelExecutor<Void> parallelExecutor = new ParallelExecutor<>(
 			callables, threadPoolExecutor);
@@ -156,14 +171,15 @@ public class JenkinsCohort {
 
 		JSONObject nodeDataJSONObject = new OrderedJSONObject();
 
-		nodeDataJSONObject.put("CI Node Capacity", getOnlineCINodeCount());
+		nodeDataJSONObject.put(
+			"CI Node Capacity", getOnlineJenkinsSlaveCount());
 
 		nodeDataJSONObject.put(
 			"Total CI Load", getRunningBuildCount() + getQueuedBuildCount());
 
-		nodeDataJSONObject.put("Offline Nodes", getOfflineCINodeCount());
+		nodeDataJSONObject.put("Offline Nodes", getOfflineJenkinsSlaveCount());
 
-		nodeDataJSONObject.put("Idle Nodes", getIdleCINodeCount());
+		nodeDataJSONObject.put("Idle Nodes", getIdleJenkinsSlaveCount());
 
 		nodeDataJSONArray.put(nodeDataJSONObject);
 
@@ -250,12 +266,10 @@ public class JenkinsCohort {
 	private static final Pattern _jobNamePattern = Pattern.compile(
 		"https?:.*job\\/(.*?)\\/");
 
-	private int _idleCINodeCount;
 	private final Map<String, JenkinsCohortJob> _jenkinsCohortJobsMap =
 		new HashMap<>();
+	private Map<String, JenkinsMaster> _jenkinsMastersMap = new HashMap<>();
 	private final String _name;
-	private int _offlineCINodeCount;
-	private int _onlineCINodeCount;
 
 	private class JenkinsCohortJob {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -154,12 +154,16 @@ public class JenkinsCohort {
 
 		JSONArray nodeDataJSONArray = new JSONArray();
 
-		JSONObject nodeDataJSONObject = new JSONObject();
+		JSONObject nodeDataJSONObject = new OrderedJSONObject();
 
 		nodeDataJSONObject.put("CI Node Capacity", getOnlineCINodeCount());
-		nodeDataJSONObject.put("Idle Nodes", getIdleCINodeCount());
+
 		nodeDataJSONObject.put(
 			"Total CI Load", getRunningBuildCount() + getQueuedBuildCount());
+
+		nodeDataJSONObject.put("Offline Nodes", getOfflineCINodeCount());
+
+		nodeDataJSONObject.put("Idle Nodes", getIdleCINodeCount());
 
 		nodeDataJSONArray.put(nodeDataJSONObject);
 
@@ -172,7 +176,7 @@ public class JenkinsCohort {
 		for (JenkinsCohortJob jenkinsCohortJob :
 				_jenkinsCohortJobsMap.values()) {
 
-			JSONObject jsonObject = new JSONObject();
+			JSONObject jsonObject = new OrderedJSONObject();
 
 			jsonObject.put("Name", jenkinsCohortJob.getJobName());
 
@@ -183,11 +187,13 @@ public class JenkinsCohort {
 				decimalFormat.format(jenkinsCohortJob.getLoadPercentage()));
 
 			jsonObject.put(
+				"Total Builds", jenkinsCohortJob.getTotalBuildCount());
+
+			jsonObject.put(
 				"Current Builds", jenkinsCohortJob.getRunningBuildCount());
+
 			jsonObject.put(
 				"Queued Builds", jenkinsCohortJob.getQueuedBuildCount());
-			jsonObject.put(
-				"Total Builds", jenkinsCohortJob.getTotalBuildCount());
 
 			List<String> topLevelBuildURLs =
 				jenkinsCohortJob.getTopLevelBuildURLs();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -304,14 +304,13 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		for (int i = 0; i < itemsJSONArray.length(); i++) {
 			JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
 
+			JSONObject taskJSONObject = null;
+
 			if (itemJSONObject.has("task")) {
-				JSONObject taskJSONObject = itemJSONObject.getJSONObject(
-					"task");
+				taskJSONObject = itemJSONObject.getJSONObject("task");
+			}
 
-				if (taskJSONObject.has("url")) {
-					_queuedBuildURLs.add(taskJSONObject.getString("url"));
-				}
-
+			if (taskJSONObject != null) {
 				String taskName = taskJSONObject.getString("name");
 
 				if (taskName.equals("verification-node")) {
@@ -327,6 +326,10 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 					why.endsWith("is offline")) {
 
 					continue;
+				}
+
+				if ((taskJSONObject != null) && taskJSONObject.has("url")) {
+					_queuedBuildURLs.add(taskJSONObject.getString("url"));
 				}
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -119,6 +119,10 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 			getOnlineJenkinsSlavesCount();
 	}
 
+	public List<String> getBuildURLs() {
+		return _buildURLs;
+	}
+
 	public int getIdleJenkinsSlavesCount() {
 		int idleSlavesCount = 0;
 
@@ -183,12 +187,8 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		return onlineJenkinsSlavesCount;
 	}
 
-	public List<String> getQueuedJobURLs() {
-		return _queuedJobURLs;
-	}
-
-	public List<String> getRunningJobURLs() {
-		return _runningJobURLs;
+	public List<String> getQueuedBuildURLs() {
+		return _queuedBuildURLs;
 	}
 
 	public Integer getSlaveRAM() {
@@ -285,7 +285,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 								"currentExecutable");
 
 						if (currentExecutableJSONObject.has("url")) {
-							_runningJobURLs.add(
+							_buildURLs.add(
 								currentExecutableJSONObject.getString("url"));
 						}
 					}
@@ -309,7 +309,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 					"task");
 
 				if (taskJSONObject.has("url")) {
-					_queuedJobURLs.add(taskJSONObject.getString("url"));
+					_queuedBuildURLs.add(taskJSONObject.getString("url"));
 				}
 
 				String taskName = taskJSONObject.getString("name");
@@ -363,13 +363,13 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 
 	private boolean _available;
 	private final Map<Long, Integer> _batchSizes = new TreeMap<>();
+	private List<String> _buildURLs = new ArrayList<>();
 	private final Map<String, JenkinsSlave> _jenkinsSlavesMap = new HashMap<>();
 	private final String _masterName;
 	private final String _masterURL;
 	private int _queueCount;
-	private List<String> _queuedJobURLs = new ArrayList<>();
+	private List<String> _queuedBuildURLs = new ArrayList<>();
 	private int _reportedAvailableSlavesCount;
-	private List<String> _runningJobURLs = new ArrayList<>();
 	private final Integer _slaveRAM;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -146,6 +146,18 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 		return _masterName;
 	}
 
+	public int getOfflineJenkinsSlavesCount() {
+		int offlineJenkinsSlavesCount = 0;
+
+		for (JenkinsSlave jenkinsSlave : _jenkinsSlavesMap.values()) {
+			if (jenkinsSlave.isOffline()) {
+				offlineJenkinsSlavesCount++;
+			}
+		}
+
+		return offlineJenkinsSlavesCount;
+	}
+
 	public List<JenkinsSlave> getOnlineJenkinsSlaves() {
 		List<JenkinsSlave> onlineJenkinsSlaves = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -110,7 +110,8 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 	}
 
 	public int getAvailableSlavesCount() {
-		return getIdleSlavesCount() - _queueCount - _getRecentBatchSizesTotal();
+		return getIdleJenkinsSlavesCount() - _queueCount -
+			_getRecentBatchSizesTotal();
 	}
 
 	public float getAverageQueueLength() {
@@ -118,7 +119,7 @@ public class JenkinsMaster implements Comparable<JenkinsMaster> {
 			getOnlineJenkinsSlavesCount();
 	}
 
-	public int getIdleSlavesCount() {
+	public int getIdleJenkinsSlavesCount() {
 		int idleSlavesCount = 0;
 
 		for (JenkinsSlave jenkinsSlave : _jenkinsSlavesMap.values()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/OrderedJSONObject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/OrderedJSONObject.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+/**
+ * @author Kenji Heigel
+ */
+public class OrderedJSONObject extends JSONObject {
+
+	public OrderedJSONObject() {
+	}
+
+	public OrderedJSONObject(JSONObject jsonObject, String[] names) {
+		super(jsonObject, names);
+	}
+
+	public OrderedJSONObject(JSONTokener jsonTokener) throws JSONException {
+		super(jsonTokener);
+	}
+
+	public OrderedJSONObject(Map<?, ?> map) {
+		super(map);
+	}
+
+	public OrderedJSONObject(Object bean) {
+		super(bean);
+	}
+
+	public OrderedJSONObject(Object object, String[] names) {
+		super(object, names);
+	}
+
+	public OrderedJSONObject(String source) throws JSONException {
+		super(source);
+	}
+
+	public OrderedJSONObject(String baseName, Locale locale)
+		throws JSONException {
+
+		super(baseName, locale);
+	}
+
+	@Override
+	public JSONObject put(String key, Object value) throws JSONException {
+		_keyOrder.add(key);
+
+		return super.put(key, value);
+	}
+
+	@Override
+	protected Set<Map.Entry<String, Object>> entrySet() {
+		Set<Map.Entry<String, Object>> originalSet = super.entrySet();
+		Set<Map.Entry<String, Object>> orderedSet = new LinkedHashSet<>();
+
+		for (String key : _keyOrder) {
+			for (Map.Entry<String, Object> entry : originalSet) {
+				if (key.equals(entry.getKey())) {
+					orderedSet.add(entry);
+
+					break;
+				}
+			}
+		}
+
+		return orderedSet;
+	}
+
+	private final List<String> _keyOrder = new ArrayList<>();
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1529

I made additional renames from job -> build where applicable. According to Jenkins terminology (https://wiki.jenkins.io/display/jenkins/terminology), a job refers to a runnable task whereas the build is essentially an instance/result of a run of that job. I think our other usages follow that pattern already, so I adjusted my naming that didn't follow that. Additionally, JenkinsCohortJob can be kept as such, because the class should contain all the data that comes from one job, which has multiple builds, etc.