### PR TITLE
LRCI-1431 Check cached properties by default

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -854,7 +854,7 @@ public class JenkinsResultsParserUtil {
 	public static String getBuildProperty(String propertyName)
 		throws IOException {
 
-		return getBuildProperty(false, propertyName);
+		return getBuildProperty(true, propertyName);
 	}
 
 	public static List<String> getBuildPropertyAsList(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1431

This isn't the bug I was looking for, but it's a bug... I noticed when turning the debug mode on that we were downloading the cached properties files hundreds of times. When generating a TopLevelBuild object without the caching, it took about 4 minutes. With caching it took 30 seconds. I tracked it down to one property usage that was spamming it. In BaseBuild.getInvocationURL we get the jenkins.authentication.token property repeatedly to get the invocation URL, which we use in findDownstreamBuilds to check for reinvocation. In any case, this should speed things up in top level builds, and should reduce the amount of network traffic substantially.

Let me know if you think otherwise, or if there's a reason that we shouldn't be caching this.. 

Edit: 
OHH, we added this recently: 
https://github.com/brianchandotcom/liferay-portal/pull/81640/commits/85dec02bf27515500e0d414ad89dfad8a8e3b874#diff-dd3d5318abb5a26d76597585cc78e632

I definitely think we should be caching it then. 