### PR TITLE
LRCI-1327 Use build profile to get batch name properties in portal release job

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
@@ -25,8 +25,16 @@ import java.util.Set;
 public abstract class BasePortalReleaseJob
 	extends BaseJob implements BatchDependentJob, PortalTestClassJob {
 
-	public BasePortalReleaseJob(String jobName, String portalBranchName) {
+	public BasePortalReleaseJob(
+		String jobName, String portalBranchName, BuildProfile buildProfile) {
+
 		super(jobName);
+
+		if (buildProfile == null) {
+			buildProfile = BuildProfile.PORTAL;
+		}
+
+		_buildProfile = buildProfile;
 
 		_portalBranchName = portalBranchName;
 
@@ -70,10 +78,36 @@ public abstract class BasePortalReleaseJob
 		return _portalGitWorkingDirectory;
 	}
 
+	public static enum BuildProfile {
+
+		DXP {
+
+			private static final String _TEXT = "dxp";
+
+			@Override
+			public String toString() {
+				return _TEXT;
+			}
+
+		},
+		PORTAL {
+
+			private static final String _TEXT = "portal";
+
+			@Override
+			public String toString() {
+				return _TEXT;
+			}
+
+		}
+
+	}
+
 	protected GitWorkingDirectory getJenkinsGitWorkingDirectory() {
 		return _jenkinsGitWorkingDirectory;
 	}
 
+	private final BuildProfile _buildProfile;
 	private final GitWorkingDirectory _jenkinsGitWorkingDirectory;
 	private final String _portalBranchName;
 	private final PortalGitWorkingDirectory _portalGitWorkingDirectory;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
@@ -62,12 +62,13 @@ public abstract class BasePortalReleaseJob
 		batchNames.addAll(
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
-					jobProperties, "test.batch.names", _portalBranchName)));
+					jobProperties, "test.batch.names", false,
+					_portalBranchName)));
 
 		batchNames.addAll(
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
-					jobProperties, "test.batch.names", _portalBranchName,
+					jobProperties, "test.batch.names", false, _portalBranchName,
 					buildProfile.toString())));
 
 		return batchNames;
@@ -82,14 +83,14 @@ public abstract class BasePortalReleaseJob
 		batchNames.addAll(
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
-					jobProperties, "test.batch.names.smoke",
+					jobProperties, "test.batch.names.smoke", false,
 					_portalBranchName)));
 
 		batchNames.addAll(
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
-					jobProperties, "test.batch.names.smoke", _portalBranchName,
-					buildProfile.toString())));
+					jobProperties, "test.batch.names.smoke", false,
+					_portalBranchName, buildProfile.toString())));
 
 		return batchNames;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
@@ -17,7 +17,9 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 
 import java.util.Collections;
+import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Michael Hashimoto
@@ -53,19 +55,43 @@ public abstract class BasePortalReleaseJob
 
 	@Override
 	public Set<String> getBatchNames() {
-		String testBatchNamesString = JenkinsResultsParserUtil.getProperty(
-			getJobProperties(), "test.batch.names[" + _portalBranchName + "]");
+		Set<String> batchNames = new TreeSet<>();
 
-		return getSetFromString(testBatchNamesString);
+		Properties jobProperties = getJobProperties();
+
+		batchNames.addAll(
+			getSetFromString(
+				JenkinsResultsParserUtil.getProperty(
+					jobProperties, "test.batch.names", _portalBranchName)));
+
+		batchNames.addAll(
+			getSetFromString(
+				JenkinsResultsParserUtil.getProperty(
+					jobProperties, "test.batch.names", _portalBranchName,
+					_buildProfile.toString())));
+
+		return batchNames;
 	}
 
 	@Override
 	public Set<String> getDependentBatchNames() {
-		String testBatchNames = JenkinsResultsParserUtil.getProperty(
-			getJobProperties(),
-			"test.batch.names.smoke[" + _portalBranchName + "]");
+		Set<String> batchNames = new TreeSet<>();
 
-		return getSetFromString(testBatchNames);
+		Properties jobProperties = getJobProperties();
+
+		batchNames.addAll(
+			getSetFromString(
+				JenkinsResultsParserUtil.getProperty(
+					jobProperties, "test.batch.names.smoke",
+					_portalBranchName)));
+
+		batchNames.addAll(
+			getSetFromString(
+				JenkinsResultsParserUtil.getProperty(
+					jobProperties, "test.batch.names.smoke", _portalBranchName,
+					_buildProfile.toString())));
+
+		return batchNames;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
@@ -32,11 +32,11 @@ public abstract class BasePortalReleaseJob
 
 		super(jobName);
 
-		if (buildProfile == null) {
-			buildProfile = BuildProfile.PORTAL;
-		}
+		this.buildProfile = buildProfile;
 
-		_buildProfile = buildProfile;
+		if (buildProfile == null) {
+			this.buildProfile = BuildProfile.PORTAL;
+		}
 
 		_portalBranchName = portalBranchName;
 
@@ -68,7 +68,7 @@ public abstract class BasePortalReleaseJob
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
 					jobProperties, "test.batch.names", _portalBranchName,
-					_buildProfile.toString())));
+					buildProfile.toString())));
 
 		return batchNames;
 	}
@@ -89,7 +89,7 @@ public abstract class BasePortalReleaseJob
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
 					jobProperties, "test.batch.names.smoke", _portalBranchName,
-					_buildProfile.toString())));
+					buildProfile.toString())));
 
 		return batchNames;
 	}
@@ -133,7 +133,8 @@ public abstract class BasePortalReleaseJob
 		return _jenkinsGitWorkingDirectory;
 	}
 
-	private final BuildProfile _buildProfile;
+	protected BuildProfile buildProfile;
+
 	private final GitWorkingDirectory _jenkinsGitWorkingDirectory;
 	private final String _portalBranchName;
 	private final PortalGitWorkingDirectory _portalGitWorkingDirectory;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1647,7 +1647,15 @@ public class JenkinsResultsParserUtil {
 		for (Object key : properties.keySet()) {
 			String keyString = key.toString();
 
-			if (!keyString.startsWith(basePropertyName)) {
+			Matcher matcher = _propertyNamePattern.matcher(keyString);
+
+			if (!matcher.find()) {
+				continue;
+			}
+
+			String name = matcher.group("name");
+
+			if (!name.equals(basePropertyName)) {
 				continue;
 			}
 
@@ -3693,6 +3701,8 @@ public class JenkinsResultsParserUtil {
 		"http://(test-[0-9]+-[0-9]+)/");
 	private static final Pattern _nestedPropertyPattern = Pattern.compile(
 		"\\$\\{([^\\}]+)\\}");
+	private static final Pattern _propertyNamePattern = Pattern.compile(
+		"(?<name>[^\\[]+)");
 	private static final Pattern _propertyOptionPattern = Pattern.compile(
 		"\\[(?<opt>[^\\]]+)\\]");
 	private static final Set<String> _redactTokens = new HashSet<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1629,7 +1629,8 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static String getProperty(
-		Properties properties, String basePropertyName, String... opts) {
+		Properties properties, String basePropertyName,
+		boolean useBasePropertyAsDefault, String... opts) {
 
 		if ((opts == null) || (opts.length == 0)) {
 			return _getProperty(
@@ -1712,11 +1713,23 @@ public class JenkinsResultsParserUtil {
 			}
 		}
 
-		if (propertyName == null) {
-			propertyName = basePropertyName;
+		if (propertyName != null) {
+			return _getProperty(
+				properties, new ArrayList<String>(), propertyName);
 		}
 
-		return _getProperty(properties, new ArrayList<String>(), propertyName);
+		if (useBasePropertyAsDefault) {
+			return _getProperty(
+				properties, new ArrayList<String>(), basePropertyName);
+		}
+
+		return null;
+	}
+
+	public static String getProperty(
+		Properties properties, String basePropertyName, String... opts) {
+
+		return getProperty(properties, basePropertyName, true, opts);
 	}
 
 	public static String getRandomGitHubDevNodeHostname() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -3523,7 +3523,7 @@ public class JenkinsResultsParserUtil {
 		int maxOptCount = 0;
 
 		for (String propertyName : propertyNames) {
-			Matcher matcher = _propertyNamePattern.matcher(propertyName);
+			Matcher matcher = _propertyOptionPattern.matcher(propertyName);
 
 			Set<String> optSet = new LinkedHashSet<>();
 
@@ -3693,7 +3693,7 @@ public class JenkinsResultsParserUtil {
 		"http://(test-[0-9]+-[0-9]+)/");
 	private static final Pattern _nestedPropertyPattern = Pattern.compile(
 		"\\$\\{([^\\}]+)\\}");
-	private static final Pattern _propertyNamePattern = Pattern.compile(
+	private static final Pattern _propertyOptionPattern = Pattern.compile(
 		"\\[(?<opt>[^\\]]+)\\]");
 	private static final Set<String> _redactTokens = new HashSet<>();
 	private static final Pattern _remoteURLAuthorityPattern1 = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
@@ -57,7 +57,16 @@ public class JobFactory {
 		String repositoryName) {
 
 		return _newJob(
-			jobName, testSuiteName, portalBranchName, repositoryName);
+			jobName, testSuiteName, portalBranchName, repositoryName, null);
+	}
+
+	public static Job newJob(
+		String jobName, String testSuiteName, String portalBranchName,
+		String repositoryName, BasePortalReleaseJob.BuildProfile buildProfile) {
+
+		return _newJob(
+			jobName, testSuiteName, portalBranchName, repositoryName,
+			buildProfile);
 	}
 
 	private static boolean _isCentralMergePullRequest(
@@ -81,7 +90,7 @@ public class JobFactory {
 
 	private static Job _newJob(
 		String jobName, String testSuiteName, String portalBranchName,
-		String repositoryName) {
+		String repositoryName, BasePortalReleaseJob.BuildProfile buildProfile) {
 
 		String jobKey = jobName;
 
@@ -168,20 +177,26 @@ public class JobFactory {
 
 		if (jobName.equals("test-portal-fixpack-release")) {
 			_jobs.put(
-				jobKey, new PortalFixpackReleaseJob(jobName, portalBranchName));
+				jobKey,
+				new PortalFixpackReleaseJob(
+					jobName, portalBranchName, buildProfile));
 
 			return _jobs.get(jobKey);
 		}
 
 		if (jobName.equals("test-portal-hotfix-release")) {
 			_jobs.put(
-				jobKey, new PortalHotfixReleaseJob(jobName, portalBranchName));
+				jobKey,
+				new PortalHotfixReleaseJob(
+					jobName, portalBranchName, buildProfile));
 
 			return _jobs.get(jobKey);
 		}
 
 		if (jobName.equals("test-portal-release")) {
-			_jobs.put(jobKey, new PortalReleaseJob(jobName, portalBranchName));
+			_jobs.put(
+				jobKey,
+				new PortalReleaseJob(jobName, portalBranchName, buildProfile));
 
 			return _jobs.get(jobKey);
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalFixpackReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalFixpackReleaseJob.java
@@ -21,8 +21,10 @@ import java.io.File;
  */
 public class PortalFixpackReleaseJob extends BasePortalReleaseJob {
 
-	public PortalFixpackReleaseJob(String jobName, String portalBranchName) {
-		super(jobName, portalBranchName);
+	public PortalFixpackReleaseJob(
+		String jobName, String portalBranchName, BuildProfile buildProfile) {
+
+		super(jobName, portalBranchName, buildProfile);
 
 		GitWorkingDirectory jenkinsGitWorkingDirectory =
 			getJenkinsGitWorkingDirectory();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalHotfixReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalHotfixReleaseJob.java
@@ -21,8 +21,10 @@ import java.io.File;
  */
 public class PortalHotfixReleaseJob extends BasePortalReleaseJob {
 
-	public PortalHotfixReleaseJob(String jobName, String portalBranchName) {
-		super(jobName, portalBranchName);
+	public PortalHotfixReleaseJob(
+		String jobName, String portalBranchName, BuildProfile buildProfile) {
+
+		super(jobName, portalBranchName, buildProfile);
 
 		GitWorkingDirectory jenkinsGitWorkingDirectory =
 			getJenkinsGitWorkingDirectory();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
@@ -67,13 +67,13 @@ public class PortalReleaseJob extends BasePortalReleaseJob {
 		batchNames.addAll(
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
-					jobProperties, "test.batch.names.optional",
+					jobProperties, "test.batch.names.optional", false,
 					_portalReleaseRef)));
 
 		batchNames.addAll(
 			getSetFromString(
 				JenkinsResultsParserUtil.getProperty(
-					jobProperties, "test.batch.names.optional",
+					jobProperties, "test.batch.names.optional", false,
 					_portalReleaseRef, buildProfile.toString())));
 
 		return batchNames;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
@@ -24,8 +24,10 @@ import java.util.Set;
  */
 public class PortalReleaseJob extends BasePortalReleaseJob {
 
-	public PortalReleaseJob(String jobName, String portalBranchName) {
-		super(jobName, portalBranchName);
+	public PortalReleaseJob(
+		String jobName, String portalBranchName, BuildProfile buildProfile) {
+
+		super(jobName, portalBranchName, buildProfile);
 
 		GitWorkingDirectory jenkinsGitWorkingDirectory =
 			getJenkinsGitWorkingDirectory();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalReleaseJob.java
@@ -17,7 +17,9 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 
 import java.util.Collections;
+import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Michael Hashimoto
@@ -58,11 +60,23 @@ public class PortalReleaseJob extends BasePortalReleaseJob {
 			return Collections.emptySet();
 		}
 
-		String testBatchNamesString = JenkinsResultsParserUtil.getProperty(
-			getJobProperties(),
-			"test.batch.names.optional[" + _portalReleaseRef + "]");
+		Set<String> batchNames = new TreeSet<>();
 
-		return getSetFromString(testBatchNamesString);
+		Properties jobProperties = getJobProperties();
+
+		batchNames.addAll(
+			getSetFromString(
+				JenkinsResultsParserUtil.getProperty(
+					jobProperties, "test.batch.names.optional",
+					_portalReleaseRef)));
+
+		batchNames.addAll(
+			getSetFromString(
+				JenkinsResultsParserUtil.getProperty(
+					jobProperties, "test.batch.names.optional",
+					_portalReleaseRef, buildProfile.toString())));
+
+		return batchNames;
 	}
 
 	private String _portalReleaseRef;


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1327

Tested the jenkins results parser jar created from this pull here:
(Search for `# Batch Names: #`)
`dxp` portal release: https://test-1-20.liferay.com/job/test-portal-release/100/consoleFull
`portal` portal release: https://test-1-20.liferay.com/job/test-portal-release/99/consoleFull

Regular relevant pull request to make sure jar is compatible:
https://github.com/yichenroy/liferay-portal/pull/480#issuecomment-669481239