### PR TITLE
LRCI-1431 Simplify reinvocation message

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2908,14 +2908,7 @@ public abstract class BaseBuild implements Build {
 	}
 
 	protected String getReinvokedMessage() {
-		StringBuffer sb = new StringBuffer();
-
-		sb.append("Reinvoked: ");
-		sb.append(getBuildURL());
-		sb.append(" at ");
-		sb.append(getInvocationURL());
-
-		return sb.toString();
+		return "Reinvoked: " + getBuildURL();
 	}
 
 	protected JSONObject getRunningBuildJSONObject() throws IOException {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1431

Something else that I noticed in BaseBuild.checkForReinvocation, is that the consoleText that we're reading from Jenkins has already been filtered by the MaskPassword plugin. This means that the token in the invocation URL is replaced with **** in the console text. I think it's ok to not put the invocation URL information as it's already available in the original failed build that gets printed out.