### PR TITLE
POSHI-108 Simplify BaseWebDriverImpl.clickAt

### DIFF
--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -806,27 +806,23 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 			click(locator);
 		}
 		else {
-			try {
-				WebElement webElement = getWebElement(locator);
+			WebElement webElement = getWebElement(locator);
 
-				WrapsDriver wrapsDriver = (WrapsDriver)webElement;
+			WrapsDriver wrapsDriver = (WrapsDriver)webElement;
 
-				WebDriver webDriver = wrapsDriver.getWrappedDriver();
+			WebDriver webDriver = wrapsDriver.getWrappedDriver();
 
-				Actions actions = new Actions(webDriver);
+			Actions actions = new Actions(webDriver);
 
-				actions.moveToElement(webElement, offsetX, offsetY);
+			actions.moveToElement(webElement, offsetX, offsetY);
 
-				actions.pause(1500);
+			actions.pause(1500);
 
-				actions.click();
+			actions.click();
 
-				Action action = actions.build();
+			Action action = actions.build();
 
-				action.perform();
-			}
-			catch (Exception exception) {
-			}
+			action.perform();
 		}
 	}
 

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -792,12 +792,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 	@Override
 	public void clickAt(String locator, String coordString) {
-		clickAt(locator, coordString, true);
-	}
-
-	public void clickAt(
-		String locator, String coordString, boolean scrollIntoView) {
-
 		int offsetX = 0;
 		int offsetY = 0;
 
@@ -812,51 +806,24 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 			click(locator);
 		}
 		else {
-			WebElement bodyWebElement = getWebElement("//body");
-
-			WrapsDriver wrapsDriver = (WrapsDriver)bodyWebElement;
-
-			WebDriver webDriver = wrapsDriver.getWrappedDriver();
-
-			WebDriver.Options options = webDriver.manage();
-
-			WebDriver.Window window = options.window();
-
-			Point windowPoint = window.getPosition();
-
-			WebElement webElement = getWebElement(locator);
-
-			Point webElementPoint = webElement.getLocation();
-
-			int clickDestinationX = 0;
-			int clickDestinationY = 0;
-
-			if (scrollIntoView) {
-				scrollWebElementIntoView(webElement);
-
-				clickDestinationX =
-					windowPoint.getX() + webElementPoint.getX() + offsetX;
-				clickDestinationY = windowPoint.getY() + offsetY;
-			}
-			else {
-				clickDestinationX =
-					windowPoint.getX() + webElementPoint.getX() + offsetX;
-				clickDestinationY =
-					windowPoint.getY() + webElementPoint.getY() + offsetY;
-			}
-
 			try {
-				Robot robot = new Robot();
+				WebElement webElement = getWebElement(locator);
 
-				robot.mouseMove(clickDestinationX, clickDestinationY);
+				WrapsDriver wrapsDriver = (WrapsDriver)webElement;
 
-				robot.mousePress(KeyEvent.BUTTON1_MASK);
+				WebDriver webDriver = wrapsDriver.getWrappedDriver();
 
-				robot.delay(1500);
+				Actions actions = new Actions(webDriver);
 
-				robot.mouseRelease(KeyEvent.BUTTON1_MASK);
+				actions.moveToElement(webElement, offsetX, offsetY);
 
-				robot.delay(1500);
+				actions.pause(1500);
+
+				actions.click();
+
+				Action action = actions.build();
+
+				action.perform();
 			}
 			catch (Exception exception) {
 			}

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -808,6 +808,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		else {
 			WebElement webElement = getWebElement(locator);
 
+			scrollWebElementIntoView(webElement);
+
 			WrapsDriver wrapsDriver = (WrapsDriver)webElement;
 
 			WebDriver webDriver = wrapsDriver.getWrappedDriver();

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/ChromeWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/ChromeWebDriverImpl.java
@@ -57,11 +57,9 @@ public class ChromeWebDriverImpl extends BaseWebDriverImpl {
 	}
 
 	@Override
-	public void clickAt(
-		String locator, String coordString, boolean scrollIntoView) {
-
+	public void clickAt(String locator, String coordString) {
 		try {
-			super.clickAt(locator, coordString, scrollIntoView);
+			super.clickAt(locator, coordString);
 		}
 		catch (WebDriverException webDriverException) {
 			String message = webDriverException.getMessage();


### PR DESCRIPTION
https://issues.liferay.com/browse/POSHI-108

@Tim-Cao, I added the 'scrollIntoView' back in. This logic is there because in some cases a web element would not be clickable because it was not viewable in the browser window. I'm adding it back in by default as a safeguard, which is how it previously functioned.