### PR TITLE
LRCI-1750 Increase POSHI heap size from 2GB to 4GB

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -910,7 +910,7 @@ jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 				override="true"
 				property="poshi.java.jdk.opts"
 				regexp="(-Xmx)(\d*\w*)"
-				replace="\12048m"
+				replace="\14096m"
 			/>
 
 			<propertyregex


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1750

Please backport all the way down to 7.0.x (clean cherry-pick). 

Tested here:
https://test-1-9.liferay.com//userContent/jobs/test-portal-acceptance-pullrequest(master)/builds/3793/jenkins-report.html

cc @xbrianlee