### PR TITLE
LRCI-1724 Rework UpstreamFailureUtil and BuildDatabaseUtil for new 'ci:reevaluate' command

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -3185,7 +3185,8 @@ public abstract class BaseBuild implements Build {
 		Map<String, String> tempMap = new HashMap<>();
 
 		if (!fromArchive) {
-			BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase();
+			BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase(
+				this);
 
 			Properties properties = buildDatabase.getProperties(tempMapName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1403,6 +1403,12 @@ public abstract class BaseBuild implements Build {
 		return !_status.equals(_previousStatus);
 	}
 
+	public boolean isCompareToUpstream() {
+		TopLevelBuild topLevelBuild = getTopLevelBuild();
+
+		return topLevelBuild.isCompareToUpstream();
+	}
+
 	@Override
 	public boolean isFromArchive() {
 		return fromArchive;
@@ -3226,12 +3232,6 @@ public abstract class BaseBuild implements Build {
 		}
 
 		throw new IllegalArgumentException("Invalid status: " + status);
-	}
-
-	protected boolean isCompareToUpstream() {
-		TopLevelBuild topLevelBuild = getTopLevelBuild();
-
-		return topLevelBuild.isCompareToUpstream();
 	}
 
 	protected boolean isParentBuildRoot() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseGitRepository.java
@@ -126,7 +126,7 @@ public abstract class BaseGitRepository implements GitRepository {
 	private static final String[] _KEYS_REQUIRED = {"name"};
 
 	private static final String _URL_PROPERTIES_REPOSITORY =
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
+		JenkinsResultsParserUtil.URL_CACHE +
 			"/liferay-jenkins-ee/commands/repository.properties";
 
 	private static Properties _repositoryProperties;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -187,6 +187,8 @@ public interface Build {
 
 	public boolean isBuildModified();
 
+	public boolean isCompareToUpstream();
+
 	public boolean isFromArchive();
 
 	public boolean isFromCompletedBuild();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDatabaseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDatabaseUtil.java
@@ -75,6 +75,10 @@ public class BuildDatabaseUtil {
 		return _buildDatabase;
 	}
 
+	public static void reset() {
+		_buildDatabase = null;
+	}
+
 	private static void _downloadBuildDatabaseFile(File baseDir, Build build) {
 		JenkinsMaster jenkinsMaster = build.getJenkinsMaster();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDatabaseUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildDatabaseUtil.java
@@ -30,7 +30,7 @@ public class BuildDatabaseUtil {
 	}
 
 	public static BuildDatabase getBuildDatabase(Build build) {
-		return getBuildDatabase(null, build, true);
+		return getBuildDatabase(_getDistPath(build), build, true);
 	}
 
 	public static BuildDatabase getBuildDatabase(
@@ -183,6 +183,27 @@ public class BuildDatabaseUtil {
 				JenkinsResultsParserUtil.sleep(3000);
 			}
 		}
+	}
+
+	private static String _getDistPath(Build build) {
+		StringBuilder sb = new StringBuilder();
+
+		if (JenkinsResultsParserUtil.isWindows()) {
+			sb.append("C:");
+		}
+
+		sb.append("/tmp/jenkins/");
+
+		JenkinsMaster jenkinsMaster = build.getJenkinsMaster();
+
+		sb.append(jenkinsMaster.getName());
+
+		sb.append("/");
+		sb.append(build.getJobName());
+		sb.append("/");
+		sb.append(build.getBuildNumber());
+
+		return sb.toString();
 	}
 
 	private static BuildDatabase _buildDatabase;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1976,6 +1976,18 @@ public class GitWorkingDirectory {
 		}
 	}
 
+	public boolean refContainsSHA(String ref, String sha) {
+		GitUtil.ExecutionResult executionResult = executeBashCommands(
+			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY, 1000 * 60 * 2,
+			"git merge-base --is-ancestor " + sha + " " + ref);
+
+		if (executionResult.getExitValue() == 0) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean remoteGitBranchExists(
 		String branchName, GitRemote gitRemote) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2501,6 +2501,22 @@ public class JenkinsResultsParserUtil {
 			int timeout, HTTPAuthorization httpAuthorizationHeader)
 		throws IOException {
 
+		if (!isCINode() && url.startsWith("file:") &&
+			url.contains("liferay-jenkins-results-parser-samples-ee")) {
+
+			File file = new File(url.replace("file:", ""));
+
+			if (!file.exists()) {
+				if (url.contains("json?")) {
+					url = url.substring(0, url.indexOf("json?") + 4);
+				}
+
+				if (url.contains("json[qt]")) {
+					url = url.substring(0, url.indexOf("json[qt]") + 4);
+				}
+			}
+		}
+
 		if (url.contains("/userContent/") && (timeout == 0)) {
 			timeout = 5000;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -3274,8 +3274,6 @@ public class JenkinsResultsParserUtil {
 	protected static String initCacheURL() {
 		String cacheDirPath = System.getenv("CACHE_DIR");
 
-		System.out.println("Using : " + cacheDirPath);
-
 		if (cacheDirPath != null) {
 			File cacheDir = new File(cacheDirPath);
 
@@ -3288,6 +3286,9 @@ public class JenkinsResultsParserUtil {
 						break;
 					}
 				}
+
+				System.out.println(
+					"Using " + cacheDirPath + " for cached files");
 
 				return "file://" + cacheDirPath;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -99,22 +99,23 @@ import org.json.JSONObject;
  */
 public class JenkinsResultsParserUtil {
 
+	public static final String[] CACHED_REPOSITORIES = {
+		"liferay-jenkins-ee", "liferay-jenkins-results-parser-samples-ee",
+		"liferay-portal"
+	};
+
+	public static final String URL_CACHE = initCacheURL();
+
 	public static final String[] URLS_BUILD_PROPERTIES_DEFAULT = {
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
-			"/liferay-jenkins-ee/build.properties",
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
-			"/liferay-jenkins-ee/commands/build.properties",
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
-			"/liferay-portal/build.properties",
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
-			"/liferay-portal/ci.properties",
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
-			"/liferay-portal/test.properties"
+		URL_CACHE + "/liferay-jenkins-ee/build.properties",
+		URL_CACHE + "/liferay-jenkins-ee/commands/build.properties",
+		URL_CACHE + "/liferay-portal/build.properties",
+		URL_CACHE + "/liferay-portal/ci.properties",
+		URL_CACHE + "/liferay-portal/test.properties"
 	};
 
 	public static final String[] URLS_JENKINS_PROPERTIES_DEFAULT = {
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
-			"/liferay-jenkins-ee/jenkins.properties"
+		URL_CACHE + "/liferay-jenkins-ee/jenkins.properties"
 	};
 
 	public static boolean debug;
@@ -3254,11 +3255,35 @@ public class JenkinsResultsParserUtil {
 
 	}
 
+	protected static String initCacheURL() {
+		String cacheDirPath = System.getenv("CACHE_DIR");
+
+		System.out.println("Using : " + cacheDirPath);
+
+		if (cacheDirPath != null) {
+			File cacheDir = new File(cacheDirPath);
+
+			if (cacheDir.exists()) {
+				for (String cachedRepository : CACHED_REPOSITORIES) {
+					File cacheRepositoryDir = new File(
+						cacheDir, cachedRepository);
+
+					if (!cacheRepositoryDir.exists()) {
+						break;
+					}
+				}
+
+				return "file://" + cacheDirPath;
+			}
+		}
+
+		return "http://mirrors-no-cache.lax.liferay.com/github.com/liferay";
+	}
+
 	protected static final String URL_DEPENDENCIES_FILE;
 
 	protected static final String URL_DEPENDENCIES_HTTP =
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
-			"/liferay-jenkins-results-parser-samples-ee/1/";
+		URL_CACHE + "/liferay-jenkins-results-parser-samples-ee/1/";
 
 	static {
 		File dependenciesDir = new File("src/test/resources/dependencies/");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiAxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiAxisBuild.java
@@ -88,9 +88,8 @@ public class PoshiAxisBuild extends AxisBuild {
 	}
 
 	private List<String> _getPoshiTestNames() {
-		TopLevelBuild topLevelBuild = getTopLevelBuild();
-
-		BuildDatabase buildDatabase = topLevelBuild.getBuildDatabase();
+		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase(
+			getTopLevelBuild());
 
 		List<String> poshiTestNames = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiAxisBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiAxisBuild.java
@@ -88,14 +88,14 @@ public class PoshiAxisBuild extends AxisBuild {
 	}
 
 	private List<String> _getPoshiTestNames() {
-		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase(
-			getTopLevelBuild());
-
 		List<String> poshiTestNames = new ArrayList<>();
 
-		if (buildDatabase == null) {
+		if (fromArchive) {
 			return poshiTestNames;
 		}
+
+		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase(
+			getTopLevelBuild());
 
 		Properties startProperties = buildDatabase.getProperties(
 			getJobVariant() + "/start.properties");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequestPortalTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequestPortalTopLevelBuild.java
@@ -35,6 +35,8 @@ public class PullRequestPortalTopLevelBuild
 
 		super(url, topLevelBuild);
 
+		setCompareToUpstream(true);
+
 		try {
 			String testSuiteName = getTestSuiteName();
 
@@ -97,7 +99,9 @@ public class PullRequestPortalTopLevelBuild
 					"pull.request.forward.upstream.failure.comparison." +
 						"enabled"));
 
-		if (!pullRequestForwardUpstreamFailureComparisonEnabled) {
+		if (!pullRequestForwardUpstreamFailureComparisonEnabled ||
+			!isCompareToUpstream()) {
+
 			return result;
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -30,7 +30,6 @@ import com.liferay.jenkins.results.parser.failure.message.generator.PoshiTestFai
 import com.liferay.jenkins.results.parser.failure.message.generator.PoshiValidationFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.RebaseFailureMessageGenerator;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 
@@ -201,63 +200,6 @@ public abstract class TopLevelBuild extends BaseBuild {
 		String tempMapName = "git." + gitRepositoryType + ".properties";
 
 		return getTempMap(tempMapName);
-	}
-
-	public BuildDatabase getBuildDatabase() {
-		if (fromArchive) {
-			return null;
-		}
-
-		if (_buildDatabase != null) {
-			return _buildDatabase;
-		}
-
-		StringBuilder sb = new StringBuilder();
-
-		if (JenkinsResultsParserUtil.isWindows()) {
-			sb.append("C:");
-		}
-
-		sb.append("/tmp/jenkins/");
-
-		JenkinsMaster jenkinsMaster = getJenkinsMaster();
-
-		sb.append(jenkinsMaster.getName());
-
-		sb.append("/");
-		sb.append(getJobName());
-		sb.append("/");
-		sb.append(getBuildNumber());
-
-		File buildDatabaseFile = new File(
-			sb.toString(), BuildDatabase.FILE_NAME_BUILD_DATABASE);
-
-		try {
-			String buildDatabaseFileContent = null;
-
-			if (buildDatabaseFile.exists()) {
-				buildDatabaseFileContent = JenkinsResultsParserUtil.read(
-					buildDatabaseFile);
-			}
-
-			if ((buildDatabaseFileContent == null) ||
-				buildDatabaseFileContent.isEmpty()) {
-
-				buildDatabaseFileContent = JenkinsResultsParserUtil.toString(
-					_getBuildDatabaseURL());
-
-				JenkinsResultsParserUtil.write(
-					buildDatabaseFile, buildDatabaseFileContent);
-			}
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		_buildDatabase = new DefaultBuildDatabase(
-			buildDatabaseFile.getParentFile());
-
-		return _buildDatabase;
 	}
 
 	public String getCompanionBranchName() {
@@ -1675,19 +1617,6 @@ public abstract class TopLevelBuild extends BaseBuild {
 	protected static final Pattern gitRepositoryTempMapNamePattern =
 		Pattern.compile("git\\.(?<gitRepositoryType>.*)\\.properties");
 
-	private String _getBuildDatabaseURL() {
-		if (fromArchive) {
-			return getBuildURL() + "/build-database.json";
-		}
-
-		JenkinsMaster jenkinsMaster = getJenkinsMaster();
-
-		return JenkinsResultsParserUtil.combine(
-			"https://", jenkinsMaster.getName(), ".liferay.com/",
-			"userContent/jobs/", getJobName(), "/builds/",
-			String.valueOf(getBuildNumber()), "/build-database.json");
-	}
-
 	private Map<Map<String, String>, Integer> _getSlaveUsageByLabels() {
 		Map<Map<String, String>, Integer> slaveUsages = new HashMap<>();
 
@@ -1746,7 +1675,6 @@ public abstract class TopLevelBuild extends BaseBuild {
 	private static ExecutorService _executorService =
 		JenkinsResultsParserUtil.getNewThreadPoolExecutor(10, true);
 
-	private BuildDatabase _buildDatabase;
 	private boolean _compareToUpstream = true;
 	private Build _controllerBuild;
 	private long _lastDownstreamBuildsListingTimestamp = -1L;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -446,6 +446,11 @@ public abstract class TopLevelBuild extends BaseBuild {
 	}
 
 	@Override
+	public boolean isCompareToUpstream() {
+		return _compareToUpstream;
+	}
+
+	@Override
 	public boolean isUniqueFailure() {
 		return true;
 	}
@@ -1556,11 +1561,6 @@ public abstract class TopLevelBuild extends BaseBuild {
 		return upstreamBranchSHA;
 	}
 
-	@Override
-	protected boolean isCompareToUpstream() {
-		return _compareToUpstream;
-	}
-
 	protected void sendBuildMetrics(String message) {
 		if (_sendBuildMetrics) {
 			DatagramRequestUtil.send(
@@ -1675,7 +1675,7 @@ public abstract class TopLevelBuild extends BaseBuild {
 	private static ExecutorService _executorService =
 		JenkinsResultsParserUtil.getNewThreadPoolExecutor(10, true);
 
-	private boolean _compareToUpstream = true;
+	private boolean _compareToUpstream;
 	private Build _controllerBuild;
 	private long _lastDownstreamBuildsListingTimestamp = -1L;
 	private String _metricsHostName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -132,8 +132,13 @@ public class UpstreamFailureUtil {
 			}
 
 			System.out.println(
-				"Using upstream failures at: " +
-					getUpstreamJobFailuresSHA(topLevelBuild));
+				JenkinsResultsParserUtil.combine(
+					"Comparing with test results from ",
+					topLevelBuild.getAcceptanceUpstreamJobURL(), "/",
+					String.valueOf(
+						_upstreamFailuresJobJSONObject.getInt("buildNumber")),
+					" at SHA ",
+					_upstreamFailuresJobJSONObject.getString("SHA")));
 		}
 		catch (IOException ioException) {
 			System.out.println(ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -104,7 +104,7 @@ public class UpstreamFailureUtil {
 	}
 
 	public static boolean isBuildFailingInUpstreamJob(Build build) {
-		if (!isUpstreamComparisonAvailable()) {
+		if (!isUpstreamComparisonAvailable() || !build.isCompareToUpstream()) {
 			return false;
 		}
 
@@ -137,11 +137,11 @@ public class UpstreamFailureUtil {
 	}
 
 	public static boolean isTestFailingInUpstreamJob(TestResult testResult) {
-		if (!isUpstreamComparisonAvailable()) {
+		Build build = testResult.getBuild();
+
+		if (!isUpstreamComparisonAvailable() || !build.isCompareToUpstream()) {
 			return false;
 		}
-
-		Build build = testResult.getBuild();
 
 		TopLevelBuild topLevelBuild = build.getTopLevelBuild();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -114,7 +114,7 @@ public class UpstreamFailureUtil {
 
 		try {
 			File upstreamJobFailuresJSONFile = new File(
-				System.getenv("WORKSPACE"), "upstream-failures.json");
+				System.getenv("WORKSPACE"), "test.results.json");
 
 			if (upstreamJobFailuresJSONFile.exists()) {
 				String fileContent = JenkinsResultsParserUtil.read(
@@ -131,6 +131,10 @@ public class UpstreamFailureUtil {
 
 				_upstreamFailuresJobJSONObject =
 					JenkinsResultsParserUtil.toJSONObject(url, false, 5000);
+
+				JenkinsResultsParserUtil.write(
+					upstreamJobFailuresJSONFile,
+					_upstreamFailuresJobJSONObject.toString());
 			}
 
 			System.out.println(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/WorkspaceUtil.java
@@ -148,7 +148,7 @@ public class WorkspaceUtil {
 	}
 
 	private static final String _URL_WORKSPACE_PROPERTIES =
-		"http://mirrors-no-cache.lax.liferay.com/github.com/liferay" +
+		JenkinsResultsParserUtil.URL_CACHE +
 			"/liferay-jenkins-ee/commands/workspace.properties";
 
 	private static Properties _workspaceProperties;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitHubMessageTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitHubMessageTest.java
@@ -16,51 +16,94 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /**
  * @author Peter Yoo
  */
+@RunWith(Parameterized.class)
 public class GitHubMessageTest extends BuildTest {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<String[]> sampleData() {
+		return Arrays.asList(
+			new String[][] {
+				{
+					"test-jenkins-acceptance-pullrequest_passed", "117",
+					"test-jenkins-acceptance-pullrequest", "test-1-17"
+				},
+				{
+					"test-plugins-acceptance-pullrequest(ee-6.2.x)_passed",
+					"66", "test-plugins-acceptance-pullrequest(ee-6.2.x)",
+					"test-1-8"
+				},
+				{
+					"test-portal-acceptance-pullrequest(7.0.x)" +
+						"_unresolved-req-failure",
+					"103", "test-portal-acceptance-pullrequest(7.0.x)",
+					"test-1-14"
+				},
+				{
+					"test-portal-acceptance-pullrequest(ee-6.2.x)_passed",
+					"337", "test-portal-acceptance-pullrequest(ee-6.2.x)",
+					"test-1-17"
+				},
+				{
+					"test-portal-acceptance-pullrequest(master)" +
+						"_generic-failure",
+					"1375", "test-portal-acceptance-pullrequest(master)",
+					"test-1-1"
+				},
+				{
+					"test-portal-acceptance-pullrequest(master)" +
+						"_modules-compile-failure",
+					"999", "test-portal-acceptance-pullrequest(master)",
+					"test-1-21"
+				},
+				{
+					"test-portal-acceptance-pullrequest(master)_passed", "446",
+					"test-portal-acceptance-pullrequest(master)", "test-1-8"
+				},
+				{
+					"test-portal-acceptance-pullrequest(master)" +
+						"_poshi-test-failure",
+					"1268", "test-portal-acceptance-pullrequest(master)",
+					"test-1-9"
+				},
+				{
+					"test-portal-acceptance-pullrequest(master)" +
+						"_semantic_versioning_failure",
+					"2003", "test-portal-acceptance-pullrequest(master)",
+					"test-1-3"
+				},
+				{
+					"test-portal-source-format_source-format-failure", "587",
+					"test-portal-source-format", "test-1-22"
+				}
+			});
+	}
+
+	public GitHubMessageTest(
+		String sampleKey, String buildNumber, String jobName, String hostName) {
+
+		_sampleKey = sampleKey;
+		_buildNumber = buildNumber;
+		_jobName = jobName;
+		_hostName = hostName;
+	}
 
 	@Before
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
 
-		downloadSample(
-			"test-jenkins-acceptance-pullrequest_passed", "117",
-			"test-jenkins-acceptance-pullrequest", "test-1-17");
-		downloadSample(
-			"test-plugins-acceptance-pullrequest(ee-6.2.x)_passed", "66",
-			"test-plugins-acceptance-pullrequest(ee-6.2.x)", "test-1-8");
-		downloadSample(
-			"test-portal-acceptance-pullrequest(7.0.x)_unresolved-req-failure",
-			"103", "test-portal-acceptance-pullrequest(7.0.x)", "test-1-14");
-		downloadSample(
-			"test-portal-acceptance-pullrequest(ee-6.2.x)_passed", "337",
-			"test-portal-acceptance-pullrequest(ee-6.2.x)", "test-1-17");
-		downloadSample(
-			"test-portal-acceptance-pullrequest(master)_generic-failure",
-			"1375", "test-portal-acceptance-pullrequest(master)", "test-1-1");
-		downloadSample(
-			"test-portal-acceptance-pullrequest(master)" +
-				"_modules-compile-failure",
-			"999", "test-portal-acceptance-pullrequest(master)", "test-1-21");
-		downloadSample(
-			"test-portal-acceptance-pullrequest(master)_passed", "446",
-			"test-portal-acceptance-pullrequest(master)", "test-1-8");
-		downloadSample(
-			"test-portal-acceptance-pullrequest(master)_poshi-test-failure",
-			"1268", "test-portal-acceptance-pullrequest(master)", "test-1-9");
-		downloadSample(
-			"test-portal-acceptance-pullrequest(master)" +
-				"_semantic_versioning_failure",
-			"2003", "test-portal-acceptance-pullrequest(master)", "test-1-3");
-		downloadSample(
-			"test-portal-source-format_source-format-failure", "587",
-			"test-portal-source-format", "test-1-22");
+		downloadSample(_sampleKey, _buildNumber, _jobName, _hostName);
 	}
 
 	@Test
@@ -87,5 +130,10 @@ public class GitHubMessageTest extends BuildTest {
 		return new File(
 			testSample.getSampleDir(), "expected-github-message.html");
 	}
+
+	private final String _buildNumber;
+	private final String _hostName;
+	private final String _jobName;
+	private final String _sampleKey;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1724

Resend of https://github.com/pyoo47/liferay-portal/pull/1527

Fixed the broken test, and added some bells and whistles. 

@michaelhashimoto, @yichenroy @pyoo47 fyi: 
#### `CACHE_DIR` environment variable
I updated our classes so that if the environment variable `CACHE_DIR` is set on our local machines then our Jenkins classes will read files from local repositories instead of mirrors-no-cache. The `CACHE_DIR` directory must contain these exact directories: `liferay-portal`, `liferay-jenkins-ee`, `liferay-jenkins-results-parser-samples-ee` (ideally it's the base dir of where your git repos are) for it to use the local files. For example, I've set `CACHE_DIR` to `/Users/kenjiheigel/Projects/github/`. 
```
~/Projects/github » tree -L 1
.
├── ...
├── jenkins-results-parser-tester
├── ...
├── liferay-binaries-cache-2020
├── ...
├── liferay-jenkins-ee
├── liferay-jenkins-results-parser-samples-ee
├── ...
├── liferay-portal
├── liferay-portal-ee
├── ...
└── poshi-dev-tools
```

For my own testing, I've set the [environment variables in Intellij](https://www.jetbrains.com/help/objc/add-environment-variables-and-program-arguments.html) for Application, Gradle, & JUnit templates. If you run tests with `gradlew` through command line, a simple `export CACHE_DIR=/Users/kenjiheigel/Projects/github/` should suffice.

Practically, this means that running tests that use the "samples" will be shorter, and additionally if you ever need to locally test new or custom properties with `JenkinsResultsParserUtil.getBuildProperties()`  without configuration or waiting for mirrors-no-cache, then you can just modify the local file and it will be read. 

Should save us some time when testing locally without having to remember how to configure the local testing.