### PR TITLE
LRCI-1724 Add methods to create/parse build id's

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/SpiraRelease.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/SpiraRelease.java
@@ -155,7 +155,7 @@ public class SpiraRelease extends IndentLevelSpiraArtifact {
 		}
 	}
 
-	public static int getID(String jobName, String suiteName) {
+	public static int getID(String jobName, String testSuiteName) {
 		Properties buildProperties = null;
 
 		try {
@@ -163,7 +163,8 @@ public class SpiraRelease extends IndentLevelSpiraArtifact {
 
 			return Integer.parseInt(
 				buildProperties.getProperty(
-					"spira.release.id[" + jobName + "][" + suiteName + "]"));
+					"spira.release.id[" + jobName + "][" + testSuiteName +
+						"]"));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1724

**Build ID**: 
```
1031312_8349
```

Here is how it works: https://regex101.com/r/VXK2nx/1

From that information we can generate this build URL: 
https://test-1-3.liferay.com/job/test-portal-acceptance-pullrequest(master)/8349

Eventually we'll post something in the GitHub comment like...

> To reevaluate this CI build against the latest valid upstream, please leave the following comment on this pull request: 
> ```
> ci:reevaluate:1031312_8349
> ```