### PR TITLE
LRCI-1645 Exclude LCS from source-format-jdk8 batch

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -6842,12 +6842,18 @@ information. Make sure to commit in all build services results.
 
 				<echo>Running com.liferay.source.formatter.jar ${Bundle-Version}.</echo>
 
+				<local name="excludes" />
+
+				<condition else="modules/dxp/apps/lcs/**" property="excludes" value="modules/dxp/**">
+					<equals arg1="${liferay.releng.public}" arg2="true" />
+				</condition>
+
 				<ant dir="portal-impl" target="format-source-all">
 					<property name="show.documentation" value="false" />
 					<property name="source.auto.fix" value="false" />
 					<property name="source.fail.on.auto.fix" value="true" />
 					<property name="source.fail.on.has.warning" value="true" />
-					<property if:true="${liferay.releng.public}" name="source.formatter.excludes" value="modules/private/**" />
+					<property name="source.formatter.excludes" value="${excludes}" />
 					<property name="source.print.errors" value="false" />
 					<property name="source.use.properties" value="false" />
 				</ant>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1645

Please backport to `7.1.x`, `7.2.x`, and `7.3.x` (clean cherry-pick)
I'll send in backport for `7.0.x` since it's not a clean cherry-pick.

Tested here:
https://github.com/yichenroy/liferay-portal/pull/537