### PR TITLE
LRCI-1848 Remove repository name from ci.test.auto.recipients

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -1,7 +1,7 @@
 allowed.sender.names[brianchandotcom]=\
     liferay-continuous-integration
 
-ci.test.auto.recipients[liferay-portal]=\
+ci.test.auto.recipients=\
     pyoo47[relevant:sf]
 
 ci.test.available.suites=\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1848

master only.