### PR TITLE
LRCI-1869 Remove the BatchTestClassGroup.BuildProfile enum

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -141,31 +141,6 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 
 	}
 
-	public static enum BuildProfile {
-
-		DXP {
-
-			private static final String _TEXT = "dxp";
-
-			@Override
-			public String toString() {
-				return _TEXT;
-			}
-
-		},
-		PORTAL {
-
-			private static final String _TEXT = "portal";
-
-			@Override
-			public String toString() {
-				return _TEXT;
-			}
-
-		}
-
-	}
-
 	protected BatchTestClassGroup(
 		String batchName, PortalTestClassJob portalTestClassJob) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/TestClassGroupFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/TestClassGroupFactory.java
@@ -43,8 +43,9 @@ public class TestClassGroupFactory {
 	}
 
 	public static BatchTestClassGroup newBatchTestClassGroup(
-		String batchName, BatchTestClassGroup.BuildProfile buildProfile,
-		Job job) {
+		String batchName, Job job) {
+
+		Job.BuildProfile buildProfile = job.getBuildProfile();
 
 		String key = JenkinsResultsParserUtil.combine(
 			batchName, "_", buildProfile.toString(), "_", job.getJobName());
@@ -122,19 +123,6 @@ public class TestClassGroupFactory {
 		_batchTestClassGroups.put(key, batchTestClassGroup);
 
 		return batchTestClassGroup;
-	}
-
-	public static BatchTestClassGroup newBatchTestClassGroup(
-		String batchName, Job job) {
-
-		BatchTestClassGroup.BuildProfile buildProfile =
-			BatchTestClassGroup.BuildProfile.PORTAL;
-
-		if (job.getBuildProfile() == Job.BuildProfile.DXP) {
-			buildProfile = BatchTestClassGroup.BuildProfile.DXP;
-		}
-
-		return newBatchTestClassGroup(batchName, buildProfile, job);
 	}
 
 	public static SegmentTestClassGroup newSegmentTestClassGroup(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1869