### PR TITLE
LRCI-1725 Add method to reset the UpstreamFailureUtil cache and json object

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -81,8 +81,6 @@ public class UpstreamFailureUtil {
 			JSONObject upstreamJobFailuresJSONObject =
 				getUpstreamJobFailuresJSONObject(topLevelBuild);
 
-			System.out.println(upstreamJobFailuresJSONObject);
-
 			return upstreamJobFailuresJSONObject.getInt("buildNumber");
 		}
 		catch (JSONException jsonException) {
@@ -189,6 +187,10 @@ public class UpstreamFailureUtil {
 			else {
 				_upstreamFailuresJobJSONObject =
 					_getUpstreamJobFailuresJSONObject(topLevelBuild);
+
+				System.out.println(
+					"Caching upstream test results in: " +
+						upstreamJobFailuresJSONFile);
 
 				JenkinsResultsParserUtil.write(
 					upstreamJobFailuresJSONFile,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -130,12 +130,9 @@ public class UpstreamFailureUtil {
 		}
 
 		try {
-			File upstreamJobFailuresJSONFile = new File(
-				System.getenv("WORKSPACE"), "test.results.json");
-
-			if (upstreamJobFailuresJSONFile.exists()) {
+			if (_upstreamJobFailuresJSONFile.exists()) {
 				String fileContent = JenkinsResultsParserUtil.read(
-					upstreamJobFailuresJSONFile);
+					_upstreamJobFailuresJSONFile);
 
 				_upstreamFailuresJobJSONObject = new JSONObject(fileContent);
 			}
@@ -145,10 +142,10 @@ public class UpstreamFailureUtil {
 
 				System.out.println(
 					"Caching upstream test results in: " +
-						upstreamJobFailuresJSONFile);
+						_upstreamJobFailuresJSONFile);
 
 				JenkinsResultsParserUtil.write(
-					upstreamJobFailuresJSONFile,
+					_upstreamJobFailuresJSONFile,
 					_upstreamFailuresJobJSONObject.toString());
 			}
 
@@ -247,6 +244,14 @@ public class UpstreamFailureUtil {
 		initUpstreamJobFailuresJSONObject(topLevelBuild);
 
 		return _upstreamComparisonAvailable;
+	}
+
+	public static void resetUpstreamJobFailuresJSONObject() {
+		if (_upstreamJobFailuresJSONFile.exists()) {
+			_upstreamJobFailuresJSONFile.delete();
+		}
+
+		_upstreamFailuresJobJSONObject = null;
 	}
 
 	private static String _formatJobVariant(String jobVariant) {
@@ -428,5 +433,7 @@ public class UpstreamFailureUtil {
 		new JSONObject("{\"SHA\":\"\",\"failedBatches\":[]}");
 	private static boolean _upstreamComparisonAvailable = true;
 	private static JSONObject _upstreamFailuresJobJSONObject;
+	private static final File _upstreamJobFailuresJSONFile = new File(
+		System.getenv("WORKSPACE"), "test.results.json");
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -29,51 +29,6 @@ import org.json.JSONObject;
  */
 public class UpstreamFailureUtil {
 
-	public static List<String> getUpstreamJobFailures(
-		String type, TopLevelBuild topLevelBuild) {
-
-		List<String> upstreamFailures = new ArrayList<>();
-
-		JSONObject upstreamJobFailuresJSONObject =
-			getUpstreamJobFailuresJSONObject(topLevelBuild);
-
-		JSONArray failedBatchesJSONArray =
-			upstreamJobFailuresJSONObject.optJSONArray("failedBatches");
-
-		if (failedBatchesJSONArray == null) {
-			return upstreamFailures;
-		}
-
-		for (int i = 0; i < failedBatchesJSONArray.length(); i++) {
-			JSONObject failedBatchJSONObject =
-				failedBatchesJSONArray.getJSONObject(i);
-
-			String jobVariant = failedBatchJSONObject.getString("jobVariant");
-
-			jobVariant = _formatJobVariant(jobVariant);
-
-			if (type.equals("build")) {
-				upstreamFailures.add(
-					_formatUpstreamBuildFailure(
-						jobVariant, failedBatchJSONObject.getString("result")));
-			}
-			else if (type.equals("test")) {
-				JSONArray failedTestsJSONArray =
-					failedBatchJSONObject.getJSONArray("failedTests");
-
-				for (int j = 0; j < failedTestsJSONArray.length(); j++) {
-					Object object = failedTestsJSONArray.get(j);
-
-					upstreamFailures.add(
-						_formatUpstreamTestFailure(
-							jobVariant, object.toString()));
-				}
-			}
-		}
-
-		return upstreamFailures;
-	}
-
 	public static int getUpstreamJobFailuresBuildNumber(
 		TopLevelBuild topLevelBuild) {
 
@@ -264,7 +219,7 @@ public class UpstreamFailureUtil {
 			jobVariant = _formatJobVariant(jobVariant);
 
 			for (String failure :
-					getUpstreamJobFailures("test", topLevelBuild)) {
+					_getUpstreamJobFailures("test", topLevelBuild)) {
 
 				if (failure.equals(
 						_formatUpstreamTestFailure(
@@ -346,6 +301,51 @@ public class UpstreamFailureUtil {
 		}
 	}
 
+	private static List<String> _getUpstreamJobFailures(
+		String type, TopLevelBuild topLevelBuild) {
+
+		List<String> upstreamFailures = new ArrayList<>();
+
+		JSONObject upstreamJobFailuresJSONObject =
+			getUpstreamJobFailuresJSONObject(topLevelBuild);
+
+		JSONArray failedBatchesJSONArray =
+			upstreamJobFailuresJSONObject.optJSONArray("failedBatches");
+
+		if (failedBatchesJSONArray == null) {
+			return upstreamFailures;
+		}
+
+		for (int i = 0; i < failedBatchesJSONArray.length(); i++) {
+			JSONObject failedBatchJSONObject =
+				failedBatchesJSONArray.getJSONObject(i);
+
+			String jobVariant = failedBatchJSONObject.getString("jobVariant");
+
+			jobVariant = _formatJobVariant(jobVariant);
+
+			if (type.equals("build")) {
+				upstreamFailures.add(
+					_formatUpstreamBuildFailure(
+						jobVariant, failedBatchJSONObject.getString("result")));
+			}
+			else if (type.equals("test")) {
+				JSONArray failedTestsJSONArray =
+					failedBatchJSONObject.getJSONArray("failedTests");
+
+				for (int j = 0; j < failedTestsJSONArray.length(); j++) {
+					Object object = failedTestsJSONArray.get(j);
+
+					upstreamFailures.add(
+						_formatUpstreamTestFailure(
+							jobVariant, object.toString()));
+				}
+			}
+		}
+
+		return upstreamFailures;
+	}
+
 	private static JSONObject _getUpstreamJobFailuresJSONObject(
 			String jobName, String buildNumber)
 		throws IOException {
@@ -409,7 +409,7 @@ public class UpstreamFailureUtil {
 		TopLevelBuild topLevelBuild = build.getTopLevelBuild();
 
 		for (String upstreamJobFailure :
-				getUpstreamJobFailures("build", topLevelBuild)) {
+				_getUpstreamJobFailures("build", topLevelBuild)) {
 
 			if (upstreamJobFailure.equals(
 					_formatUpstreamBuildFailure(jobVariant, result))) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1725

The plan is for ci:test:relevant builds to use the latest upstream result before posting the GitHub comment. 