### PR TITLE
LRCI-1958 Add SimpleBuild implementation

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SimpleBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SimpleBuild.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.net.URL;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class SimpleBuild extends BaseBuild {
+
+	public SimpleBuild(String url) {
+		super(url);
+	}
+
+	@Override
+	public void addTimelineData(TimelineData timelineData) {
+	}
+
+	@Override
+	public URL getArtifactsBaseURL() {
+		return null;
+	}
+
+	@Override
+	protected Element getGitHubMessageJobResultsElement() {
+		return null;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -51,25 +51,31 @@ public class UpstreamFailureUtil {
 	public static int getUpstreamJobFailuresBuildNumber(
 		TopLevelBuild topLevelBuild, String sha) {
 
-		int buildNumber = _getLastUpstreamBuildNumber(topLevelBuild);
+		int lastUpstreamBuildNumber = _getLastUpstreamBuildNumber(
+			topLevelBuild);
 
-		int oldestBuildNumber = Math.max(0, buildNumber - 10);
+		int buildNumber = lastUpstreamBuildNumber;
 
 		String jobURL = getUpstreamJobFailuresJobURL(topLevelBuild);
 
-		while (buildNumber > oldestBuildNumber) {
-			String upstreamBranchSHA =
-				JenkinsResultsParserUtil.getBuildParameter(
-					jobURL + "/" + buildNumber, "PORTAL_GIT_COMMIT");
+		while (buildNumber > Math.max(0, buildNumber - 10)) {
+			try {
+				String upstreamBranchSHA =
+					JenkinsResultsParserUtil.getBuildParameter(
+						jobURL + "/" + buildNumber, "PORTAL_GIT_COMMIT");
 
-			if (upstreamBranchSHA.equals(sha)) {
-				return buildNumber;
+				if (upstreamBranchSHA.equals(sha)) {
+					return buildNumber;
+				}
+			}
+			catch (RuntimeException runtimeException) {
+				System.out.println(runtimeException.getMessage());
 			}
 
 			buildNumber--;
 		}
 
-		return 0;
+		return lastUpstreamBuildNumber;
 	}
 
 	public static String getUpstreamJobFailuresJobURL(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1958

Basically, I just want to use the Jenkins api to check if a job is finished running \(`Build.getResult()`\). If I use TopLevelBuild, it gets all the additional downstream information, which is unnecessary.