### PR TITLE
LRCI-1951 Multiple GitHub comparison/reevaluation comment fixes

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequestPortalTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequestPortalTopLevelBuild.java
@@ -194,10 +194,16 @@ public class PullRequestPortalTopLevelBuild
 
 	@Override
 	public boolean isUniqueFailure() {
-		for (Build downstreamBuild : getFailedDownstreamBuilds()) {
+		List<Build> failedDownstreamBuilds = getFailedDownstreamBuilds();
+
+		for (Build downstreamBuild : failedDownstreamBuilds) {
 			if (downstreamBuild.isUniqueFailure()) {
 				return true;
 			}
+		}
+
+		if (failedDownstreamBuilds.isEmpty()) {
+			return true;
 		}
 
 		return false;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -1592,7 +1592,7 @@ public abstract class TopLevelBuild extends BaseBuild {
 				UpstreamFailureUtil.getUpstreamJobFailuresBuildNumber(
 					this, upstreamBranchSHA);
 
-			if ((result != null) && !result.equals("SUCCESS") &&
+			if ((result != null) && !result.matches("(APPROVED|SUCCESS)") &&
 				(buildNumber != 0) &&
 				!upstreamBranchSHA.equals(
 					UpstreamFailureUtil.getUpstreamJobFailuresSHA(this))) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -1593,7 +1593,7 @@ public abstract class TopLevelBuild extends BaseBuild {
 					this, upstreamBranchSHA);
 
 			if ((result != null) && !result.matches("(APPROVED|SUCCESS)") &&
-				(buildNumber != 0) &&
+				(downstreamBuilds.size() != 0) &&
 				!upstreamBranchSHA.equals(
 					UpstreamFailureUtil.getUpstreamJobFailuresSHA(this))) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuild.java
@@ -1592,11 +1592,7 @@ public abstract class TopLevelBuild extends BaseBuild {
 				UpstreamFailureUtil.getUpstreamJobFailuresBuildNumber(
 					this, upstreamBranchSHA);
 
-			if ((result != null) && !result.matches("(APPROVED|SUCCESS)") &&
-				(downstreamBuilds.size() != 0) &&
-				!upstreamBranchSHA.equals(
-					UpstreamFailureUtil.getUpstreamJobFailuresSHA(this))) {
-
+			if (isEligibleForReevaluation(result, upstreamBranchSHA)) {
 				Dom4JUtil.addToElement(
 					detailsElement, Dom4JUtil.getNewElement("br"),
 					getReevaluationDetailsElement(buildNumber));
@@ -1671,6 +1667,20 @@ public abstract class TopLevelBuild extends BaseBuild {
 					buildNumber));
 
 		return upstreamComparisonDetailsElement;
+	}
+
+	protected boolean isEligibleForReevaluation(
+		String result, String upstreamBranchSHA) {
+
+		if ((result != null) && !result.matches("(APPROVED|SUCCESS)") &&
+			(downstreamBuilds.size() != 0) &&
+			!upstreamBranchSHA.equals(
+				UpstreamFailureUtil.getUpstreamJobFailuresSHA(this))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	protected void sendBuildMetrics(String message) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1951

Fixes multiple GitHub comment issues:
1. "no unique failures" incorrectly showing up on liferay-jenkins-ee PRs
2. Top level builds that fail out without triggering downstreams should not be eligible for reevaluation
3. Top level build results that have been approved should not display reevaluation eligibility snippe