### PR TITLE
LRCI-2010 Use first property from the ordered properties that matched

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1952,6 +1952,8 @@ public class JenkinsResultsParserUtil {
 
 				if (matchesAllPropertyOptRegexes) {
 					propertyName = propertyOptRegexEntry.getKey();
+
+					break;
 				}
 			}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2010

Jar containing the change was tested here:

1. With `modules/sdk` removed the `project-templates` downstream batches are not invoked:
    https://test-5-1.liferay.com/userContent/jobs/test-portal-acceptance-pullrequest(master)/builds/3937/jenkins-report.html

2. ci:test:relevant runs normally:
https://test-5-1.liferay.com//userContent/jobs/test-portal-acceptance-pullrequest%28master%29/builds/3936/jenkins-report.html