### PR TITLE
LRCI-2036 Generate data for CI status report's new PR section

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
@@ -16,6 +16,10 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.IOException;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -48,6 +52,42 @@ public class JenkinsAPIUtil {
 		catch (IOException ioException) {
 			throw new RuntimeException("Unable to get build JSON", ioException);
 		}
+	}
+
+	public static Map<String, String> getBuildParameters(
+		JSONObject jsonObject) {
+
+		Map<String, String> buildParameters = new HashMap<>();
+
+		JSONArray actionsJSONArray = jsonObject.getJSONArray("actions");
+
+		for (int i = 0; i < actionsJSONArray.length(); i++) {
+			Object actions = actionsJSONArray.get(i);
+
+			if (actions == JSONObject.NULL) {
+				continue;
+			}
+
+			JSONObject actionJSONObject = actionsJSONArray.getJSONObject(i);
+
+			if (!actionJSONObject.has("parameters")) {
+				continue;
+			}
+
+			JSONArray parametersJSONArray = actionJSONObject.getJSONArray(
+				"parameters");
+
+			for (int j = 0; j < parametersJSONArray.length(); j++) {
+				JSONObject parameterJSONObject =
+					parametersJSONArray.getJSONObject(j);
+
+				buildParameters.put(
+					parameterJSONObject.getString("name"),
+					parameterJSONObject.getString("value"));
+			}
+		}
+
+		return buildParameters;
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
@@ -55,11 +55,11 @@ public class JenkinsAPIUtil {
 	}
 
 	public static Map<String, String> getBuildParameters(
-		JSONObject jsonObject) {
+		JSONObject buildJSONObject) {
 
 		Map<String, String> buildParameters = new HashMap<>();
 
-		JSONArray actionsJSONArray = jsonObject.getJSONArray("actions");
+		JSONArray actionsJSONArray = buildJSONObject.getJSONArray("actions");
 
 		for (int i = 0; i < actionsJSONArray.length(); i++) {
 			Object actions = actionsJSONArray.get(i);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -253,10 +253,12 @@ public class JenkinsCohort {
 							JenkinsAPIUtil.getBuildParameters(jsonObject)));
 				}
 
-				Map<String, JSONObject> queuedTopLevelBuildURLs =
-					jenkinsCohortJob.getQueuedTopLevelBuildURLs();
+				Map<String, JSONObject> queuedTopLevelBuildsJsonMap =
+					jenkinsCohortJob.getQueuedTopLevelBuildsJsonMap();
 
-				for (JSONObject jsonObject : queuedTopLevelBuildURLs.values()) {
+				for (JSONObject jsonObject :
+						queuedTopLevelBuildsJsonMap.values()) {
+
 					try {
 						Map<String, String> buildParameters =
 							JenkinsAPIUtil.getBuildParameters(jsonObject);
@@ -407,10 +409,12 @@ public class JenkinsCohort {
 					jobName);
 
 				if (batchJobName == null) {
-					jenkinsCohortJob.addQueuedTopLevelBuildURL(queuedBuildURL);
+					jenkinsCohortJob.addQueuedTopLevelBuildJsonMapEntry(
+						queuedBuildURL);
 				}
 				else {
-					jenkinsCohortJob.addQueuedOtherBuildURL(queuedBuildURL);
+					jenkinsCohortJob.addQueuedOtherBuildJsonMapEntry(
+						queuedBuildURL);
 				}
 			}
 		}
@@ -437,19 +441,20 @@ public class JenkinsCohort {
 			_otherBuildURLs.add(buildURL);
 		}
 
-		public void addQueuedOtherBuildURL(
-			Map.Entry<String, JSONObject> queuedBuildURL) {
+		public void addQueuedOtherBuildJsonMapEntry(
+			Map.Entry<String, JSONObject> queuedBuildsJsonMapEntry) {
 
-			_queuedOtherBuildURLs.put(
-				queuedBuildURL.getKey(), queuedBuildURL.getValue());
+			_queuedOtherBuildsJsonMap.put(
+				queuedBuildsJsonMapEntry.getKey(),
+				queuedBuildsJsonMapEntry.getValue());
 		}
 
-		public void addQueuedTopLevelBuildURL(
-			Map.Entry<String, JSONObject> queuedTopLevelBuildURL) {
+		public void addQueuedTopLevelBuildJsonMapEntry(
+			Map.Entry<String, JSONObject> queuedTopLevelBuildMapEntry) {
 
-			_queuedTopLevelBuildURLs.put(
-				queuedTopLevelBuildURL.getKey(),
-				queuedTopLevelBuildURL.getValue());
+			_queuedTopLevelBuildsJsonMap.put(
+				queuedTopLevelBuildMapEntry.getKey(),
+				queuedTopLevelBuildMapEntry.getValue());
 		}
 
 		public void addTopLevelBuildURL(String topLevelBuildURL) {
@@ -461,8 +466,8 @@ public class JenkinsCohort {
 		}
 
 		public int getQueuedBuildCount() {
-			return _queuedTopLevelBuildURLs.size() +
-				_queuedOtherBuildURLs.size();
+			return _queuedTopLevelBuildsJsonMap.size() +
+				_queuedOtherBuildsJsonMap.size();
 		}
 
 		public String getQueuedBuildPercentage() {
@@ -471,8 +476,8 @@ public class JenkinsCohort {
 				JenkinsCohort.this.getQueuedBuildCount());
 		}
 
-		public Map<String, JSONObject> getQueuedTopLevelBuildURLs() {
-			return _queuedTopLevelBuildURLs;
+		public Map<String, JSONObject> getQueuedTopLevelBuildsJsonMap() {
+			return _queuedTopLevelBuildsJsonMap;
 		}
 
 		public int getRunningBuildCount() {
@@ -486,7 +491,8 @@ public class JenkinsCohort {
 		}
 
 		public int getTopLevelBuildCount() {
-			return _topLevelBuildURLs.size() + _queuedTopLevelBuildURLs.size();
+			return _topLevelBuildURLs.size() +
+				_queuedTopLevelBuildsJsonMap.size();
 		}
 
 		public List<String> getTopLevelBuildURLs() {
@@ -506,8 +512,9 @@ public class JenkinsCohort {
 
 		private final String _jenkinsCohortJobName;
 		private List<String> _otherBuildURLs = new ArrayList<>();
-		private Map<String, JSONObject> _queuedOtherBuildURLs = new HashMap<>();
-		private Map<String, JSONObject> _queuedTopLevelBuildURLs =
+		private Map<String, JSONObject> _queuedOtherBuildsJsonMap =
+			new HashMap<>();
+		private Map<String, JSONObject> _queuedTopLevelBuildsJsonMap =
 			new HashMap<>();
 		private List<String> _topLevelBuildURLs = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -401,21 +401,11 @@ public class JenkinsCohort {
 					JenkinsCohort.this.getQueuedBuildCount());
 		}
 
-		public void incrementQueuedJobCount() {
-			_queuedBuildCount = _queuedBuildCount + 1;
-		}
-
-		public void incrementRunningJobCount() {
-			_runningBuildCount = _runningBuildCount + 1;
-		}
-
 		private final String _jenkinsCohortJobName;
 		private List<String> _otherBuildURLs = new ArrayList<>();
-		private int _queuedBuildCount;
 		private Map<String, JSONObject> _queuedOtherBuildURLs = new HashMap<>();
 		private Map<String, JSONObject> _queuedTopLevelBuildURLs =
 			new HashMap<>();
-		private int _runningBuildCount;
 		private List<String> _topLevelBuildURLs = new ArrayList<>();
 
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -279,7 +279,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return onlineJenkinsSlavesCount;
 	}
 
-	public List<String> getQueuedBuildURLs() {
+	public Map<String, JSONObject> getQueuedBuildURLs() {
 		return _queuedBuildURLs;
 	}
 
@@ -325,7 +325,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				JenkinsResultsParserUtil.getLocalURL(
 					JenkinsResultsParserUtil.combine(
 						_masterURL,
-						"/queue/api/json?tree=items[task[name,url],why]")),
+						"/queue/api/json?tree=items[task[name,url],url,why]")),
 				false, 5000);
 		}
 		catch (Exception exception) {
@@ -424,8 +424,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 					continue;
 				}
 
-				if ((taskJSONObject != null) && taskJSONObject.has("url")) {
-					_queuedBuildURLs.add(taskJSONObject.getString("url"));
+				if (itemJSONObject.has("url")) {
+					_queuedBuildURLs.put(
+						getURL() + "/" + itemJSONObject.getString("url"),
+						itemJSONObject);
 				}
 			}
 
@@ -467,7 +469,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	private final String _masterName;
 	private final String _masterURL;
 	private int _queueCount;
-	private final List<String> _queuedBuildURLs = new ArrayList<>();
+	private final Map<String, JSONObject> _queuedBuildURLs = new HashMap<>();
 	private int _reportedAvailableSlavesCount;
 	private final Integer _slaveRAM;
 	private final Integer _slavesPerHost;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -325,7 +325,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				JenkinsResultsParserUtil.getLocalURL(
 					JenkinsResultsParserUtil.combine(
 						_masterURL,
-						"/queue/api/json?tree=items[task[name,url],url,why]")),
+						"/queue/api/json?tree=items[actions[parameters",
+						"[name,value]],task[name,url],url,why]")),
 				false, 5000);
 		}
 		catch (Exception exception) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -40,6 +40,21 @@ import org.json.JSONObject;
  */
 public class PullRequest {
 
+	public static String getURL(
+		String username, String repositoryName, String pullRequestNumber) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("https://github.com/");
+		sb.append(username);
+		sb.append("/");
+		sb.append(repositoryName);
+		sb.append("/pull/");
+		sb.append(pullRequestNumber);
+
+		return sb.toString();
+	}
+
 	public static boolean isValidGitHubPullRequestURL(String gitHubURL) {
 		Matcher matcher = _gitHubPullRequestURLPattern.matcher(gitHubURL);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2036

Did some logic reorgs. In JenkinsCohort.JenkinsCohortJob, instead of storing build counters, in addition to build URLs, we can store maps of queued build json objects. This will give us lots of information from minimal api calls. 

I decided to forego the durations for the next iteration of this, since it wasn't in the initial requirements. Working on adding those in on top of this pull. Additionally, I think I figured out how we can cheaply do the currently running/queued build numbers in the new report section too, so I can add that in a follow up pull as well. 

![image](https://user-images.githubusercontent.com/2567802/109737659-3f696e00-7b7b-11eb-900e-16813590ec8f.png)