### PR TITLE
LRCI-2036 Generate data for CI status report's new PR section

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2569,7 +2569,7 @@ public abstract class BaseBuild implements Build {
 
 	protected void extractBuildURLComponents(Matcher matcher) {
 		_buildNumber = Integer.parseInt(matcher.group("buildNumber"));
-		setJenkinsMaster(new JenkinsMaster(matcher.group("master")));
+		setJenkinsMaster(JenkinsMaster.getInstance(matcher.group("master")));
 		setJobName(matcher.group("jobName"));
 	}
 
@@ -3564,7 +3564,7 @@ public abstract class BaseBuild implements Build {
 
 		setJobName(invocationURLMatcher.group("jobName"));
 		setJenkinsMaster(
-			new JenkinsMaster(invocationURLMatcher.group("master")));
+			JenkinsMaster.getInstance(invocationURLMatcher.group("master")));
 
 		loadParametersFromQueryString(invocationURL);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
@@ -16,6 +16,10 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.IOException;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -48,6 +52,42 @@ public class JenkinsAPIUtil {
 		catch (IOException ioException) {
 			throw new RuntimeException("Unable to get build JSON", ioException);
 		}
+	}
+
+	public static Map<String, String> getBuildParameters(
+		JSONObject jsonObject) {
+
+		Map<String, String> buildParameters = new HashMap<>();
+
+		JSONArray actionsJSONArray = jsonObject.getJSONArray("actions");
+
+		for (int i = 0; i < actionsJSONArray.length(); i++) {
+			Object actions = actionsJSONArray.get(i);
+
+			if (actions == JSONObject.NULL) {
+				continue;
+			}
+
+			JSONObject actionJSONObject = actionsJSONArray.getJSONObject(i);
+
+			if (!actionJSONObject.has("parameters")) {
+				continue;
+			}
+
+			JSONArray parametersJSONArray = actionJSONObject.getJSONArray(
+				"parameters");
+
+			for (int j = 0; j < parametersJSONArray.length(); j++) {
+				JSONObject parameterJSONObject =
+					parametersJSONArray.getJSONObject(j);
+
+				buildParameters.put(
+					parameterJSONObject.getString("name"),
+					parameterJSONObject.getString("value"));
+			}
+		}
+
+		return buildParameters;
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
@@ -55,11 +55,11 @@ public class JenkinsAPIUtil {
 	}
 
 	public static Map<String, String> getBuildParameters(
-		JSONObject jsonObject) {
+		JSONObject buildJSONObject) {
 
 		Map<String, String> buildParameters = new HashMap<>();
 
-		JSONArray actionsJSONArray = jsonObject.getJSONArray("actions");
+		JSONArray actionsJSONArray = buildJSONObject.getJSONArray("actions");
 
 		for (int i = 0; i < actionsJSONArray.length(); i++) {
 			Object actions = actionsJSONArray.get(i);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -276,23 +276,9 @@ public class JenkinsCohort {
 						}
 					}
 
-					long currentTimeMillis = System.currentTimeMillis();
-
-					if (JenkinsResultsParserUtil.isCINode()) {
-						Matcher matcher = _jobURLPattern.matcher(buildURL);
-
-						matcher.find();
-
-						long currentTimeSeconds =
-							JenkinsResultsParserUtil.
-								getRemoteCurrentTimeSeconds(
-									matcher.group("masterHostname"));
-
-						currentTimeMillis = currentTimeSeconds * 1000;
-					}
-
 					long duration =
-						currentTimeMillis - jsonObject.getLong("timestamp");
+						JenkinsResultsParserUtil.getCurrentTimeMillis() -
+							jsonObject.getLong("timestamp");
 
 					pullRequestDataTableJSONArray.put(
 						_createpullRequestDataTableRow(
@@ -316,23 +302,8 @@ public class JenkinsCohort {
 
 						String jobURL = taskJSONObject.getString("url");
 
-						long currentTimeMillis = System.currentTimeMillis();
-
-						if (JenkinsResultsParserUtil.isCINode()) {
-							Matcher matcher = _jobURLPattern.matcher(jobURL);
-
-							matcher.find();
-
-							long currentTimeSeconds =
-								JenkinsResultsParserUtil.
-									getRemoteCurrentTimeSeconds(
-										matcher.group("masterHostname"));
-
-							currentTimeMillis = currentTimeSeconds * 1000;
-						}
-
 						long queueDuration =
-							currentTimeMillis -
+							JenkinsResultsParserUtil.getCurrentTimeMillis() -
 								jsonObject.optLong("inQueueSince");
 
 						pullRequestDataTableJSONArray.put(
@@ -497,11 +468,6 @@ public class JenkinsCohort {
 		".*\\/([0-9]+)");
 	private static final Pattern _jobNamePattern = Pattern.compile(
 		"https?:.*job\\/(.*?)\\/");
-	private static final Pattern _jobURLPattern = Pattern.compile(
-		JenkinsResultsParserUtil.combine(
-			"(?<jobURL>https?://(?<masterHostname>",
-			"(?<cohortName>test-\\d+)-\\d+)(\\.liferay\\.com)?/job/",
-			"(?<jobName>[^/]+)/(.*/)?)/?"));
 
 	private final Map<String, JenkinsCohortJob> _jenkinsCohortJobsMap =
 		new HashMap<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -253,10 +253,12 @@ public class JenkinsCohort {
 							JenkinsAPIUtil.getBuildParameters(jsonObject)));
 				}
 
-				Map<String, JSONObject> queuedTopLevelBuildURLs =
-					jenkinsCohortJob.getQueuedTopLevelBuildURLs();
+				Map<String, JSONObject> queuedTopLevelBuildsJsonMap =
+					jenkinsCohortJob.getQueuedTopLevelBuildsJsonMap();
 
-				for (JSONObject jsonObject : queuedTopLevelBuildURLs.values()) {
+				for (JSONObject jsonObject :
+						queuedTopLevelBuildsJsonMap.values()) {
+
 					try {
 						Map<String, String> buildParameters =
 							JenkinsAPIUtil.getBuildParameters(jsonObject);
@@ -407,10 +409,12 @@ public class JenkinsCohort {
 					jobName);
 
 				if (batchJobName == null) {
-					jenkinsCohortJob.addQueuedTopLevelBuildURL(queuedBuildURL);
+					jenkinsCohortJob.addQueuedTopLevelBuildJsonMapEntry(
+						queuedBuildURL);
 				}
 				else {
-					jenkinsCohortJob.addQueuedOtherBuildURL(queuedBuildURL);
+					jenkinsCohortJob.addQueuedOtherBuildJsonMapEntry(
+						queuedBuildURL);
 				}
 			}
 		}
@@ -437,19 +441,20 @@ public class JenkinsCohort {
 			_otherBuildURLs.add(buildURL);
 		}
 
-		public void addQueuedOtherBuildURL(
-			Map.Entry<String, JSONObject> queuedBuildURL) {
+		public void addQueuedOtherBuildJsonMapEntry(
+			Map.Entry<String, JSONObject> queuedBuildsJsonMapEntry) {
 
-			_queuedOtherBuildURLs.put(
-				queuedBuildURL.getKey(), queuedBuildURL.getValue());
+			_queuedOtherBuildsJsonMap.put(
+				queuedBuildsJsonMapEntry.getKey(),
+				queuedBuildsJsonMapEntry.getValue());
 		}
 
-		public void addQueuedTopLevelBuildURL(
-			Map.Entry<String, JSONObject> queuedTopLevelBuildURL) {
+		public void addQueuedTopLevelBuildJsonMapEntry(
+			Map.Entry<String, JSONObject> queuedTopLevelBuildMapEntry) {
 
-			_queuedTopLevelBuildURLs.put(
-				queuedTopLevelBuildURL.getKey(),
-				queuedTopLevelBuildURL.getValue());
+			_queuedTopLevelBuildsJsonMap.put(
+				queuedTopLevelBuildMapEntry.getKey(),
+				queuedTopLevelBuildMapEntry.getValue());
 		}
 
 		public void addTopLevelBuildURL(String topLevelBuildURL) {
@@ -461,8 +466,8 @@ public class JenkinsCohort {
 		}
 
 		public int getQueuedBuildCount() {
-			return _queuedTopLevelBuildURLs.size() +
-				_queuedOtherBuildURLs.size();
+			return _queuedTopLevelBuildsJsonMap.size() +
+				_queuedOtherBuildsJsonMap.size();
 		}
 
 		public String getQueuedBuildPercentage() {
@@ -471,8 +476,8 @@ public class JenkinsCohort {
 				JenkinsCohort.this.getQueuedBuildCount());
 		}
 
-		public Map<String, JSONObject> getQueuedTopLevelBuildURLs() {
-			return _queuedTopLevelBuildURLs;
+		public Map<String, JSONObject> getQueuedTopLevelBuildsJsonMap() {
+			return _queuedTopLevelBuildsJsonMap;
 		}
 
 		public int getRunningBuildCount() {
@@ -486,7 +491,8 @@ public class JenkinsCohort {
 		}
 
 		public int getTopLevelBuildCount() {
-			return _topLevelBuildURLs.size() + _queuedTopLevelBuildURLs.size();
+			return _topLevelBuildURLs.size() +
+				_queuedTopLevelBuildsJsonMap.size();
 		}
 
 		public List<String> getTopLevelBuildURLs() {
@@ -506,8 +512,9 @@ public class JenkinsCohort {
 
 		private final String _jenkinsCohortJobName;
 		private List<String> _otherBuildURLs = new ArrayList<>();
-		private Map<String, JSONObject> _queuedOtherBuildURLs = new HashMap<>();
-		private Map<String, JSONObject> _queuedTopLevelBuildURLs =
+		private Map<String, JSONObject> _queuedOtherBuildsJsonMap =
+			new HashMap<>();
+		private Map<String, JSONObject> _queuedTopLevelBuildsJsonMap =
 			new HashMap<>();
 		private List<String> _topLevelBuildURLs = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -401,21 +401,11 @@ public class JenkinsCohort {
 					JenkinsCohort.this.getQueuedBuildCount());
 		}
 
-		public void incrementQueuedJobCount() {
-			_queuedBuildCount = _queuedBuildCount + 1;
-		}
-
-		public void incrementRunningJobCount() {
-			_runningBuildCount = _runningBuildCount + 1;
-		}
-
 		private final String _jenkinsCohortJobName;
 		private List<String> _otherBuildURLs = new ArrayList<>();
-		private int _queuedBuildCount;
 		private Map<String, JSONObject> _queuedOtherBuildURLs = new HashMap<>();
 		private Map<String, JSONObject> _queuedTopLevelBuildURLs =
 			new HashMap<>();
-		private int _runningBuildCount;
 		private List<String> _topLevelBuildURLs = new ArrayList<>();
 
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -138,7 +138,7 @@ public class JenkinsCohort {
 
 				@Override
 				public Void call() {
-					jenkinsMaster.update();
+					jenkinsMaster.update(false);
 
 					buildURLs.addAll(jenkinsMaster.getBuildURLs());
 					queuedBuildURLs.putAll(jenkinsMaster.getQueuedBuildURLs());
@@ -312,6 +312,8 @@ public class JenkinsCohort {
 					}
 					catch (JSONException jsonException) {
 						System.out.println(jsonObject.toString());
+
+						throw new RuntimeException(jsonException);
 					}
 				}
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -39,6 +39,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			String propertyValue = JenkinsResultsParserUtil.getBuildProperty(
 				"slave.ram.minimum.default");
 
+			if (propertyValue == null) {
+				return SLAVE_RAM_DEFAULT;
+			}
+
 			return Integer.valueOf(propertyValue);
 		}
 		catch (Exception exception) {
@@ -62,6 +66,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		try {
 			String propertyValue = JenkinsResultsParserUtil.getBuildProperty(
 				"slaves.per.host.default");
+
+			if (propertyValue == null) {
+				return SLAVES_PER_HOST_DEFAULT;
+			}
 
 			return Integer.valueOf(propertyValue);
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -279,7 +279,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return onlineJenkinsSlavesCount;
 	}
 
-	public List<String> getQueuedBuildURLs() {
+	public Map<String, JSONObject> getQueuedBuildURLs() {
 		return _queuedBuildURLs;
 	}
 
@@ -325,7 +325,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				JenkinsResultsParserUtil.getLocalURL(
 					JenkinsResultsParserUtil.combine(
 						_masterURL,
-						"/queue/api/json?tree=items[task[name,url],why]")),
+						"/queue/api/json?tree=items[task[name,url],url,why]")),
 				false, 5000);
 		}
 		catch (Exception exception) {
@@ -424,8 +424,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 					continue;
 				}
 
-				if ((taskJSONObject != null) && taskJSONObject.has("url")) {
-					_queuedBuildURLs.add(taskJSONObject.getString("url"));
+				if (itemJSONObject.has("url")) {
+					_queuedBuildURLs.put(
+						getURL() + "/" + itemJSONObject.getString("url"),
+						itemJSONObject);
 				}
 			}
 
@@ -467,7 +469,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	private final String _masterName;
 	private final String _masterURL;
 	private int _queueCount;
-	private final List<String> _queuedBuildURLs = new ArrayList<>();
+	private final Map<String, JSONObject> _queuedBuildURLs = new HashMap<>();
 	private int _reportedAvailableSlavesCount;
 	private final Integer _slaveRAM;
 	private final Integer _slavesPerHost;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -276,7 +276,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			String.valueOf(_reportedAvailableSlavesCount), "}");
 	}
 
-	public void update() {
+	public synchronized void update() {
 		JSONObject computerAPIJSONObject = null;
 		JSONObject queueAPIJSONObject = null;
 
@@ -486,7 +486,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	private boolean _available;
 	private final Map<Long, Integer> _batchSizes = new TreeMap<>();
 	private final List<String> _buildURLs = new ArrayList<>();
-	private final Map<String, JenkinsSlave> _jenkinsSlavesMap = new HashMap<>();
+	private final Map<String, JenkinsSlave> _jenkinsSlavesMap =
+		Collections.synchronizedMap(new HashMap<String, JenkinsSlave>());
 	private final String _masterName;
 	private final String _masterURL;
 	private int _queueCount;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -277,6 +277,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public synchronized void update() {
+		update(true);
+	}
+
+	public synchronized void update(boolean minimal) {
 		JSONObject computerAPIJSONObject = null;
 		JSONObject queueAPIJSONObject = null;
 
@@ -288,12 +292,19 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 						"/computer/api/json?tree=computer[displayName,",
 						"executors[currentExecutable[url]],idle,offline]")),
 				false, 5000);
+
+			String queueAPIQuery = "tree=items[task[name,url],url,why]";
+
+			if (!minimal) {
+				queueAPIQuery =
+					"tree=items[actions[parameters[name,value]]," +
+						"inQueueSince,task[name,url],url,why]";
+			}
+
 			queueAPIJSONObject = JenkinsResultsParserUtil.toJSONObject(
 				JenkinsResultsParserUtil.getLocalURL(
 					JenkinsResultsParserUtil.combine(
-						_masterURL,
-						"/queue/api/json?tree=items[actions[parameters",
-						"[name,value]],inQueueSince,task[name,url],url,why]")),
+						_masterURL, "/queue/api/json?" + queueAPIQuery)),
 				false, 5000);
 		}
 		catch (Exception exception) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -326,7 +326,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 					JenkinsResultsParserUtil.combine(
 						_masterURL,
 						"/queue/api/json?tree=items[actions[parameters",
-						"[name,value]],task[name,url],url,why]")),
+						"[name,value]],inQueueSince,task[name,url],url,why]")),
 				false, 5000);
 		}
 		catch (Exception exception) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -325,7 +325,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				JenkinsResultsParserUtil.getLocalURL(
 					JenkinsResultsParserUtil.combine(
 						_masterURL,
-						"/queue/api/json?tree=items[task[name,url],url,why]")),
+						"/queue/api/json?tree=items[actions[parameters",
+						"[name,value]],task[name,url],url,why]")),
 				false, 5000);
 		}
 		catch (Exception exception) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1531,7 +1531,8 @@ public class JenkinsResultsParserUtil {
 				 "master.slaves(" + prefix + "-" + i + ")");
 			 i++) {
 
-			JenkinsMaster jenkinsMaster = new JenkinsMaster(prefix + "-" + i);
+			JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
+				prefix + "-" + i);
 
 			if ((jenkinsMaster.getSlaveRAM() >= minimumRAM) &&
 				(jenkinsMaster.getSlavesPerHost() <= maximumSlavesPerHost)) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -834,8 +834,6 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static Map<String, String> getBuildParameters(String buildURL) {
-		Map<String, String> buildParameters = new HashMap<>();
-
 		if (!buildURL.endsWith("/")) {
 			buildURL += "/";
 		}
@@ -846,39 +844,11 @@ public class JenkinsResultsParserUtil {
 		try {
 			JSONObject jsonObject = toJSONObject(buildParametersURL);
 
-			JSONArray actionsJSONArray = jsonObject.getJSONArray("actions");
-
-			for (int i = 0; i < actionsJSONArray.length(); i++) {
-				Object actions = actionsJSONArray.get(i);
-
-				if (actions == JSONObject.NULL) {
-					continue;
-				}
-
-				JSONObject actionJSONObject = actionsJSONArray.getJSONObject(i);
-
-				if (!actionJSONObject.has("parameters")) {
-					continue;
-				}
-
-				JSONArray parametersJSONArray = actionJSONObject.getJSONArray(
-					"parameters");
-
-				for (int j = 0; j < parametersJSONArray.length(); j++) {
-					JSONObject parameterJSONObject =
-						parametersJSONArray.getJSONObject(j);
-
-					buildParameters.put(
-						parameterJSONObject.getString("name"),
-						parameterJSONObject.getString("value"));
-				}
-			}
+			return JenkinsAPIUtil.getBuildParameters(jsonObject);
 		}
 		catch (IOException ioException) {
-			throw new RuntimeException();
+			throw new RuntimeException(ioException);
 		}
-
-		return buildParameters;
 	}
 
 	public static Properties getBuildProperties() throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsSlave.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsSlave.java
@@ -43,7 +43,7 @@ public class JenkinsSlave implements JenkinsNode<JenkinsSlave> {
 					"hostname ", hostname));
 		}
 
-		_jenkinsMaster = new JenkinsMaster(jenkinsMasterName);
+		_jenkinsMaster = JenkinsMaster.getInstance(jenkinsMasterName);
 
 		String jenkinsSlaveJSONObjectURL = JenkinsResultsParserUtil.getLocalURL(
 			JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -40,6 +40,21 @@ import org.json.JSONObject;
  */
 public class PullRequest {
 
+	public static String getURL(
+		String username, String repositoryName, String pullRequestNumber) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("https://github.com/");
+		sb.append(username);
+		sb.append("/");
+		sb.append(repositoryName);
+		sb.append("/pull/");
+		sb.append(pullRequestNumber);
+
+		return sb.toString();
+	}
+
 	public static boolean isValidGitHubPullRequestURL(String gitHubURL) {
 		Matcher matcher = _gitHubPullRequestURLPattern.matcher(gitHubURL);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/result/SpiraResultImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/spira/result/SpiraResultImporter.java
@@ -413,7 +413,8 @@ public class SpiraResultImporter {
 
 			if (!spiraAutomationHostMap.containsKey(masterHostname)) {
 				SpiraAutomationHost spiraAutomationHost =
-					_getSpiraAutomationHost(new JenkinsMaster(masterHostname));
+					_getSpiraAutomationHost(
+						JenkinsMaster.getInstance(masterHostname));
 
 				spiraAutomationHostMap.put(
 					spiraAutomationHost.getName(), spiraAutomationHost);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -171,8 +171,7 @@ public class LoadBalancerUtilTest
 				new File(sampleDir, jenkinsMaster.getName()),
 				JenkinsResultsParserUtil.createURL(jenkinsMaster.getURL()),
 				JenkinsResultsParserUtil.combine(
-					"/queue/api/json?tree=items[actions[parameters",
-					"[name,value]],inQueueSince,task[name,url],url,why]"));
+					"/queue/api/json?tree=items[task[name,url],url,why]"));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -170,7 +170,9 @@ public class LoadBalancerUtilTest
 			downloadSampleURL(
 				new File(sampleDir, jenkinsMaster.getName()),
 				JenkinsResultsParserUtil.createURL(jenkinsMaster.getURL()),
-				"/queue/api/json?tree=items[task[name,url],why]");
+				JenkinsResultsParserUtil.combine(
+					"/queue/api/json?tree=items[actions[parameters",
+					"[name,value]],inQueueSince,task[name,url],url,why]"));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/LoadBalancerUtilTest/test-1/expected-message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/LoadBalancerUtilTest/test-1/expected-message.html
@@ -1,1 +1,1 @@
-http://test-1-16
+http://test-1-8


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2036
https://issues.liferay.com/browse/LRCI-2039
https://issues.liferay.com/browse/LRCI-2040
https://issues.liferay.com/browse/LRCI-2050

Did some logic reorgs. In JenkinsCohort.JenkinsCohortJob, instead of storing build counters, in addition to build URLs, we can store maps of queued build json objects. This will give us lots of information from minimal api calls. 

Additionally, I added the duration data into the LRCI-2039 commits. LRCI-2050 addresses potential memory issues, and was exposed by one of the tests due to changes I made.  

![image](https://user-images.githubusercontent.com/2567802/109886374-cfb7b980-7c34-11eb-8887-e56444825ddc.png)
