### PR TITLE
LRCI-2097 Streamline portal-fixpack-release and add gauntlet-bucket test suite

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -4273,6 +4273,18 @@ log.sanitizer.enabled=false</echo>
 		/>
 	</target>
 
+	<target name="functional-smoke-bundle-tomcat-db2111-jdk8">
+		<antcall target="functional-bundle-tomcat-db2111-jdk8" />
+	</target>
+
+	<target name="functional-smoke-bundle-tomcat-hypersonic20-jdk8">
+		<antcall target="functional-bundle-tomcat-hypersonic20-jdk8" />
+	</target>
+
+	<target name="functional-smoke-bundle-tomcat-mariadb102-jdk8">
+		<antcall target="functional-bundle-tomcat-mariadb102-jdk8" />
+	</target>
+
 	<target name="functional-smoke-bundle-tomcat-mysql56-jdk8">
 		<antcall target="functional-bundle-tomcat-mysql56-jdk8" />
 	</target>
@@ -4283,6 +4295,14 @@ log.sanitizer.enabled=false</echo>
 
 	<target name="functional-smoke-bundle-tomcat-mysql57-jdk11_open">
 		<antcall target="functional-bundle-tomcat-mysql57-jdk11_open" />
+	</target>
+
+	<target name="functional-smoke-bundle-tomcat-oracle193-jdk8">
+		<antcall target="functional-bundle-tomcat-oracle193-jdk8" />
+	</target>
+
+	<target name="functional-smoke-bundle-tomcat-postgresql11-jdk8">
+		<antcall target="functional-bundle-tomcat-postgresql11-jdk8" />
 	</target>
 
 	<target name="functional-smoke-bundle-weblogic-mysql57-jdk8">

--- a/ci.properties
+++ b/ci.properties
@@ -59,6 +59,7 @@ ci.test.available.suites=\
     forms,\
     frontend,\
     gauntlet,\
+    gauntlet-bucket,\
     gradle-plugins,\
     headless,\
     headless-acceptance,\
@@ -151,6 +152,7 @@ ci.test.suite.description[export-import]=Test exportimport tests.
 ci.test.suite.description[frontend]=Test frontend tests.
 ci.test.suite.description[forms]=Test forms tests.
 ci.test.suite.description[gauntlet]=Test upstream tests.
+ci.test.suite.description[gauntlet-bucket]=Test a subset of upstream tests.
 ci.test.suite.description[gradle-plugins]=Test Gradle Plugins tests.
 ci.test.suite.description[headless]=Test headless team tests.
 ci.test.suite.description[headless-acceptance]=Test headless team acceptance tests considering Headless and Rest Builder.

--- a/test.properties
+++ b/test.properties
@@ -3328,6 +3328,73 @@
         (portal.release == true)
 
     #
+    # Gauntlet Bucket
+    #
+
+    test.batch.names[gauntlet-bucket]=\
+        archived-module-smoke-jdk8,\
+        archived-modules-test-jdk8,\
+        blade-samples-jdk8,\
+        bundle-blacklist-restart-jdk8,\
+        central-requirements-jdk8,\
+        compile-jsp-jdk8,\
+        empty-temp-dir-jdk8,\
+        functional-smoke-jboss72-mysql57-jdk8,\
+        functional-smoke-tomcat90-db2111-jdk8,\
+        functional-smoke-tomcat90-mariadb102-jdk8,\
+        functional-smoke-tomcat90-mysql57-jdk8,\
+        functional-smoke-tomcat90-mysql57-jdk11_open,\
+        functional-smoke-tomcat90-mysql80-jdk8,\
+        functional-smoke-tomcat90-oracle193-jdk8,\
+        functional-smoke-tomcat90-postgresql11-jdk8,\
+        functional-smoke-tomcat90-postgresql121-jdk8,\
+        functional-smoke-tomcat90-sqlserver2017-jdk8,\
+        functional-smoke-tomcat90-sqlserver2019-jdk8,\
+        functional-smoke-weblogic122-mysql57-jdk8,\
+        functional-smoke-websphere90-mysql57-jdk8,\
+        functional-smoke-wildfly140-mariadb102-jdk8,\
+        functional-smoke-wildfly170-mariadb104-jdk8,\
+        functional-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-mysql57-jdk8,\
+        gogo-shell-client-jdk8,\
+        javadoc-jdk8,\
+        js-unit-jdk8,\
+        jsp-runtime-compile-jdk8,\
+        lpkg-base-jdk8,\
+        lpkg-container-jdk8,\
+        lpkg-controller-jdk8,\
+        lpkg-hot-deployment-jdk8,\
+        lpkg-independence-jdk8,\
+        lpkg-override-jdk8,\
+        lpkg-persistence-jdk8,\
+        lpkg-release-jdk8,\
+        lpkg-startup-jdk8,\
+        modules-compile-jdk8,\
+        modules-functional-jdk8,\
+        modules-functional-tomcat90-mysql57-jdk8,\
+        modules-integration-mysql57-jdk8,\
+        modules-integration-project-templates-jdk8,\
+        modules-semantic-versioning-jdk8,\
+        modules-unit-jdk8,\
+        modules-unit-project-templates-jdk8,\
+        pmd-jdk8,\
+        portal-renamed-tomcat-in-path-jdk8,\
+        portal-second-startup-space-in-path-jdk8,\
+        portal-startup-space-in-path-jdk8,\
+        poshi-validation-jdk8,\
+        release-osgi-state-exploded-test-jdk8,\
+        release-osgi-state-lpkg-change-directory-test-jdk8,\
+        release-osgi-state-lpkg-test-jdk8,\
+        rest-builder-jdk8,\
+        ruby-sass-compiler-jdk8,\
+        semantic-versioning-jdk8,\
+        service-builder-jdk8,\
+        source-format-jdk8,\
+        tck-jdk8,\
+        unit-jdk8,\
+        wsdd-builder-jdk8
+
+    #
     # Gradle Plugins
     #
 

--- a/test.properties
+++ b/test.properties
@@ -3997,61 +3997,6 @@
             (portal.fixpack.release == true OR portal.release == true)\
         )
 
-    test.batch.run.property.query[functional-smoke-bundle-jboss-mysql57-jdk8][portal-fixpack-release]=\
-        (app.server.types ~ jboss) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tcserver-mysql57-jdk8][portal-fixpack-release]=\
-        (app.server.types ~ tcserver) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-db2111-jdk8][portal-fixpack-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ db2) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-hypersonic20-jdk8][portal-fixpack-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ hypersonic) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mariadb102-jdk8][portal-fixpack-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ mariadb) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk11_open][portal-fixpack-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-oracle193-jdk8][portal-fixpack-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ oracle) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-postgresql11-jdk8][portal-fixpack-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ postgresql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-weblogic-mysql57-jdk8][portal-fixpack-release]=\
-        (app.server.types ~ weblogic) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-websphere-mysql57-jdk8][portal-fixpack-release]=\
-        (app.server.types ~ websphere) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-wildfly-mysql57-jdk8][portal-fixpack-release]=\
-        (app.server.types ~ wildfly) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
     test.release.bundle[portal-fixpack-release]=true
 
     #
@@ -4076,9 +4021,6 @@
     test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8][portal-fixpack-release-functional]=\
         ${test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8][portal-fixpack-release]}
 
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-fixpack-release-functional]=\
-        ${test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-fixpack-release]}
-
     test.release.bundle[portal-fixpack-release-functional]=true
 
     #
@@ -4087,9 +4029,6 @@
 
     test.batch.names.smoke[portal-fixpack-release-smoke]=\
         ${test.batch.names.smoke[portal-fixpack-release]}
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-fixpack-release-smoke]=\
-        ${test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-fixpack-release]}
 
     test.release.bundle[portal-fixpack-release-smoke]=true
 
@@ -4108,9 +4047,6 @@
 
     test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8][portal-fixpack-release-tomcat]=\
         ${test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8][portal-fixpack-release]}
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-fixpack-release-tomcat]=\
-        ${test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-fixpack-release]}
 
     test.release.bundle[portal-fixpack-release-tomcat]=true
 
@@ -4245,31 +4181,6 @@
             (portal.release == true)\
         )
 
-    test.batch.run.property.query[functional-smoke-bundle-jboss-mysql57-jdk8][portal-hotfix-release]=\
-        (app.server.types ~ jboss) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-hotfix-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-weblogic-mysql57-jdk8][portal-hotfix-release]=\
-        (app.server.types ~ weblogic) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-websphere-mysql57-jdk8][portal-hotfix-release]=\
-        (app.server.types ~ websphere) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-wildfly-mysql57-jdk8][portal-hotfix-release]=\
-        (app.server.types ~ wildfly) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
     test.release.bundle[portal-hotfix-release]=true
 
     #
@@ -4296,9 +4207,6 @@
 
     test.batch.names.smoke[portal-hotfix-release-smoke]=\
         ${test.batch.names.smoke[portal-hotfix-release]}
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-hotfix-release-smoke]=\
-        ${test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-hotfix-release]}
 
     test.release.bundle[portal-hotfix-release-smoke]=true
 
@@ -4478,31 +4386,6 @@
             (portal.release == true)\
         )
 
-    test.batch.run.property.query[functional-smoke-bundle-jboss-mysql57-jdk8][portal-release]=\
-        (app.server.types ~ jboss) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-release]=\
-        (app.server.types == null OR app.server.types ~ tomcat) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-weblogic-mysql57-jdk8][portal-release]=\
-        (app.server.types ~ weblogic) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-websphere-mysql57-jdk8][portal-release]=\
-        (app.server.types ~ websphere) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
-    test.batch.run.property.query[functional-smoke-bundle-wildfly-mysql57-jdk8][portal-release]=\
-        (app.server.types ~ wildfly) AND \
-        (database.types == null OR database.types ~ mysql) AND \
-        (portal.smoke == true)
-
     test.release.bundle[portal-release]=true
 
     test.release.post.startup.dependency.modules=\
@@ -4541,9 +4424,6 @@
 
     test.batch.names.smoke[portal-release-smoke]=\
         ${test.batch.names.smoke[portal-release]}
-
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-release-smoke]=\
-        ${test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-release]}
 
     test.release.bundle[portal-release-smoke]=true
 

--- a/test.properties
+++ b/test.properties
@@ -1182,6 +1182,66 @@
         (database.types ~ mysql) AND \
         (environment.acceptance == true)
 
+    test.batch.run.property.query[functional-smoke-bundle-jboss-mysql57-jdk8]=\
+        (app.server.types ~ jboss) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tcserver-mysql57-jdk8]=\
+        (app.server.types ~ tcserver) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-db2111-jdk8]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ db2) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-hypersonic20-jdk8]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ hypersonic) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-mariadb102-jdk8]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ mariadb) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk11_open]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-oracle193-jdk8]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ oracle) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-postgresql11-jdk8]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ postgresql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-weblogic-mysql57-jdk8]=\
+        (app.server.types ~ weblogic) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-websphere-mysql57-jdk8]=\
+        (app.server.types ~ websphere) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-wildfly-mysql57-jdk8]=\
+        (app.server.types ~ wildfly) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
     #test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8]=(portal.smoke == true) AND (app.server.types == null OR app.server.types ~ tomcat) AND (database.types == null OR database.types ~ mysql)
     test.batch.run.property.query[functional-smoke-jboss72-mysql57-jdk8]=\
         (app.server.types ~ jboss) AND \

--- a/test.properties
+++ b/test.properties
@@ -3817,29 +3817,20 @@
     #
 
     test.batch.names[portal-fixpack-release]=\
-        functional-bundle-jboss-mysql57-jdk8,\
-        functional-bundle-tcserver-mysql57-jdk8,\
-        functional-bundle-tomcat-db2111-jdk8,\
-        functional-bundle-tomcat-hypersonic20-jdk8,\
-        functional-bundle-tomcat-mariadb102-jdk8,\
         functional-bundle-tomcat-mysql57-jdk8,\
-        functional-bundle-tomcat-mysql57-jdk11_open,\
-        functional-bundle-tomcat-oracle193-jdk8,\
-        functional-bundle-tomcat-postgresql11-jdk8,\
-        functional-bundle-weblogic-mysql57-jdk8,\
-        functional-bundle-websphere-mysql57-jdk8,\
-        functional-bundle-wildfly-mysql57-jdk8,\
         functional-smoke-bundle-jboss-mysql57-jdk8,\
+        functional-smoke-bundle-tcserver-mysql57-jdk8,\
+        functional-smoke-bundle-tomcat-db2111-jdk8,\
+        functional-smoke-bundle-tomcat-hypersonic20-jdk8,\
+        functional-smoke-bundle-tomcat-mariadb102-jdk8,\
+        functional-smoke-bundle-tomcat-mysql57-jdk11_open,\
+        functional-smoke-bundle-tomcat-oracle193-jdk8,\
+        functional-smoke-bundle-tomcat-postgresql11-jdk8,\
         functional-smoke-bundle-weblogic-mysql57-jdk8,\
         functional-smoke-bundle-websphere-mysql57-jdk8,\
         functional-smoke-bundle-wildfly-mysql57-jdk8,\
         jsf-jdk8,\
-        modules-integration-bundle-db2111-jdk8,\
-        modules-integration-bundle-hypersonic20-jdk8,\
-        modules-integration-bundle-mariadb102-jdk8,\
         modules-integration-bundle-mysql57-jdk8,\
-        modules-integration-bundle-oracle193-jdk8,\
-        modules-integration-bundle-postgresql11-jdk8,\
         patching-tool-custom-scripts-jdk8
 
     test.batch.names.smoke[portal-fixpack-release]=\
@@ -3951,9 +3942,39 @@
         (database.types == null OR database.types ~ mysql) AND \
         (portal.smoke == true)
 
-    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk8][portal-fixpack-release]=\
+    test.batch.run.property.query[functional-smoke-bundle-tcserver-mysql57-jdk8][portal-fixpack-release]=\
+        (app.server.types ~ tcserver) AND \
+        (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-db2111-jdk8][portal-fixpack-release]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ db2) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-hypersonic20-jdk8][portal-fixpack-release]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ hypersonic) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-mariadb102-jdk8][portal-fixpack-release]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ mariadb) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-mysql57-jdk11_open][portal-fixpack-release]=\
         (app.server.types == null OR app.server.types ~ tomcat) AND \
         (database.types == null OR database.types ~ mysql) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-oracle193-jdk8][portal-fixpack-release]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ oracle) AND \
+        (portal.smoke == true)
+
+    test.batch.run.property.query[functional-smoke-bundle-tomcat-postgresql11-jdk8][portal-fixpack-release]=\
+        (app.server.types == null OR app.server.types ~ tomcat) AND \
+        (database.types == null OR database.types ~ postgresql) AND \
         (portal.smoke == true)
 
     test.batch.run.property.query[functional-smoke-bundle-weblogic-mysql57-jdk8][portal-fixpack-release]=\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2097

Tested here:
gauntlet-bucket (master):
https://test-1-17.liferay.com/userContent/jobs/test-portal-acceptance-pullrequest(master)/builds/7456/jenkins-report.html

portal-fixpack-release (7.3.x):
https://test-1-1.liferay.com//userContent/jobs/test-portal-fixpack-release/builds/801/jenkins-report.html

Please backport to `7.3.x` (clean cherry-pick)

I'll also prepare and send in backport pulls for 7.0.x, 7.1.x, 7.2.x.

cc @brianwulbern