### PR TITLE
LRCI-1863 Deploy petra jar when setting up release test environment

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1683,6 +1683,12 @@ app.server.type=@{app.server.type}]]></echo>
 
 								<ant dir="portal-kernel" inheritAll="false" target="install-portal-snapshot" />
 
+								<gradle-execute dir="${project.dir}/modules/apps/petra" task="deploy">
+									<arg value="--parallel" />
+									<arg value="-Dportal.build=true" />
+									<arg value="-Pforced.deploy.dir=${project.dir}/tmp/lib-pre" />
+								</gradle-execute>
+
 								<ant dir="portal-test" inheritAll="false" target="jar" />
 
 								<local name="artifact.version" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1863

Please backport to `7.1.x`, `7.2.x`, and `7.3.x` (clean cherry-pick, no `7.0.x`)

fyi @michaelhashimoto