### PR TITLE
LRCI-2178 Make upstream comparison more robust when there are missing test.results.json files

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1082,7 +1082,7 @@ public class JenkinsResultsParserUtil {
 		int buildNumber = Math.max(0, lastCompletedBuildNumber - maxBuildCount);
 
 		while (buildNumber <= lastCompletedBuildNumber) {
-			String buildURL = jobURL + buildNumber;
+			String buildURL = jobURL + "/" + buildNumber;
 
 			buildResultJsonURLs.add(
 				getBuildArtifactURL(buildURL, "build-result.json"));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -353,6 +353,13 @@ public class UpstreamFailureUtil {
 
 		for (String buildResultJSONURL : buildResultJSONURLs) {
 			try {
+				buildResultJSONURL = buildResultJSONURL.replace(
+					"test-1-1/userContent/jobs/",
+					"test-1-0/userContent/testResults/");
+
+				buildResultJSONURL = buildResultJSONURL.replace(
+					"build-result.json", "test.results.json");
+
 				JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
 					buildResultJSONURL);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2178

Previously, if test.results.json files were unavailable, no comparison would be attempted. This adds additional logic to attempt multiple test.results.json files in the event that an acceptance upstream result has failed out, which will result in using the previous build's results. Eventually, I want to shift this to use build-result.json files, so we have amore standardized way of grabbing results, but that will require some refactors and additional testing. This gets us one step closer to that, solves the issue at hand, and keeps the comparison against the existing test.results.json file.