### PR TITLE
LRCI-2177 Update create script and sql file permissions before copying into database container

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11388,6 +11388,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 						<execute>
 							<![CDATA[
+								chmod 755 ${create.sh.file.path} ${create.sql.file.path}
+
 								docker cp ${create.sh.file.path} ${database.host}:/tmp/create.sh
 								docker cp ${create.sql.file.path} ${database.host}:/tmp/create.sql
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2177

Please cherry-pick all the way down to `7.0.x` (clean cherry-pick).

Tested here:
https://github.com/yichenroy/liferay-portal/pull/632#issuecomment-822783824

cc @vicnate5