### PR TITLE
LRCI-1608 Do not treat the load balancer as a CI node

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2534,6 +2534,10 @@ public class JenkinsResultsParserUtil {
 	public static boolean isCINode() {
 		String hostName = getHostName("");
 
+		if (hostName.equals(_HOSTNAME_LOAD_BALANCER)) {
+			return false;
+		}
+
 		if (hostName.startsWith("cloud-10-0-") ||
 			hostName.startsWith("test-")) {
 
@@ -4504,6 +4508,9 @@ public class JenkinsResultsParserUtil {
 	private static final String _DIST_PORTAL_JOB_URL_DEFAULT =
 		"http://test-1-1/job/test-portal-acceptance-upstream";
 
+	private static final String _HOSTNAME_LOAD_BALANCER =
+		"cloud-10-0-0-31.lax.liferay.com";
+
 	private static final long _MILLIS_BASH_COMMAND_TIMEOUT_DEFAULT =
 		1000 * 60 * 60;
 
@@ -4524,7 +4531,7 @@ public class JenkinsResultsParserUtil {
 	private static final int _SECONDS_RETRY_PERIOD_DEFAULT = 5;
 
 	private static final String _URL_LOAD_BALANCER =
-		"http://cloud-10-0-0-31.lax.liferay.com/osb-jenkins-web/load_balancer";
+		"http://" + _HOSTNAME_LOAD_BALANCER + "/osb-jenkins-web/load_balancer";
 
 	private static final Log _log = LogFactory.getLog(
 		JenkinsResultsParserUtil.class);


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-1608

@pyoo47 - I believe this is the correct hostname because when I ping *cloud-10-0-0-31* I get the following:
<pre>[root@cloud-10-0-11-64 liferay-portal]# ping cloud-10-0-0-31
PING cloud-10-0-0-31.lax.liferay.com (10.0.0.31) 56(84) bytes of data.
64 bytes from cloud-10-0-0-31.lax.liferay.com (10.0.0.31): icmp_seq=1 ttl=63 time=0.735 ms
64 bytes from cloud-10-0-0-31.lax.liferay.com (10.0.0.31): icmp_seq=2 ttl=63 time=0.220 ms
64 bytes from cloud-10-0-0-31.lax.liferay.com (10.0.0.31): icmp_seq=3 ttl=63 time=0.262 ms</pre>