### PR TITLE
LRCI-2303 Allow empty BATCH_TEST_SELECTOR parameter for most batch types in RCA Tool

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RootCauseAnalysisToolTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RootCauseAnalysisToolTopLevelBuildRunner.java
@@ -262,6 +262,10 @@ public class RootCauseAnalysisToolTopLevelBuildRunner
 
 		List<String> list = new ArrayList<>();
 
+		if (portalBatchTestSelector.isEmpty()) {
+			return list;
+		}
+
 		for (String portalBatchTest : portalBatchTestSelector.split(",")) {
 			list.add(portalBatchTest.trim());
 		}
@@ -346,6 +350,18 @@ public class RootCauseAnalysisToolTopLevelBuildRunner
 	}
 
 	private void _validateBuildParameterPortalBatchTestSelector() {
+		String portalBatchName = getBuildParameter(
+			_NAME_BUILD_PARAMETER_PORTAL_BATCH);
+
+		if (!portalBatchName.startsWith("integration") &&
+			!portalBatchName.startsWith("functional") &&
+			!portalBatchName.startsWith("modules-integration") &&
+			!portalBatchName.startsWith("modules-unit") &&
+			!portalBatchName.startsWith("unit")) {
+
+			return;
+		}
+
 		String portalBatchTestSelector = getBuildParameter(
 			_NAME_BUILD_PARAMETER_PORTAL_BATCH_TEST_SELECTOR);
 
@@ -353,7 +369,9 @@ public class RootCauseAnalysisToolTopLevelBuildRunner
 			portalBatchTestSelector.isEmpty()) {
 
 			failBuildRunner(
-				_NAME_BUILD_PARAMETER_PORTAL_BATCH_TEST_SELECTOR + " is null");
+				JenkinsResultsParserUtil.combine(
+					_NAME_BUILD_PARAMETER_PORTAL_BATCH_TEST_SELECTOR,
+					" is required for ", portalBatchName));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -140,6 +140,19 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		return _segmentTestClassGroups;
 	}
 
+	public String getTestCasePropertiesContent() {
+		StringBuilder sb = new StringBuilder();
+
+		for (SegmentTestClassGroup segmentTestClassGroup :
+				getSegmentTestClassGroups()) {
+
+			sb.append(segmentTestClassGroup.getTestCasePropertiesContent());
+			sb.append("\n");
+		}
+
+		return sb.toString();
+	}
+
 	public static class BatchTestClass extends BaseTestClass {
 
 		protected static BatchTestClass getInstance(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2303