### PR TITLE
LRCI-2605 Ensure that fix URL can be run multiple times against a URL or snippet

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -928,13 +928,7 @@ public abstract class BaseBuild implements Build {
 
 		sb.deleteCharAt(sb.length() - 1);
 
-		try {
-			return JenkinsResultsParserUtil.encode(sb.toString());
-		}
-		catch (MalformedURLException | URISyntaxException exception) {
-			throw new RuntimeException(
-				"Unable to encode URL " + sb.toString(), exception);
-		}
+		return JenkinsResultsParserUtil.fixURL(sb.toString());
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -951,6 +951,8 @@ public class JenkinsResultsParserUtil {
 					urlString, StandardCharsets.UTF_8.name());
 
 				urlString = urlString.replaceAll("\\+", "%20");
+				urlString = urlString.replaceAll("%21", "!");
+				urlString = urlString.replaceAll("%25", "%");
 
 				return urlString;
 			}
@@ -981,12 +983,17 @@ public class JenkinsResultsParserUtil {
 			try {
 				String queryParameterValue = matcher.group(2);
 
-				queryParameterValue = queryParameterValue.replaceAll(
-					"\\+", " ");
+				queryParameterValue = URLEncoder.encode(
+					queryParameterValue, StandardCharsets.UTF_8.name());
 
-				sb.append(
-					URLEncoder.encode(
-						queryParameterValue, StandardCharsets.UTF_8.name()));
+				queryParameterValue = queryParameterValue.replaceAll(
+					"\\+", "%20");
+				queryParameterValue = queryParameterValue.replaceAll(
+					"%21", "!");
+				queryParameterValue = queryParameterValue.replaceAll(
+					"%25", "%");
+
+				sb.append(queryParameterValue);
 			}
 			catch (UnsupportedEncodingException unsupportedEncodingException) {
 				throw new RuntimeException(unsupportedEncodingException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -951,8 +951,10 @@ public class JenkinsResultsParserUtil {
 					urlString, StandardCharsets.UTF_8.name());
 
 				urlString = urlString.replaceAll("\\+", "%20");
+
 				urlString = urlString.replaceAll("%21", "!");
 				urlString = urlString.replaceAll("%25", "%");
+				urlString = urlString.replaceAll("%2B", "+");
 
 				return urlString;
 			}
@@ -988,10 +990,13 @@ public class JenkinsResultsParserUtil {
 
 				queryParameterValue = queryParameterValue.replaceAll(
 					"\\+", "%20");
+
 				queryParameterValue = queryParameterValue.replaceAll(
 					"%21", "!");
 				queryParameterValue = queryParameterValue.replaceAll(
 					"%25", "%");
+				queryParameterValue = queryParameterValue.replaceAll(
+					"%2B", "+");
 
 				sb.append(queryParameterValue);
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseTestClass.java
@@ -98,7 +98,9 @@ public abstract class BaseTestClass implements TestClass {
 
 	@Override
 	public int hashCode() {
-		return _testClassFile.hashCode();
+		JSONObject jsonObject = getJSONObject();
+
+		return jsonObject.hashCode();
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -81,10 +81,18 @@ public class JenkinsResultsParserUtilTest
 
 	@Test
 	public void testFixURL() {
-		testEquals("ABC%28123", JenkinsResultsParserUtil.fixURL("ABC(123"));
-		testEquals("ABC%29123", JenkinsResultsParserUtil.fixURL("ABC)123"));
-		testEquals("ABC%5B123", JenkinsResultsParserUtil.fixURL("ABC[123"));
-		testEquals("ABC%5D123", JenkinsResultsParserUtil.fixURL("ABC]123"));
+		testEquals("ABC%28123", _fixURLMultipleTimes("ABC(123"));
+		testEquals("ABC%29123", _fixURLMultipleTimes("ABC)123"));
+		testEquals("ABC%5B123", _fixURLMultipleTimes("ABC[123"));
+		testEquals("ABC%5D123", _fixURLMultipleTimes("ABC]123"));
+		testEquals("!master", _fixURLMultipleTimes("!master"));
+		testEquals("0%201%202", _fixURLMultipleTimes("0 1 2"));
+		testEquals(
+			"https://test-1-1.liferay.com/job(master)?" +
+				"AXIS_VARIABLE=0%201&label_exp=!master&job=test%287.2.x%29",
+			_fixURLMultipleTimes(
+				"https://test-1-1.liferay.com/job(master)?" +
+					"AXIS_VARIABLE=0 1&label_exp=!master&job=test(7.2.x)"));
 	}
 
 	@Test
@@ -461,6 +469,12 @@ public class JenkinsResultsParserUtilTest
 		URL url = uri.toURL();
 
 		return url.toString();
+	}
+
+	private String _fixURLMultipleTimes(String urlString) {
+		return JenkinsResultsParserUtil.fixURL(
+			JenkinsResultsParserUtil.fixURL(
+				JenkinsResultsParserUtil.fixURL(urlString)));
 	}
 
 	private void _testGetProperty(


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2605

@pyoo47 - I could not do the quick fix of just replacing values in the *AXIS_VARIABLES*.  It was no longer matching up when I attempted to do the quick fix which lead to the downstream build being unable to be found.  So I had to dig deeper and do the real fix.  I thought it was randomly occurring, but it was actually consistently occurred on all reinvocations.

I think the logic takes the URL through another round of URL encoding somewhere in the Build object lifecycle.  It was too hard to figure out which fixURL needed to be removed.  But then, I realized all I need to do is make it so *fixURL()* can be run against a given URL or snippet multiple times.

It seems to be working after taking that approach.

It was able to get through a Pull Request, and I am testing it against this Portal Release:
* https://test-5-1.liferay.com/job/test-portal-acceptance-pullrequest(master)/4803/
* https://test-1-1.liferay.com/job/test-portal-release/3055

If this release works as expected, I'm going to do an emergency jar.  I am not sure why there are so many reinvocations happening right now.  But that's a different issue..