### PR TITLE
LRCI-2857 Avoid finding the batch test class groups when generating a JSONObject

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
@@ -81,7 +81,13 @@ public abstract class BaseJob implements Job {
 
 	@Override
 	public List<BatchTestClassGroup> getBatchTestClassGroups() {
-		return getBatchTestClassGroups(getRawBatchNames());
+		if (_batchTestClassGroups != null) {
+			return _batchTestClassGroups;
+		}
+
+		_batchTestClassGroups = getBatchTestClassGroups(getRawBatchNames());
+
+		return _batchTestClassGroups;
 	}
 
 	@Override
@@ -110,6 +116,18 @@ public abstract class BaseJob implements Job {
 	@Override
 	public BuildProfile getBuildProfile() {
 		return _buildProfile;
+	}
+
+	@Override
+	public List<BatchTestClassGroup> getDependentBatchTestClassGroups() {
+		if (_dependentBatchTestClassGroups != null) {
+			return _dependentBatchTestClassGroups;
+		}
+
+		_dependentBatchTestClassGroups = getBatchTestClassGroups(
+			getRawDependentBatchNames());
+
+		return _dependentBatchTestClassGroups;
 	}
 
 	@Override
@@ -217,10 +235,12 @@ public abstract class BaseJob implements Job {
 
 		JSONArray batchesJSONArray = new JSONArray();
 
-		for (BatchTestClassGroup batchTestClassGroup :
-				getBatchTestClassGroups()) {
+		if (_batchTestClassGroups != null) {
+			for (BatchTestClassGroup batchTestClassGroup :
+					_batchTestClassGroups) {
 
-			batchesJSONArray.put(batchTestClassGroup.getJSONObject());
+				batchesJSONArray.put(batchTestClassGroup.getJSONObject());
+			}
 		}
 
 		jsonObject.put("batches", batchesJSONArray);
@@ -232,11 +252,9 @@ public abstract class BaseJob implements Job {
 
 		JSONArray smokeBatchesJSONArray = new JSONArray();
 
-		if (this instanceof BatchDependentJob) {
-			BatchDependentJob batchDependentJob = (BatchDependentJob)this;
-
+		if (_dependentBatchTestClassGroups != null) {
 			for (BatchTestClassGroup batchTestClassGroup :
-					batchDependentJob.getDependentBatchTestClassGroups()) {
+					_dependentBatchTestClassGroups) {
 
 				smokeBatchesJSONArray.put(batchTestClassGroup.getJSONObject());
 			}
@@ -632,6 +650,14 @@ public abstract class BaseJob implements Job {
 		return getSetFromString(jobProperty.getValue());
 	}
 
+	protected Set<String> getRawDependentBatchNames() {
+		JobProperty jobProperty = getJobProperty("test.batch.names.smoke");
+
+		recordJobProperty(jobProperty);
+
+		return getSetFromString(jobProperty.getValue());
+	}
+
 	protected List<SegmentTestClassGroup> getSegmentTestClassGroups(
 		Set<String> rawBatchNames) {
 
@@ -798,7 +824,9 @@ public abstract class BaseJob implements Job {
 	private static final ExecutorService _executorService =
 		JenkinsResultsParserUtil.getNewThreadPoolExecutor(_THREAD_COUNT, true);
 
+	private List<BatchTestClassGroup> _batchTestClassGroups;
 	private final BuildProfile _buildProfile;
+	private List<BatchTestClassGroup> _dependentBatchTestClassGroups;
 	private boolean _initializeJobProperties;
 	private final String _jobName;
 	private final List<JobProperty> _jobProperties = new ArrayList<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalReleaseJob.java
@@ -55,11 +55,6 @@ public abstract class BasePortalReleaseJob
 	}
 
 	@Override
-	public List<BatchTestClassGroup> getDependentBatchTestClassGroups() {
-		return getBatchTestClassGroups(getRawDependentBatchNames());
-	}
-
-	@Override
 	public Set<String> getDependentSegmentNames() {
 		return getFilteredSegmentNames(getRawDependentBatchNames());
 	}
@@ -140,6 +135,7 @@ public abstract class BasePortalReleaseJob
 		return getSetFromString(jobProperty.getValue());
 	}
 
+	@Override
 	protected Set<String> getRawDependentBatchNames() {
 		JobProperty jobProperty = getJobProperty(
 			"test.batch.names.smoke", false);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Job.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Job.java
@@ -44,6 +44,8 @@ public interface Job {
 
 	public BuildProfile getBuildProfile();
 
+	public List<BatchTestClassGroup> getDependentBatchTestClassGroups();
+
 	public List<String> getDistNodes();
 
 	public DistType getDistType();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptanceTestSuiteJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalAcceptanceTestSuiteJob.java
@@ -51,11 +51,6 @@ public abstract class PortalAcceptanceTestSuiteJob
 	}
 
 	@Override
-	public List<BatchTestClassGroup> getDependentBatchTestClassGroups() {
-		return getBatchTestClassGroups(getRawDependentBatchNames());
-	}
-
-	@Override
 	public Set<String> getDependentSegmentNames() {
 		return getFilteredSegmentNames(getRawDependentBatchNames());
 	}
@@ -155,14 +150,6 @@ public abstract class PortalAcceptanceTestSuiteJob
 		rawBatchNames.addAll(getSetFromString(jobProperty.getValue()));
 
 		return rawBatchNames;
-	}
-
-	protected Set<String> getRawDependentBatchNames() {
-		JobProperty jobProperty = getJobProperty("test.batch.names.smoke");
-
-		recordJobProperty(jobProperty);
-
-		return getSetFromString(jobProperty.getValue());
 	}
 
 	private final String _testSuiteName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SubrepositoryGitRepositoryJob.java
@@ -14,7 +14,6 @@
 
 package com.liferay.jenkins.results.parser;
 
-import com.liferay.jenkins.results.parser.job.property.JobProperty;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.BatchTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.SegmentTestClassGroup;
@@ -52,11 +51,6 @@ public class SubrepositoryGitRepositoryJob
 	@Override
 	public Set<String> getDependentBatchNames() {
 		return getFilteredBatchNames(getRawDependentBatchNames());
-	}
-
-	@Override
-	public List<BatchTestClassGroup> getDependentBatchTestClassGroups() {
-		return getBatchTestClassGroups(getRawDependentBatchNames());
 	}
 
 	@Override
@@ -167,14 +161,6 @@ public class SubrepositoryGitRepositoryJob
 		_upstreamBranchName = jsonObject.getString("upstream_branch_name");
 
 		_initialize();
-	}
-
-	protected Set<String> getRawDependentBatchNames() {
-		JobProperty jobProperty = getJobProperty("test.batch.names.smoke");
-
-		recordJobProperty(jobProperty);
-
-		return getSetFromString(jobProperty.getValue());
 	}
 
 	protected PortalGitWorkingDirectory portalGitWorkingDirectory;


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2857