### PR TITLE
LRCI-2953 hardcode db2 jar version

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -8194,7 +8194,7 @@ org.apache.catalina.tribes.level = FINE]]>
 					<sequential>
 						<mirrors-get
 							dest="${todir}"
-							src="${test.jdbc.drivers.url}/db2/${database.version}/@{jdbc.driver}"
+							src="${test.jdbc.drivers.url}/db2/11.1.3/@{jdbc.driver}"
 						/>
 
 						<tstamp>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2953

Please backport all the way to 7.0.x (cherry-picks cleanly)