### PR TITLE
LRCI-2996 Don't fail out if an error occurs in print-jstack-logs

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -12483,7 +12483,16 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 	<target name="print-jstack-logs">
 		<fail message="Please set the property ${process.name}." unless="process.name" />
 
-		<print-jstack-logs process.name="${process.name}" />
+		<trycatch property="exception.message">
+			<try>
+				<print-jstack-logs process.name="${process.name}" />
+			</try>
+			<catch>
+				<echo>Unable to print jstack log</echo>
+
+				<echo>${exception.message}</echo>
+			</catch>
+		</trycatch>
 	</target>
 
 	<target name="print-scm-revision">


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-2996

Please backport all the way to 7.0.x (Cherry-picks cleanly)