### PR TITLE
Revert "LRCI-1398 Remove file path comparison with modules base dir"

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
@@ -347,6 +347,10 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 
 		Path parentFilePath = parentFile.toPath();
 
+		if (parentFilePath.equals(modulesBaseDirPath)) {
+			return concatedPQL;
+		}
+
 		if (!canonicalFile.isDirectory()) {
 			return _concatPQL(parentFile, concatedPQL);
 		}


### PR DESCRIPTION
This reverts commit 22220e2146bfe660addcaec466d1f714683bee9b.

https://issues.liferay.com/browse/LRCI-1398 