### PR TITLE
LRCI-3180 Catch null pointer exception when upstream build is missing

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UpstreamFailureUtil.java
@@ -319,6 +319,10 @@ public class UpstreamFailureUtil {
 		TopLevelBuildReport topLevelBuildReport =
 			getUpstreamTopLevelBuildReport(topLevelBuild);
 
+		if (topLevelBuildReport == null) {
+			return upstreamFailures;
+		}
+
 		for (DownstreamBuildReport downstreamBuildReport :
 				topLevelBuildReport.getDownstreamBuildReports()) {
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3180