### PR TITLE
LRCI-3414 Only require ci:test:sf for all workspaces changes

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -175,6 +175,7 @@ ci.test.relevant.bypass.file.path.patterns=\
     .*/liferay-portal[^/]*/modules/test/poshi/.*,\
     .*/liferay-portal[^/]*/portal-web/build-test.gradle,\
     .*/liferay-portal[^/]*/readme/.*,\
+    .*/liferay-portal[^/]*/workspaces/.*,\
     .*/packageinfo$,\
     .*\\.function$,\
     .*\\.macro$,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3414

@brianchandotcom - This will make it so any changes made within the following directory will only require `ci:test:sf`:
<pre>.*/liferay-portal[^/]*/workspaces/.*</pre>

We felt that it should be okay, because these workspaces shouldn't affect portal.  It could be adjusted if you don't this this is correct.  Please let us know if this is too aggressive.  Thanks!