### PR TITLE
LRCI-3420 Extend default timeout to 2 hours.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
@@ -90,7 +90,7 @@ public class ParallelExecutor<T> {
 		}
 
 		if (timeoutSeconds == null) {
-			timeoutSeconds = 60L * 5L;
+			timeoutSeconds = 60L * 60L * 2L;
 		}
 
 		try {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3420