### PR TITLE
LRCI-3505 Add the Jenkins Publisher name & make all JenkinsPublisher fields private

### DIFF
--- a/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/JenkinsEventsDescriptor.java
+++ b/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/JenkinsEventsDescriptor.java
@@ -21,7 +21,6 @@ import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/JenkinsEventsDescriptor.java
+++ b/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/JenkinsEventsDescriptor.java
@@ -35,8 +35,6 @@ public class JenkinsEventsDescriptor
 	public JenkinsEventsDescriptor() {
 		super(JenkinsEventsDescriptor.class);
 
-		jenkinsPublishers = new ArrayList<>();
-
 		load();
 	}
 

--- a/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/jms/JMSQueue.java
+++ b/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/jms/JMSQueue.java
@@ -53,13 +53,12 @@ public class JMSQueue {
 	public void subscribe(MessageListener messageListener) {
 		synchronized (_log) {
 			if (_messageConsumer != null) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
+				if (_log.isWarnEnabled()) {
+					_log.warn(
 						"[" + _queueName + "] Already subscribed to queue");
 				}
 
-				throw new RuntimeException(
-					"Unable to subscribe to " + _queueName);
+				return;
 			}
 
 			try {

--- a/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/publisher/JenkinsPublisher.java
+++ b/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/publisher/JenkinsPublisher.java
@@ -105,7 +105,7 @@ public class JenkinsPublisher {
 			EventTrigger.QUEUE_ITEM_LEFT);
 
 		if ((_inboundJMSQueueName != null) && _jmsRequest) {
-			JMSConnection jmsConnection = JMSFactory.newJMSConnection(getUrl());
+			JMSConnection jmsConnection = JMSFactory.newJMSConnection(_url);
 
 			JMSQueue jmsQueue = JMSFactory.newJMSQueue(
 				jmsConnection, _inboundJMSQueueName);
@@ -158,7 +158,7 @@ public class JenkinsPublisher {
 	}
 
 	public String getUrl() {
-		return _userPassword;
+		return _url;
 	}
 
 	public String getUserName() {

--- a/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/publisher/JenkinsPublisher.java
+++ b/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/publisher/JenkinsPublisher.java
@@ -66,6 +66,7 @@ public class JenkinsPublisher {
 				"outboundJMSQueueName");
 		}
 
+		name = jsonObject.getString("name");
 		queueItemEnterBlocked = jsonObject.getBoolean("queueItemEnterBlocked");
 		queueItemEnterBuildable = jsonObject.getBoolean(
 			"queueItemEnterBuildable");
@@ -118,6 +119,7 @@ public class JenkinsPublisher {
 	public boolean computerTemporarilyOnline;
 	public String inboundJMSQueueName;
 	public boolean jmsRequest;
+	public String name;
 	public String outboundJMSQueueName;
 	public boolean queueItemEnterBlocked;
 	public boolean queueItemEnterBuildable;

--- a/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/publisher/JenkinsPublisher.java
+++ b/modules/test/jenkins-plugin-events/src/main/java/com/liferay/jenkins/plugin/events/publisher/JenkinsPublisher.java
@@ -114,17 +114,6 @@ public class JenkinsPublisher {
 		}
 	}
 
-	public boolean containsEventTrigger(String eventTriggerString) {
-		for (EventTrigger eventTrigger : EventTrigger.values()) {
-			if (Objects.equals(eventTriggerString, eventTrigger.toString())) {
-				return containsEventTrigger(
-					EventTrigger.valueOf(eventTriggerString));
-			}
-		}
-
-		return false;
-	}
-
 	public boolean containsEventTrigger(EventTrigger eventTrigger) {
 		if (eventTrigger == null) {
 			return false;
@@ -132,6 +121,17 @@ public class JenkinsPublisher {
 
 		if (_eventTriggers.contains(eventTrigger)) {
 			return true;
+		}
+
+		return false;
+	}
+
+	public boolean containsEventTrigger(String eventTriggerString) {
+		for (EventTrigger eventTrigger : EventTrigger.values()) {
+			if (Objects.equals(eventTriggerString, eventTrigger.toString())) {
+				return containsEventTrigger(
+					EventTrigger.valueOf(eventTriggerString));
+			}
 		}
 
 		return false;
@@ -206,9 +206,6 @@ public class JenkinsPublisher {
 		sb.append(base64Encoder.encodeToString(userNamePassword.getBytes()));
 
 		return sb.toString();
-	}
-
-	private void _initializeEventTypes() {
 	}
 
 	private void _publishHttp(String payload, EventTrigger eventTrigger) {
@@ -316,9 +313,9 @@ public class JenkinsPublisher {
 	}
 
 	private final List<EventTrigger> _eventTriggers = new ArrayList<>();
-	private final String _name;
 	private final String _inboundJMSQueueName;
 	private final boolean _jmsRequest;
+	private final String _name;
 	private final String _outboundJMSQueueName;
 	private final String _url;
 	private final String _userName;

--- a/modules/test/jenkins-plugin-events/src/main/resources/com/liferay/jenkins/plugin/events/JenkinsEventsManagementLink/index.jelly
+++ b/modules/test/jenkins-plugin-events/src/main/resources/com/liferay/jenkins/plugin/events/JenkinsEventsManagementLink/index.jelly
@@ -53,53 +53,53 @@
                             <f:advanced title="Event Configurations">
                                 <f:section title="Build Events">
                                     <f:entry title="BUILD_COMPLETED">
-                                        <f:checkbox checked="${jenkinsPublishers.buildCompleted}" name="buildCompleted" value="${jenkinsPublishers.buildCompleted}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('BUILD_COMPLETED')}" name="buildCompleted" />
                                     </f:entry>
                                     <f:entry title="BUILD_STARTED">
-                                        <f:checkbox checked="${jenkinsPublishers.buildStarted}" name="buildStarted" value="${jenkinsPublishers.buildStarted}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('BUILD_STARTED')}" name="buildStarted" />
                                     </f:entry>
                                 </f:section>
                                 <f:section title="Computer Events">
                                     <f:entry title="COMPUTER_BUSY">
-                                        <f:checkbox checked="${jenkinsPublishers.computerBusy}" name="computerBusy" value="${jenkinsPublishers.computerBusy}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('COMPUTER_BUSY')}" name="computerBusy" />
                                     </f:entry>
                                     <f:entry title="COMPUTER_IDLE">
-                                        <f:checkbox checked="${jenkinsPublishers.computerIdle}" name="computerIdle" value="${jenkinsPublishers.computerIdle}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('COMPUTER_IDLE')}" name="computerIdle" />
                                     </f:entry>
                                     <f:entry title="COMPUTER_OFFLINE">
-                                        <f:checkbox checked="${jenkinsPublishers.computerOffline}" name="computerOffline" value="${jenkinsPublishers.computerOffline}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('COMPUTER_OFFLINE')}" name="computerOffline" />
                                     </f:entry>
                                     <f:entry title="COMPUTER_ONLINE">
-                                        <f:checkbox checked="${jenkinsPublishers.computerOnline}" name="computerOnline" value="${jenkinsPublishers.computerOnline}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('COMPUTER_ONLINE')}" name="computerOnline" />
                                     </f:entry>
                                     <f:entry title="COMPUTER_TEMPORARILY_OFFLINE">
-                                        <f:checkbox checked="${jenkinsPublishers.computerTemporarilyOffline}" name="computerTemporarilyOffline" value="${jenkinsPublishers.computerTemporarilyOffline}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('COMPUTER_TEMPORARILY_OFFLINE')}" name="computerTemporarilyOffline" />
                                     </f:entry>
                                     <f:entry title="COMPUTER_TEMPORARILY_ONLINE">
-                                        <f:checkbox checked="${jenkinsPublishers.computerTemporarilyOnline}" name="computerTemporarilyOnline" value="${jenkinsPublishers.computerTemporarilyOnline}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('COMPUTER_TEMPORARILY_ONLINE')}" name="computerTemporarilyOnline" />
                                     </f:entry>
                                 </f:section>
                                 <f:section title="Queue Events">
                                     <f:entry title="QUEUE_ITEM_ENTER_BLOCKED">
-                                        <f:checkbox checked="${jenkinsPublishers.queueItemEnterBlocked}" name="queueItemEnterBlocked" value="${jenkinsPublishers.queueItemEnterBlocked}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('QUEUE_ITEM_ENTER_BLOCKED')}" name="queueItemEnterBlocked" />
                                     </f:entry>
                                     <f:entry title="QUEUE_ITEM_ENTER_BUILDABLE">
-                                        <f:checkbox checked="${jenkinsPublishers.queueItemEnterBuildable}" name="queueItemEnterBuildable" value="${jenkinsPublishers.queueItemEnterBuildable}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('QUEUE_ITEM_ENTER_BUILDABLE')}" name="queueItemEnterBuildable" />
                                     </f:entry>
                                     <f:entry title="QUEUE_ITEM_ENTER_WAITING">
-                                        <f:checkbox checked="${jenkinsPublishers.queueItemEnterWaiting}" name="queueItemEnterWaiting" value="${jenkinsPublishers.queueItemEnterWaiting}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('QUEUE_ITEM_ENTER_WAITING')}" name="queueItemEnterWaiting" />
                                     </f:entry>
                                     <f:entry title="QUEUE_ITEM_LEAVE_BLOCKED">
-                                        <f:checkbox checked="${jenkinsPublishers.queueItemLeaveBlocked}" name="queueItemLeaveBlocked" value="${jenkinsPublishers.queueItemLeaveBlocked}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('QUEUE_ITEM_LEAVE_BLOCKED')}" name="queueItemLeaveBlocked" />
                                     </f:entry>
                                     <f:entry title="QUEUE_ITEM_LEAVE_BUILDABLE">
-                                        <f:checkbox checked="${jenkinsPublishers.queueItemLeaveBuildable}" name="queueItemLeaveBuildable" value="${jenkinsPublishers.queueItemLeaveBuildable}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('QUEUE_ITEM_LEAVE_BUILDABLE')}" name="queueItemLeaveBuildable" />
                                     </f:entry>
                                     <f:entry title="QUEUE_ITEM_LEAVE_WAITING">
-                                        <f:checkbox checked="${jenkinsPublishers.queueItemLeaveWaiting}" name="queueItemLeaveWaiting" value="${jenkinsPublishers.queueItemLeaveWaiting}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('QUEUE_ITEM_LEAVE_WAITING')}" name="queueItemLeaveWaiting" />
                                     </f:entry>
                                     <f:entry title="QUEUE_ITEM_LEFT">
-                                        <f:checkbox checked="${jenkinsPublishers.queueItemLeft}" name="queueItemLeft" value="${jenkinsPublishers.queueItemLeft}" />
+                                        <f:checkbox checked="${jenkinsPublishers.containsEventTrigger('QUEUE_ITEM_LEFT')}" name="queueItemLeft" />
                                     </f:entry>
                                 </f:section>
                             </f:advanced>

--- a/modules/test/jenkins-plugin-events/src/main/resources/com/liferay/jenkins/plugin/events/JenkinsEventsManagementLink/index.jelly
+++ b/modules/test/jenkins-plugin-events/src/main/resources/com/liferay/jenkins/plugin/events/JenkinsEventsManagementLink/index.jelly
@@ -30,6 +30,9 @@
                                     <f:repeatableDeleteButton />
                                 </div>
                             </f:entry>
+                            <f:entry title="Name">
+                                <f:textbox name="name" value="${jenkinsPublishers.name}" />
+                            </f:entry>
                             <f:entry title="URL">
                                 <f:textbox name="url" value="${jenkinsPublishers.url}" />
                             </f:entry>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3505

@pyoo47 - I was wrong about being able to use private fields in Jenkins Plugins for jelly files, but it seems like you can access those fields in the jelly files if you have a public method.

In this particular case:
<pre>public String getName()</pre>

Will allow this in a jelly file:
<pre>${jenkinsPublishers.name}</pre>