### PR TITLE
LRCI-3420 Extend default timeout to 4 hours

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
@@ -90,7 +90,7 @@ public class ParallelExecutor<T> {
 		}
 
 		if (timeoutSeconds == null) {
-			timeoutSeconds = 60L * 60L * 2L;
+			timeoutSeconds = 60L * 60L * 4L;
 		}
 
 		try {


### PR DESCRIPTION
It seems I've underestimated how long it takes for Jenkins to retrieve the JSONObject for some builds. SInce we know we didn't see freezes occur when there was no timeout, we know that every request should eventually return. I'm extending the timeout from 2 hours to 4 hours.