### PR TITLE
LRCI-3529 Add ability to deploy a client extensions from a given workspace

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -10108,44 +10108,6 @@ org.apache.catalina.tribes.level = FINE]]>
 		</for>
 	</target>
 
-	<target name="deploy-workspaces">
-		<for list="${workspaces.includes}" param="workspace.name">
-			<sequential>
-				<local name="workspace.name" />
-
-				<antelope:stringutil property="workspace.name" string="@{workspace.name}">
-					<antelope:trim />
-				</antelope:stringutil>
-
-				<property location="${project.dir}/workspaces/${workspace.name}" name="workspace.dir" />
-
-				<if>
-					<available file="${workspace.dir}" />
-					<then>
-						<execute dir="${workspace.dir}">
-							./gradlew clean assemble
-						</execute>
-
-						<for param="client.extension.zip.file">
-							<path>
-								<fileset
-									dir="${workspace.dir}/client-extensions"
-									includes="**/dist/*.zip"
-								/>
-							</path>
-							<sequential>
-								<copy
-									file="@{client.extension.zip.file}"
-									todir="${liferay.home}/deploy"
-								/>
-							</sequential>
-						</for>
-					</then>
-				</if>
-			</sequential>
-		</for>
-	</target>
-
 	<target name="execute-groovy-script-from-gogo-shell">
 		<set-app-server-properties
 			app.server.bundle.index="${bundle.index}"
@@ -15123,10 +15085,6 @@ mail.send.blacklist=</echo>
 		<get-testcase-property property.name="workspace.client.extensions.includes" />
 
 		<antcall if:set="workspace.client.extensions.includes" target="deploy-workspace-client-extensions" />
-
-		<get-testcase-property property.name="workspaces.includes" />
-
-		<antcall if:set="workspaces.includes" target="deploy-workspaces" />
 
 		<get-testcase-property property.name="liferay.data.guard.enabled" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -10077,6 +10077,37 @@ org.apache.catalina.tribes.level = FINE]]>
 		</if>
 	</target>
 
+	<target name="deploy-workspace-client-extensions">
+		<for list="${workspace.client.extensions.includes}" param="workspace.client.extension.name">
+			<sequential>
+				<local name="workspace.client.extension.name" />
+
+				<antelope:stringutil property="workspace.client.extension.name" string="@{workspace.client.extension.name}">
+					<antelope:trim />
+				</antelope:stringutil>
+
+				<for param="workspace.client.extension.dir">
+					<path>
+						<dirset
+							dir="${project.dir}/workspaces/"
+							includes="*/client-extensions/${workspace.client.extension.name}"
+						/>
+					</path>
+					<sequential>
+						<execute dir="@{workspace.client.extension.dir}">
+							../../gradlew clean assemble
+						</execute>
+
+						<copy
+							file="@{workspace.client.extension.dir}/dist/${workspace.client.extension.name}.zip"
+							todir="${liferay.home}/deploy"
+						/>
+					</sequential>
+				</for>
+			</sequential>
+		</for>
+	</target>
+
 	<target name="deploy-workspaces">
 		<for list="${workspaces.includes}" param="workspace.name">
 			<sequential>
@@ -15088,6 +15119,10 @@ mail.send.blacklist=</echo>
 		<antcall target="hot-deploy-osgi-apps" />
 
 		<antcall target="deploy-osgi-modules" />
+
+		<get-testcase-property property.name="workspace.client.extensions.includes" />
+
+		<antcall if:set="workspace.client.extensions.includes" target="deploy-workspace-client-extensions" />
 
 		<get-testcase-property property.name="workspaces.includes" />
 

--- a/test.properties
+++ b/test.properties
@@ -9889,8 +9889,7 @@
         web.plugins.includes,\
         web.xml.timeout,\
         websphere.ssl.truststore.enabled,\
-        workspace.client.extensions.includes,\
-        workspaces.includes
+        workspace.client.extensions.includes
 
     test.case.available.property.values[minimum.slave.ram]=\
         12,\

--- a/test.properties
+++ b/test.properties
@@ -9889,6 +9889,7 @@
         web.plugins.includes,\
         web.xml.timeout,\
         websphere.ssl.truststore.enabled,\
+        workspace.client.extensions.includes,\
         workspaces.includes
 
     test.case.available.property.values[minimum.slave.ram]=\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3529

@brianchandotcom - In response to this [comment](https://github.com/brianchandotcom/liferay-portal/pull/132396#issuecomment-1485423922), I decided to just get rid of **deploy-workspaces** altogether.  After talking with Tai, he said it was more important to deploy individual client extensions vs the whole workspace.