### PR TITLE
LRCI-3536 Add method to get an OAuth2AccessToken from client extension util module

### DIFF
--- a/modules/util/client-extension-util-spring-boot/src/main/java/com/liferay/client/extension/util/spring/boot/LiferayOAuth2Util.java
+++ b/modules/util/client-extension-util-spring-boot/src/main/java/com/liferay/client/extension/util/spring/boot/LiferayOAuth2Util.java
@@ -17,6 +17,10 @@ package com.liferay.client.extension.util.spring.boot;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -71,6 +75,40 @@ public class LiferayOAuth2Util {
 				}
 			}
 		}
+	}
+
+	public static OAuth2AccessToken getOAuth2AccessToken(
+		AuthorizedClientServiceOAuth2AuthorizedClientManager
+			authorizedClientServiceOAuth2AuthorizedClientManager,
+		String externalReferenceCode) {
+
+		OAuth2AuthorizeRequest.Builder oAuth2AuthorizeRequestBuilder =
+			OAuth2AuthorizeRequest.withClientRegistrationId(
+				externalReferenceCode
+			).principal(
+				externalReferenceCode
+			);
+
+		OAuth2AuthorizedClient oAuth2AuthorizedClient =
+			authorizedClientServiceOAuth2AuthorizedClientManager.authorize(
+				oAuth2AuthorizeRequestBuilder.build());
+
+		if (oAuth2AuthorizedClient == null) {
+			_log.error("Unable to get OAuth 2 authorized client");
+
+			return null;
+		}
+
+		OAuth2AccessToken oAuth2AccessToken =
+			oAuth2AuthorizedClient.getAccessToken();
+
+		if (oAuth2AccessToken == null) {
+			_log.error("Unable to get OAuth 2 access token");
+
+			return null;
+		}
+
+		return oAuth2AccessToken;
 	}
 
 	private static final Log _log = LogFactory.getLog(LiferayOAuth2Util.class);


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3536

@brianchandotcom - After talking with @gamerson we came up with this method.

How it'll be used within the workspaces would be like this:
<pre>LiferayOAuth2Util.getOAuth2AccessToken(
	_authorizedClientServiceOAuth2AuthorizedClientManager,
	"liferay-jethr0-oauth-application-headless-server")</pre>

It needs to be a method because there is a possibility to have multiple external reference codes per project.  I thought that this was the right object to return because it can be used more universally like in how `liferay-sample-etc-cron` used it.

This logic can still be used to replace this method as well:
https://github.com/liferay/liferay-portal/blob/master/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/src/main/java/com/liferay/sample/SampleCommandLineRunner.java#L46-L61
