### PR TITLE
LRCI-3548 Escape single backslash characters when in SlaveOfflineRule.toString() when generating groovy script

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2076,10 +2076,14 @@ public abstract class BaseBuild implements Build {
 
 		JenkinsSlave jenkinsSlave = getJenkinsSlave();
 
+		String slaveOfflineRuleString = slaveOfflineRule.toString();
+
+		slaveOfflineRuleString = slaveOfflineRuleString.replace("\\", "\\\\");
+
 		String message = JenkinsResultsParserUtil.combine(
 			pinnedMessage, slaveOfflineRule.getName(), " failure detected at ",
 			getBuildURL(), ". ", jenkinsSlave.getName(),
-			" will be taken offline.\n\n", slaveOfflineRule.toString(),
+			" will be taken offline.\n\n", slaveOfflineRuleString,
 			"\n\n\nOffline Slave URL: https://", _jenkinsMaster.getName(),
 			".liferay.com/computer/", jenkinsSlave.getName(), "\n");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3548