### PR TITLE
LRCI-3640 Console text loaders should always bypass the console file size limit for top-level builds.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -762,7 +762,7 @@ public abstract class BaseBuild implements Build {
 
 		if (_jenkinsConsoleTextLoader == null) {
 			_jenkinsConsoleTextLoader = new JenkinsConsoleTextLoader(
-				getBuildURL());
+				getBuildURL(), this instanceof TopLevelBuild);
 		}
 
 		return _jenkinsConsoleTextLoader.getConsoleText();


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-3640