### PR TITLE
LRCI-3746 Fix regex and make match case sensitive

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -737,11 +737,11 @@ mariadb.executable=${mariadb.executable}]]></echo>
 			<local name="test.class.java" />
 
 			<propertyregex
-				casesensitive="false"
+				casesensitive="true"
 				input="@{test.class}"
 				property="test.class.java"
-				regexp=".class"
-				replace=".java"
+				regexp="\.class"
+				replace="\.java"
 			/>
 
 			<first id="test.class.file">


### PR DESCRIPTION
This will fix the modules unit/integration error "Unable to load properties.file". This was due to a case sensitive issue.
https://liferay.atlassian.net/browse/LRCI-3746 