### PR TITLE
LRCI-3749 Always keep the Controller jobs for Upstream jobs after invoked

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerSingleSuiteBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalTestSuiteUpstreamControllerSingleSuiteBuildRunner.java
@@ -172,6 +172,8 @@ public class PortalTestSuiteUpstreamControllerSingleSuiteBuildRunner
 
 		try {
 			JenkinsResultsParserUtil.toString(sb.toString());
+
+			keepJenkinsBuild(true);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3749

@pyoo47 - I had to publish an emergency jar here:
https://github.com/liferay/liferay-jenkins-ee/commit/6f79c087c01361b59b04507c619d9b844147cd40

@brittneyq & I found out that this could lead to extra load.  I think it's mostly affecting controller jobs that have lower priority & frequent runs.