### PR TITLE
LRCI-3731 Change test.batch.run.property.global.query to use the overloaded getJobProperty method.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/FunctionalBatchTestClassGroup.java
@@ -602,7 +602,7 @@ public class FunctionalBatchTestClassGroup extends BatchTestClassGroup {
 		String testBatchRunPropertyQuery = sb.toString();
 
 		JobProperty jobProperty = getJobProperty(
-			"test.batch.run.property.global.query");
+			"test.batch.run.property.global.query", testSuiteName, batchName);
 
 		String jobPropertyValue = jobProperty.getValue();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3731