### PR TITLE
LRCI-3784 add property for semantic-versioning batches to only run on 24 gb slaves

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1226,6 +1226,7 @@
     test.batch.minimum.slave.ram[portal-license-smoke-mysql57-jdk8]=24
     test.batch.minimum.slave.ram[*redhat9*]=24
     test.batch.minimum.slave.ram[*rockylinux*]=24
+    test.batch.minimum.slave.ram[*semantic-versioning*]=24
 
     test.batch.names=${test.batch.names[acceptance-dxp]}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3784