### PR TITLE
LRCI-3791 Create a folder to put custom LCP Services in Workspaces to add ActiveMQ

### DIFF
--- a/workspaces/liferay-jethr0-workspace/lcp-services/liferay-jethr0-activemq/LCP.json
+++ b/workspaces/liferay-jethr0-workspace/lcp-services/liferay-jethr0-activemq/LCP.json
@@ -1,0 +1,32 @@
+{
+	"cpu": 1.0,
+	"id": "activemq",
+	"image": "rmohr/activemq:5.15.9-alpine",
+	"kind": "Deployment",
+	"livenessProbe": {
+		"httpGet": {
+			"path": "/",
+			"port": 8161
+		}
+	},
+	"loadBalancer": {
+		"cdn": false,
+		"targetPort": 8161
+	},
+	"memory": 1024,
+	"ports": [
+		{
+			"external": true,
+			"port": 61616,
+			"protocol": "TCP",
+			"targetPort": 61616
+		}
+	],
+	"readinessProbe": {
+		"httpGet": {
+			"path": "/",
+			"port": 8161
+		}
+	},
+	"scale": 1
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3791

@brianchandotcom - There is no convention for this type of standalone LCP.json file within our other workspaces.  I talked with Greg and he said that maybe just creating a new folder separate from `client-extensions` might make sense because there's no actual associated Client Extension related to these [Custom Services](https://learn.liferay.com/w/liferay-cloud/platform-services/using-a-custom-service).

Here's the folder structure for Jethr0:
```
liferay-workspace-jethr0/
    client-extensions/
        liferay-jethr0-batch-0/
        liferay-jethr0-batch-1/
        liferay-jethr0-custom-element/
        liferay-jethr0-etc-spring-boot/
    lcp-services/
        liferay-jethr0-activemq/
```

The `services` part of the name `lcp-services` is based off of the name "Services" within the LXC UI:
![image](https://github.com/pyoo47/liferay-portal/assets/863043/d4c654f7-5b69-48fc-b0f6-3a9f121970c2)

The `activemq` part of the name `liferay-jethr0-activemq` is based off of the `id` of the LCP Service.  Here's an article that shows what an `id` is within the LCP.json file:
https://learn.liferay.com/en/w/liferay-cloud/reference/configuration-via-lcp-json

The resulting URL for this new service will be available here at these URLs and are generated based off of the `id`:
* https://activemq-exte5t1jethr0-extdev.lfr.cloud
* tcp://activemq-exte5t1jethr0-extdev--ports.lfr.cloud:61616

Please let me know.  Thanks!