### PR TITLE
LRCI-3826 Avoid recursion when fetching upstream remote branches

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2647,13 +2647,18 @@ public class GitWorkingDirectory {
 			String upstreamGitBranchSHA = upstreamRemoteGitBranch.getSHA();
 
 			if (!localSHAExists(upstreamGitBranchSHA)) {
-				fetch(upstreamRemoteGitBranch);
+				commands.add(
+					JenkinsResultsParserUtil.combine(
+						"git fetch -f upstream ",
+						upstreamRemoteGitBranch.getName(), ":",
+						tempBranchName));
 			}
-
-			commands.add(
-				JenkinsResultsParserUtil.combine(
-					"git branch -f ", tempBranchName, " ",
-					upstreamGitBranchSHA));
+			else {
+				commands.add(
+					JenkinsResultsParserUtil.combine(
+						"git branch -f ", tempBranchName, " ",
+						upstreamGitBranchSHA));
+			}
 
 			commands.add(
 				JenkinsResultsParserUtil.combine(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3826

Hey @pyoo47,

We saw that there was recursion happening with:
* `createLocalGitBranch`
* `_createLocalGitBranch`
* `fetch`

And so if we fetch using lower-level commands it should avoid this situation and break the cycle.

We haven't tested it yet, but can you look at it to see if this makes sense?

See the jstack file in the ticket to see the actual lines it seems to get stuck at.