### PR TITLE
LRCI-3837 Avoid printing the stacktrace when mirrors-get is unable to get a resource from mirrors

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -193,8 +193,6 @@ public class MirrorsGetTask extends Task {
 			if (!_ignoreErrors) {
 				throw ioException;
 			}
-
-			ioException.printStackTrace();
 		}
 
 		if (_verbose) {
@@ -254,7 +252,6 @@ public class MirrorsGetTask extends Task {
 						Thread.sleep(30000);
 					}
 					catch (InterruptedException interruptedException) {
-						interruptedException.printStackTrace();
 					}
 				}
 			}
@@ -429,8 +426,6 @@ public class MirrorsGetTask extends Task {
 		}
 		catch (Exception exception) {
 			System.out.println("Unable to get process output.");
-
-			exception.printStackTrace();
 		}
 
 		return processOutput.toString();

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -337,9 +337,11 @@ public class MirrorsGetTask extends Task {
 				catch (IOException ioException) {
 					URL defaultURL = new URL(_src);
 
-					System.out.println(
-						"Unable to connect to " + sourceURL +
-							", defaulting to " + defaultURL);
+					if (_verbose) {
+						System.out.println(
+							"Unable to connect to " + sourceURL +
+								", defaulting to " + defaultURL);
+					}
 
 					_downloadFile(defaultURL, localCacheFile, 0);
 				}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3837