### PR TITLE
LRCI-3945 Log duration of upgrading database & print docker stats to see if MySQL is still up

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7166,6 +7166,12 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 			/>
 
 			<lstopwatch action="total" name="start.app.server.@{app.server.bundle.index}" />
+
+			<execute>
+				<![CDATA[
+					docker stats --no-stream
+				]]>
+			</execute>
 		</sequential>
 	</macrodef>
 
@@ -16622,6 +16628,8 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 	</target>
 
 	<target name="upgrade-legacy-database">
+		<lstopwatch action="start" name="upgrade-legacy-database" />
+
 		<prepare-database-upgrade-properties />
 
 		<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
@@ -16692,6 +16700,15 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 					</else>
 				</if>
 			</catch>
+			<finally>
+				<lstopwatch action="total" name="upgrade-legacy-database" />
+
+				<execute>
+					<![CDATA[
+						docker stats --no-stream
+					]]>
+				</execute>
+			</finally>
 		</trycatch>
 	</target>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3945

@pyoo47 - I looked into the error that was being thrown in the PR in the ticket & I saw that it happens when upgrading the database.  So, I added a timer into that target.  I also added a docker stat after that & portal starts up to show which containers are still up.