### PR TITLE
master qa 83508

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
@@ -80,12 +80,12 @@ public class GenerateTestrayCSVUtil {
 			sb.append("\n");
 		}
 
-		if (sb.length() > 0) {
-			return JenkinsResultsParserUtil.combine(
-				testrayCaseResultType.toString(), " Failures\n", sb.toString());
+		if (sb.length() == 0) {
+			sb.append("NONE\n");
 		}
 
-		return "";
+		return JenkinsResultsParserUtil.combine(
+			testrayCaseResultType.toString(), " Failures\n", sb.toString());
 	}
 
 	private static List<TestrayCaseResult> _getTestrayCaseResults(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
@@ -12,6 +12,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -154,6 +155,10 @@ public class GenerateTestrayCSVUtil {
 
 	private static final String _CSV_DELIMITER = ",";
 
+	private static final List<String> _didNotRunErrorMessages = Arrays.asList(
+		"Aborted prior to running test", "Failed prior to running test",
+		"Failed for unknown reason");
+
 	private static class TestrayCaseResult {
 
 		public TestrayCaseResult(JSONObject resultJSONObject) {
@@ -277,9 +282,7 @@ public class GenerateTestrayCSVUtil {
 				return _type;
 			}
 
-			if (Objects.equals(
-					getErrorMessage(), "Failed prior to running test")) {
-
+			if (_didNotRunErrorMessages.contains(getErrorMessage())) {
 				_type = Type.DID_NOT_RUN;
 			}
 			else {


### PR DESCRIPTION
Tested here: https://test-1-1.liferay.com/job/generate-testray-csv/7425/

Change 1) If a category has no test failures, it appears as a double newline which confuses new users, I think its better so be explicit that a category has no test failures so they know that category exists
Change 2) Some test failures that contained tests that never ran were being categorized as common failures since their error message was different than expected