### PR TITLE
LRQA-84859 Move failure classification to a column to allow users to sort and filter results

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
@@ -36,7 +36,7 @@ public class GenerateTestrayCSVUtil {
 		sb.append(
 			JenkinsResultsParserUtil.join(
 				_CSV_DELIMITER, "Case Name", "Case History URL",
-				"Error Message"));
+				"Error Message", "Failure Type"));
 		sb.append("\n");
 
 		List<TestrayCaseResult> allTestrayCaseResults = _getTestrayCaseResults(
@@ -45,13 +45,9 @@ public class GenerateTestrayCSVUtil {
 		sb.append(
 			_generate(allTestrayCaseResults, TestrayCaseResult.Type.UNIQUE));
 
-		sb.append("\n");
-
 		sb.append(
 			_generate(
 				allTestrayCaseResults, TestrayCaseResult.Type.DID_NOT_RUN));
-
-		sb.append("\n");
 
 		sb.append(
 			_generate(allTestrayCaseResults, TestrayCaseResult.Type.COMMON));
@@ -82,11 +78,14 @@ public class GenerateTestrayCSVUtil {
 		}
 
 		if (sb.length() == 0) {
-			sb.append("NONE\n");
+			sb.append(
+				JenkinsResultsParserUtil.join(
+					_CSV_DELIMITER, "NONE", "N/A", "N/A",
+					testrayCaseResultType.toString()));
+			sb.append("\n");
 		}
 
-		return JenkinsResultsParserUtil.combine(
-			testrayCaseResultType.toString(), " Failures\n", sb.toString());
+		return sb.toString();
 	}
 
 	private static List<TestrayCaseResult> _getTestrayCaseResults(
@@ -169,7 +168,8 @@ public class GenerateTestrayCSVUtil {
 			return JenkinsResultsParserUtil.join(
 				_CSV_DELIMITER, _cleanCSVData(getTestrayCaseName()),
 				_cleanCSVData(getHistoryURL()),
-				_cleanCSVData(getErrorMessage()));
+				_cleanCSVData(getErrorMessage()),
+				_cleanCSVData(getType().toString()));
 		}
 
 		public String getErrorMessage() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateTestrayCSVUtil.java
@@ -169,7 +169,7 @@ public class GenerateTestrayCSVUtil {
 				_CSV_DELIMITER, _cleanCSVData(getTestrayCaseName()),
 				_cleanCSVData(getHistoryURL()),
 				_cleanCSVData(getErrorMessage()),
-				_cleanCSVData(getType().toString()));
+				_cleanCSVData(String.valueOf(getType())));
 		}
 
 		public String getErrorMessage() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRQA-84859
Some users requested the Failure type to be moved to a column so they can use their own sorting/filtering tools to help them see the results better. There is still pre-sorting done so this shouldn't affect the visibility of users who do not use external filtering methods.
Tested here: https://test-1-1.liferay.com/job/generate-testray-csv/7856/