### PR TITLE
LRCI-4145 Reduce memory profile of report generation

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -1,6 +1,3 @@
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
-
 dependencies {
 	api group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.262"
 	api group: "com.amazonaws", name: "aws-java-sdk-ec2", version: "1.12.262"

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
@@ -153,11 +153,6 @@ public class BuildHistory {
 
 			for (BuildJSONObject buildJSONObject : buildJSONObjects) {
 				long buildDuration = buildJSONObject.getDuration();
-
-				if (buildDuration < (5 * 60 * 1000)) {
-					continue;
-				}
-
 				long buildStartTime = buildJSONObject.getStartTime();
 				long queueDuration = buildJSONObject.getQueueDuration();
 
@@ -168,20 +163,38 @@ public class BuildHistory {
 
 				buildCountsForAverage[startIndex]++;
 
-				int endIndex =
-					startIndex + _getDurationIndexSize(buildDuration);
+				long relativeStartTime = buildStartTime - _startTime;
 
-				if (endIndex > (_size - 1)) {
-					endIndex = _size - 1;
+				long relativeEndTime = relativeStartTime + buildDuration;
+
+				long timelineSamplePeriodMillis = TimeUnit.MINUTES.toMillis(
+					TIMELINE_SAMPLE_PERIOD_MINUTES);
+
+				if ((relativeStartTime >
+						(startIndex * timelineSamplePeriodMillis)) &&
+					(relativeEndTime <
+						((startIndex + 1) * timelineSamplePeriodMillis))) {
+
+					continue;
 				}
 
-				for (int i = startIndex; i < endIndex; i++) {
-					_buildCounts[i]++;
+				if (relativeEndTime >
+						(startIndex * timelineSamplePeriodMillis)) {
 
-					if (buildHistory.containsTopLevelBuildURL(
-							buildJSONObject.getURL())) {
+					int endIndex = _getIndex(buildStartTime + buildDuration);
 
-						_topLevelBuildCounts[i]++;
+					if (startIndex < (_size - 1)) {
+						startIndex++;
+					}
+
+					for (int i = startIndex; i <= endIndex; i++) {
+						_buildCounts[i]++;
+
+						if (buildHistory.containsTopLevelBuildURL(
+								buildJSONObject.getURL())) {
+
+							_topLevelBuildCounts[i]++;
+						}
 					}
 				}
 			}
@@ -202,23 +215,6 @@ public class BuildHistory {
 				_averageQueueTime[i] =
 					totalQueueTime[i] / buildCountsForAverage[i];
 			}
-		}
-
-		private int _getDurationIndexSize(long duration) {
-			long durationIndexSize = getTimelineSize(duration);
-
-			long timelineSamplePeriodMillis = TimeUnit.MINUTES.toMillis(
-				TIMELINE_SAMPLE_PERIOD_MINUTES);
-
-			long roundingSize = timelineSamplePeriodMillis / 2;
-
-			long durationRemainder = duration % timelineSamplePeriodMillis;
-
-			if (durationRemainder >= roundingSize) {
-				durationIndexSize++;
-			}
-
-			return (int)durationIndexSize;
 		}
 
 		private int _getIndex(long timeMillis) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
@@ -31,19 +31,19 @@ public class BuildHistory {
 		_startTime = startTime;
 	}
 
-	public void addBuildDataJSONObject(BuildJSONObject buildJSONObject) {
-		_buildJSONObjects.add(buildJSONObject);
+	public void addBuildJSONObject(BuildJSONObject buildJSONObject) {
+		_addData(buildJSONObject);
 
-		if (buildJSONObject.isTopLevelBuild()) {
-			_topLevelBuildURLs.add(buildJSONObject.getURL());
-		}
+		Timeline timeline = _getTimeline();
+
+		timeline.addData(buildJSONObject);
 	}
 
-	public void addBuildDataJSONObjects(
+	public void addBuildJSONObjects(
 		Collection<BuildJSONObject> buildJSONObjects) {
 
 		for (BuildJSONObject buildJSONObject : buildJSONObjects) {
-			addBuildDataJSONObject(buildJSONObject);
+			addBuildJSONObject(buildJSONObject);
 		}
 	}
 
@@ -51,12 +51,38 @@ public class BuildHistory {
 		return _topLevelBuildURLs.contains(url);
 	}
 
-	public Set<BuildJSONObject> getBuildDataJSONObjects() {
-		return _buildJSONObjects;
+	public Map<String, Long> getDailyInvokedBuilds() {
+		return _dailyInvokedBuilds;
+	}
+
+	public Map<String, Long> getDailyInvokedTopLevelBuilds() {
+		return _dailyInvokedTopLevelBuilds;
+	}
+
+	public Map<String, Long> getDailyTotalBuildDurations() {
+		return _dailyTotalBuildDurations;
+	}
+
+	public Map<String, Long> getDailyTotalQueueTime() {
+		return _dailyTotalTopLevelQueueTime;
+	}
+
+	public Map<String, Long> getDailyTotalTopLevelBuildDurations() {
+		return _dailyTotalTopLevelBuildDurations;
 	}
 
 	public long getDuration() {
 		return _duration;
+	}
+
+	public long getInvokedBuildCount() {
+		long totalInvokedBuildCount = 0;
+
+		for (Long invokedBuildCount : _dailyInvokedBuilds.values()) {
+			totalInvokedBuildCount += invokedBuildCount;
+		}
+
+		return totalInvokedBuildCount;
 	}
 
 	public String getName() {
@@ -83,163 +109,56 @@ public class BuildHistory {
 		return _topLevelBuildURLs;
 	}
 
-	protected static class Timeline {
+	public void merge(BuildHistory buildHistory) {
+		_mergeMap(_dailyInvokedBuilds, buildHistory.getDailyInvokedBuilds());
+		_mergeMap(
+			_dailyTotalTopLevelQueueTime,
+			buildHistory.getDailyTotalQueueTime());
+		_mergeMap(
+			_dailyInvokedTopLevelBuilds,
+			buildHistory.getDailyInvokedTopLevelBuilds());
+		_mergeMap(
+			_dailyTotalTopLevelBuildDurations,
+			buildHistory.getDailyTotalTopLevelBuildDurations());
+		_mergeMap(
+			_dailyTotalBuildDurations,
+			buildHistory.getDailyTotalBuildDurations());
 
-		public static final long TIMELINE_SAMPLE_PERIOD_MINUTES = 15;
-
-		public static JSONArray getTimeJSONArray(
-			long duration, long startTime) {
-
-			int size = getTimelineSize(duration);
-
-			long[] timeMillis = new long[size];
-
-			for (int i = 0; i < timeMillis.length; i++) {
-				if (i == 0) {
-					timeMillis[i] = startTime;
-
-					continue;
-				}
-
-				timeMillis[i] = timeMillis[i - 1] + (duration / size);
-			}
-
-			return new JSONArray(timeMillis);
+		if (buildHistory.getDuration() > _duration) {
+			setDuration(buildHistory.getDuration());
 		}
 
-		public static int getTimelineSize(long duration) {
-			return (int)
-				(duration /
-					TimeUnit.MINUTES.toMillis(TIMELINE_SAMPLE_PERIOD_MINUTES));
+		if (buildHistory.getStartTime() < _startTime) {
+			setStartTime(buildHistory.getStartTime());
 		}
 
-		public JSONObject getJSONObject() {
-			JSONObject jsonObject = new JSONObject();
+		_topLevelBuildURLs.addAll(buildHistory.getTopLevelBuildURLs());
+	}
 
-			jsonObject.put(
-				"averageBuildTime", new JSONArray(_averageBuildTime)
-			).put(
-				"averageQueueTime", new JSONArray(_averageQueueTime)
-			).put(
-				"buildCounts", new JSONArray(_buildCounts)
-			).put(
-				"name", _name
-			).put(
-				"topLevelBuildCounts", new JSONArray(_topLevelBuildCounts)
-			);
+	public void setDuration(long duration) {
+		_duration = duration;
+	}
 
-			return jsonObject;
+	public void setStartTime(long startTime) {
+		_startTime = startTime;
+	}
+
+	protected static JSONArray getTimeJSONArray(long duration, long startTime) {
+		int size = _getTimelineSize(duration);
+
+		long[] timeMillis = new long[size];
+
+		for (int i = 0; i < timeMillis.length; i++) {
+			if (i == 0) {
+				timeMillis[i] = startTime;
+
+				continue;
+			}
+
+			timeMillis[i] = timeMillis[i - 1] + (duration / size);
 		}
 
-		protected Timeline(
-			BuildHistory buildHistory, long duration, long startTime) {
-
-			_duration = duration;
-			_startTime = startTime;
-
-			_size = getTimelineSize(duration);
-
-			_buildCounts = new long[_size];
-
-			_name = buildHistory.getName();
-			_topLevelBuildCounts = new long[_size];
-
-			Set<BuildJSONObject> buildJSONObjects =
-				buildHistory.getBuildDataJSONObjects();
-
-			long[] buildCountsForAverage = new long[_size];
-			long[] totalBuildTime = new long[_size];
-			long[] totalQueueTime = new long[_size];
-
-			for (BuildJSONObject buildJSONObject : buildJSONObjects) {
-				long buildDuration = buildJSONObject.getDuration();
-				long buildStartTime = buildJSONObject.getStartTime();
-				long queueDuration = buildJSONObject.getQueueDuration();
-
-				int startIndex = _getIndex(buildStartTime);
-
-				totalBuildTime[startIndex] += buildDuration;
-				totalQueueTime[startIndex] += queueDuration;
-
-				buildCountsForAverage[startIndex]++;
-
-				long relativeStartTime = buildStartTime - _startTime;
-
-				long relativeEndTime = relativeStartTime + buildDuration;
-
-				long timelineSamplePeriodMillis = TimeUnit.MINUTES.toMillis(
-					TIMELINE_SAMPLE_PERIOD_MINUTES);
-
-				if ((relativeStartTime >
-						(startIndex * timelineSamplePeriodMillis)) &&
-					(relativeEndTime <
-						((startIndex + 1) * timelineSamplePeriodMillis))) {
-
-					continue;
-				}
-
-				if (relativeEndTime >
-						(startIndex * timelineSamplePeriodMillis)) {
-
-					int endIndex = _getIndex(buildStartTime + buildDuration);
-
-					if (startIndex < (_size - 1)) {
-						startIndex++;
-					}
-
-					for (int i = startIndex; i <= endIndex; i++) {
-						_buildCounts[i]++;
-
-						if (buildHistory.containsTopLevelBuildURL(
-								buildJSONObject.getURL())) {
-
-							_topLevelBuildCounts[i]++;
-						}
-					}
-				}
-			}
-
-			_averageBuildTime = new long[_size];
-			_averageQueueTime = new long[_size];
-
-			for (int i = 0; i < _size; i++) {
-				if (buildCountsForAverage[i] == 0) {
-					_averageBuildTime[i] = 0;
-					_averageQueueTime[i] = 0;
-
-					continue;
-				}
-
-				_averageBuildTime[i] =
-					totalBuildTime[i] / buildCountsForAverage[i];
-				_averageQueueTime[i] =
-					totalQueueTime[i] / buildCountsForAverage[i];
-			}
-		}
-
-		private int _getIndex(long timeMillis) {
-			int index = (int)((timeMillis - _startTime) * _size / _duration);
-
-			if (index >= _size) {
-				return _size - 1;
-			}
-
-			if (index < 0) {
-				return 0;
-			}
-
-			return index;
-		}
-
-		private final long[] _averageBuildTime;
-		private final long[] _averageQueueTime;
-		private final long[] _buildCounts;
-		private final long _duration;
-		private final String _name;
-		private final int _size;
-		private final long _startTime;
-		private final long[] _topLevelBuildCounts;
-
+		return new JSONArray(timeMillis);
 	}
 
 	protected class Table {
@@ -255,93 +174,34 @@ public class BuildHistory {
 		}
 
 		protected Table(final String firstColumnHeader) {
-			Set<BuildJSONObject> buildJSONObjects = getBuildDataJSONObjects();
-
-			Map<String, List<BuildJSONObject>> groupedBuildDataJSONObjectsMap =
-				new TreeMap<>();
-
 			final String[] dateStrings =
 				JenkinsResultsParserUtil.getDateStrings(
 					getStartTime(), getDuration());
 
-			for (String dateString : dateStrings) {
-				groupedBuildDataJSONObjectsMap.put(
-					dateString, new ArrayList<BuildJSONObject>());
-			}
+			_averageTopLevelBuildDurations = new Long[dateStrings.length];
+			_averageTopLevelQueueDurations = new Long[dateStrings.length];
+			_invokedBuilds = new Long[dateStrings.length];
+			_invokedTopLevelBuilds = new Long[dateStrings.length];
+			_totalServerDurations = new Long[dateStrings.length];
 
-			for (BuildJSONObject buildJSONObject : buildJSONObjects) {
-				String startDateString = buildJSONObject.getStartDateString();
+			for (int i = 0; i < dateStrings.length; i++) {
+				String dateString = dateStrings[i];
 
-				if (!groupedBuildDataJSONObjectsMap.containsKey(
-						startDateString)) {
+				_invokedBuilds[i] = _getValue(_dailyInvokedBuilds, dateString);
 
-					continue;
-				}
+				_invokedTopLevelBuilds[i] = _getValue(
+					_dailyInvokedTopLevelBuilds, dateString);
 
-				List<BuildJSONObject> groupedBuildJSONObjects =
-					groupedBuildDataJSONObjectsMap.get(startDateString);
+				_totalServerDurations[i] = _getValue(
+					_dailyTotalBuildDurations, dateString);
 
-				groupedBuildJSONObjects.add(buildJSONObject);
-			}
+				_averageTopLevelBuildDurations[i] = _getQuotient(
+					_getValue(_dailyTotalTopLevelBuildDurations, dateString),
+					_getValue(_dailyInvokedTopLevelBuilds, dateString));
 
-			int size = groupedBuildDataJSONObjectsMap.size();
-
-			_averageTopLevelBuildDurations = new Long[size];
-			_averageTopLevelQueueDurations = new Long[size];
-			_invokedBuilds = new Long[size];
-			_invokedTopLevelBuilds = new Long[size];
-			_totalServerDurations = new Long[size];
-
-			int index = 0;
-
-			for (List<BuildJSONObject> groupedBuildJSONObjects :
-					groupedBuildDataJSONObjectsMap.values()) {
-
-				long buildsInvoked = 0;
-				long topLevelBuildsInvoked = 0;
-				long totalTopLevelBuildDuration = 0;
-				long totalDownstreamBuildDuration = 0;
-				long totalTopLevelQueueDuration = 0;
-
-				for (BuildJSONObject buildJSONObject :
-						groupedBuildJSONObjects) {
-
-					if (containsTopLevelBuildURL(buildJSONObject.getURL())) {
-						topLevelBuildsInvoked++;
-
-						totalTopLevelBuildDuration +=
-							buildJSONObject.getDuration();
-
-						totalTopLevelQueueDuration +=
-							buildJSONObject.getQueueDuration();
-					}
-					else {
-						buildsInvoked++;
-
-						totalDownstreamBuildDuration +=
-							buildJSONObject.getDuration();
-					}
-				}
-
-				_invokedBuilds[index] = buildsInvoked;
-				_invokedTopLevelBuilds[index] = topLevelBuildsInvoked;
-
-				if (topLevelBuildsInvoked != 0) {
-					_averageTopLevelBuildDurations[index] =
-						totalTopLevelBuildDuration / topLevelBuildsInvoked;
-
-					_averageTopLevelQueueDurations[index] =
-						totalTopLevelQueueDuration / topLevelBuildsInvoked;
-				}
-				else {
-					_averageTopLevelBuildDurations[index] = 0L;
-					_averageTopLevelQueueDurations[index] = 0L;
-				}
-
-				_totalServerDurations[index] =
-					totalTopLevelBuildDuration + totalDownstreamBuildDuration;
-
-				index++;
+				_averageTopLevelQueueDurations[i] = _getQuotient(
+					_getValue(_dailyTotalTopLevelQueueTime, dateString),
+					_getValue(_dailyInvokedTopLevelBuilds, dateString));
 			}
 
 			_rows.add(
@@ -399,6 +259,173 @@ public class BuildHistory {
 
 	}
 
+	protected class Timeline {
+
+		public void addData(BuildJSONObject buildJSONObject) {
+			long buildStartTime = buildJSONObject.getStartTime();
+
+			int startIndex = _getIndex(buildStartTime);
+
+			long buildDuration = buildJSONObject.getDuration();
+
+			_totalBuildTime[startIndex] += buildDuration;
+
+			long queueDuration = buildJSONObject.getQueueDuration();
+
+			_totalQueueTime[startIndex] += queueDuration;
+
+			_buildCountsForAverage[startIndex]++;
+
+			long relativeStartTime = buildStartTime - _startTime;
+
+			long relativeEndTime = relativeStartTime + buildDuration;
+
+			long timelineSamplePeriodMillis = TimeUnit.MINUTES.toMillis(
+				_TIMELINE_SAMPLE_PERIOD_MINUTES);
+
+			if ((relativeStartTime >
+					(startIndex * timelineSamplePeriodMillis)) &&
+				(relativeEndTime <
+					((startIndex + 1) * timelineSamplePeriodMillis))) {
+
+				return;
+			}
+
+			if (relativeEndTime > (startIndex * timelineSamplePeriodMillis)) {
+				int endIndex = _getIndex(buildStartTime + buildDuration);
+
+				if (startIndex < (_size - 1)) {
+					startIndex++;
+				}
+
+				for (int i = startIndex; i <= endIndex; i++) {
+					_buildCounts[i]++;
+
+					if (containsTopLevelBuildURL(buildJSONObject.getURL())) {
+						_topLevelBuildCounts[i]++;
+					}
+				}
+			}
+		}
+
+		public JSONObject getJSONObject() {
+			_calculateAverages();
+
+			JSONObject jsonObject = new JSONObject();
+
+			jsonObject.put(
+				"averageBuildTime", new JSONArray(_averageBuildTime)
+			).put(
+				"averageQueueTime", new JSONArray(_averageQueueTime)
+			).put(
+				"buildCounts", new JSONArray(_buildCounts)
+			).put(
+				"name", _name
+			).put(
+				"topLevelBuildCounts", new JSONArray(_topLevelBuildCounts)
+			);
+
+			return jsonObject;
+		}
+
+		protected Timeline() {
+			_size = _getTimelineSize(_duration);
+
+			_buildCounts = new long[_size];
+			_topLevelBuildCounts = new long[_size];
+			_buildCountsForAverage = new long[_size];
+			_totalBuildTime = new long[_size];
+			_totalQueueTime = new long[_size];
+			_averageBuildTime = new long[_size];
+			_averageQueueTime = new long[_size];
+		}
+
+		private void _calculateAverages() {
+			for (int i = 0; i < _size; i++) {
+				if (_buildCountsForAverage[i] == 0) {
+					_averageBuildTime[i] = 0;
+					_averageQueueTime[i] = 0;
+
+					continue;
+				}
+
+				_averageBuildTime[i] =
+					_totalBuildTime[i] / _buildCountsForAverage[i];
+				_averageQueueTime[i] =
+					_totalQueueTime[i] / _buildCountsForAverage[i];
+			}
+		}
+
+		private int _getIndex(long timeMillis) {
+			int index = (int)((timeMillis - _startTime) * _size / _duration);
+
+			if (index >= _size) {
+				return _size - 1;
+			}
+
+			if (index < 0) {
+				return 0;
+			}
+
+			return index;
+		}
+
+		private final long[] _averageBuildTime;
+		private final long[] _averageQueueTime;
+		private final long[] _buildCounts;
+		private final long[] _buildCountsForAverage;
+		private final int _size;
+		private final long[] _topLevelBuildCounts;
+		private final long[] _totalBuildTime;
+		private final long[] _totalQueueTime;
+
+	}
+
+	private static int _getTimelineSize(long duration) {
+		return (int)
+			(duration /
+				TimeUnit.MINUTES.toMillis(_TIMELINE_SAMPLE_PERIOD_MINUTES));
+	}
+
+	private void _addData(BuildJSONObject buildJSONObject) {
+		String dateString = buildJSONObject.getStartDateString();
+
+		_addData(_dailyInvokedBuilds, dateString, 1L);
+		_addData(
+			_dailyTotalBuildDurations, dateString,
+			buildJSONObject.getDuration());
+
+		if (buildJSONObject.isTopLevelBuild()) {
+			_topLevelBuildURLs.add(buildJSONObject.getURL());
+
+			_addData(
+				_dailyTotalTopLevelQueueTime, dateString,
+				buildJSONObject.getQueueDuration());
+			_addData(_dailyInvokedTopLevelBuilds, dateString, 1L);
+			_addData(
+				_dailyTotalTopLevelBuildDurations, dateString,
+				buildJSONObject.getDuration());
+		}
+	}
+
+	private void _addData(Map<String, Long> dataMap, String key, Long value) {
+		if (!dataMap.containsKey(key)) {
+			dataMap.put(key, value);
+
+			return;
+		}
+
+		dataMap.put(key, dataMap.get(key) + value);
+	}
+
+	private Long _getQuotient(Long value1, Long value2) {
+		if (value1 == 0L) {
+			return value1;
+		}
+
+		return value1 / value2;
+	}
+
 	private Table _getTable(String firstColumnHeader) {
 		if (_table == null) {
 			_table = new Table(firstColumnHeader);
@@ -409,16 +436,48 @@ public class BuildHistory {
 
 	private Timeline _getTimeline() {
 		if (_timeline == null) {
-			_timeline = new Timeline(this, getDuration(), getStartTime());
+			_timeline = new Timeline();
 		}
 
 		return _timeline;
 	}
 
-	private final Set<BuildJSONObject> _buildJSONObjects = new HashSet<>();
-	private final long _duration;
+	private Long _getValue(Map<String, Long> dailyValueMap, String dateString) {
+		if (dailyValueMap.containsKey(dateString)) {
+			return dailyValueMap.get(dateString);
+		}
+
+		return 0L;
+	}
+
+	private void _mergeMap(
+		Map<String, Long> dataMap1, Map<String, Long> dataMap2) {
+
+		for (Map.Entry<String, Long> entry : dataMap2.entrySet()) {
+			String key = entry.getKey();
+
+			Long currentValue = dataMap1.get(key);
+
+			dataMap1.put(
+				key,
+				(currentValue == null) ? entry.getValue() :
+					entry.getValue() + currentValue);
+		}
+	}
+
+	private static final long _TIMELINE_SAMPLE_PERIOD_MINUTES = 15;
+
+	private final Map<String, Long> _dailyInvokedBuilds = new TreeMap<>();
+	private final Map<String, Long> _dailyInvokedTopLevelBuilds =
+		new TreeMap<>();
+	private final Map<String, Long> _dailyTotalBuildDurations = new TreeMap<>();
+	private final Map<String, Long> _dailyTotalTopLevelBuildDurations =
+		new TreeMap<>();
+	private final Map<String, Long> _dailyTotalTopLevelQueueTime =
+		new TreeMap<>();
+	private long _duration;
 	private final String _name;
-	private final long _startTime;
+	private long _startTime;
 	private Table _table;
 	private Timeline _timeline;
 	private final Set<String> _topLevelBuildURLs = new HashSet<>();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
@@ -85,7 +85,7 @@ public class BuildHistory {
 
 	protected static class Timeline {
 
-		public static final long TIMELINE_SAMPLE_PERIOD_MINUTES = 10;
+		public static final long TIMELINE_SAMPLE_PERIOD_MINUTES = 15;
 
 		public static JSONArray getTimeJSONArray(
 			long duration, long startTime) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
@@ -268,14 +268,6 @@ public class BuildHistory {
 
 			long buildDuration = buildJSONObject.getDuration();
 
-			_totalBuildTime[startIndex] += buildDuration;
-
-			long queueDuration = buildJSONObject.getQueueDuration();
-
-			_totalQueueTime[startIndex] += queueDuration;
-
-			_buildCountsForAverage[startIndex]++;
-
 			long relativeStartTime = buildStartTime - _startTime;
 
 			long relativeEndTime = relativeStartTime + buildDuration;
@@ -284,9 +276,11 @@ public class BuildHistory {
 				_TIMELINE_SAMPLE_PERIOD_MINUTES);
 
 			if ((relativeStartTime >
+					((_size - 1) * timelineSamplePeriodMillis)) ||
+				((relativeStartTime >
 					(startIndex * timelineSamplePeriodMillis)) &&
-				(relativeEndTime <
-					((startIndex + 1) * timelineSamplePeriodMillis))) {
+				 (relativeEndTime <
+					 ((startIndex + 1) * timelineSamplePeriodMillis)))) {
 
 				return;
 			}
@@ -305,6 +299,14 @@ public class BuildHistory {
 						_topLevelBuildCounts[i]++;
 					}
 				}
+
+				_totalBuildTime[startIndex] += buildDuration;
+
+				long queueDuration = buildJSONObject.getQueueDuration();
+
+				_totalQueueTime[startIndex] += queueDuration;
+
+				_buildCountsForAverage[startIndex]++;
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistory.java
@@ -112,17 +112,17 @@ public class BuildHistory {
 	public void merge(BuildHistory buildHistory) {
 		_mergeMap(_dailyInvokedBuilds, buildHistory.getDailyInvokedBuilds());
 		_mergeMap(
-			_dailyTotalTopLevelQueueTime,
-			buildHistory.getDailyTotalQueueTime());
-		_mergeMap(
 			_dailyInvokedTopLevelBuilds,
 			buildHistory.getDailyInvokedTopLevelBuilds());
+		_mergeMap(
+			_dailyTotalBuildDurations,
+			buildHistory.getDailyTotalBuildDurations());
 		_mergeMap(
 			_dailyTotalTopLevelBuildDurations,
 			buildHistory.getDailyTotalTopLevelBuildDurations());
 		_mergeMap(
-			_dailyTotalBuildDurations,
-			buildHistory.getDailyTotalBuildDurations());
+			_dailyTotalTopLevelQueueTime,
+			buildHistory.getDailyTotalQueueTime());
 
 		if (buildHistory.getDuration() > _duration) {
 			setDuration(buildHistory.getDuration());
@@ -333,13 +333,13 @@ public class BuildHistory {
 		protected Timeline() {
 			_size = _getTimelineSize(_duration);
 
-			_buildCounts = new long[_size];
-			_topLevelBuildCounts = new long[_size];
-			_buildCountsForAverage = new long[_size];
-			_totalBuildTime = new long[_size];
-			_totalQueueTime = new long[_size];
 			_averageBuildTime = new long[_size];
 			_averageQueueTime = new long[_size];
+			_buildCounts = new long[_size];
+			_buildCountsForAverage = new long[_size];
+			_topLevelBuildCounts = new long[_size];
+			_totalBuildTime = new long[_size];
+			_totalQueueTime = new long[_size];
 		}
 
 		private void _calculateAverages() {
@@ -400,13 +400,13 @@ public class BuildHistory {
 		if (buildJSONObject.isTopLevelBuild()) {
 			_topLevelBuildURLs.add(buildJSONObject.getURL());
 
-			_addData(
-				_dailyTotalTopLevelQueueTime, dateString,
-				buildJSONObject.getQueueDuration());
 			_addData(_dailyInvokedTopLevelBuilds, dateString, 1L);
 			_addData(
 				_dailyTotalTopLevelBuildDurations, dateString,
 				buildJSONObject.getDuration());
+			_addData(
+				_dailyTotalTopLevelQueueTime, dateString,
+				buildJSONObject.getQueueDuration());
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -405,6 +405,12 @@ public class BuildHistoryProcessor {
 		implements Function<BuildJSONObject, String> {
 
 		public String apply(BuildJSONObject buildJSONObject) {
+			String jobName = buildJSONObject.getJobName();
+
+			if (jobName.contains("acceptance-upstream-dxp")) {
+				return "acceptance-dxp";
+			}
+
 			if (buildJSONObject.isTopLevelBuild()) {
 				Map<String, String> parameters =
 					buildJSONObject.getParameters();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,99 +47,147 @@ public class BuildHistoryProcessor {
 	public static Collection<BuildHistory> newAggregateJobHistories(
 		long duration, long startTime) {
 
-		Set<BuildJSONObject> buildJSONObjects =
-			_getFilteredBuildDataJSONObjects(duration, startTime);
+		BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>> biConsumer =
+			new BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>>() {
 
-		return _getGroupedBuildHistories(
-			buildJSONObjects, duration, new GroupByCategory(), startTime);
+				@Override
+				public void accept(
+					Set<BuildJSONObject> buildJSONObjects,
+					Map<String, BuildHistory> buildHistories) {
+
+					_addToBuildHistoriesMap(
+						buildJSONObjects, buildHistories, duration,
+						new GroupByCategory(), startTime);
+				}
+
+			};
+
+		return _getBuildHistories(duration, null, startTime, biConsumer);
 	}
 
 	public static Collection<BuildHistory> newDefaultJobHistories(
 		long duration, long startTime) {
 
-		Set<BuildJSONObject> buildJSONObjects =
-			_getFilteredBuildDataJSONObjects(duration, startTime);
+		BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>> biConsumer =
+			new BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>>() {
 
-		return _getGroupedBuildHistories(
-			buildJSONObjects, duration, new GroupByJobName(), startTime);
+				@Override
+				public void accept(
+					Set<BuildJSONObject> buildJSONObjects,
+					Map<String, BuildHistory> buildHistories) {
+
+					_addToBuildHistoriesMap(
+						buildJSONObjects, buildHistories, duration,
+						new GroupByJobName(), startTime);
+				}
+
+			};
+
+		return _getBuildHistories(duration, null, startTime, biConsumer);
 	}
 
 	public static Collection<BuildHistory> newTestSuiteJobHistories(
-		long duration, Function<BuildJSONObject, String> groupingFunction,
-		Pattern jobNamePattern, long startTime) {
+		long duration, Pattern jobNamePattern, long startTime) {
 
-		Set<BuildJSONObject> buildJSONObjects =
-			_getFilteredBuildDataJSONObjects(
-				duration, jobNamePattern, startTime);
+		BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>> biConsumer =
+			new BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>>() {
 
-		Set<BuildJSONObject> downstreamBuildJSONObjects = new HashSet<>();
-		Set<BuildJSONObject> topLevelBuildJSONObjects = new HashSet<>();
+				@Override
+				public void accept(
+					Set<BuildJSONObject> buildJSONObjects,
+					Map<String, BuildHistory> buildHistories) {
 
-		for (BuildJSONObject buildJSONObject : buildJSONObjects) {
-			if (buildJSONObject.isTopLevelBuild()) {
-				topLevelBuildJSONObjects.add(buildJSONObject);
-			}
-			else {
-				downstreamBuildJSONObjects.add(buildJSONObject);
-			}
-		}
+					Set<BuildJSONObject> downstreamBuildJSONObjects =
+						new HashSet<>();
+					Set<BuildJSONObject> topLevelBuildJSONObjects =
+						new HashSet<>();
 
-		if (groupingFunction == null) {
-			groupingFunction = new GroupByTopLevelTestSuite();
-		}
+					for (BuildJSONObject buildJSONObject : buildJSONObjects) {
+						if (buildJSONObject.isTopLevelBuild()) {
+							topLevelBuildJSONObjects.add(buildJSONObject);
+						}
+						else {
+							downstreamBuildJSONObjects.add(buildJSONObject);
+						}
+					}
 
-		Map<String, BuildHistory> groupedBuildHistoriesMap =
-			_getGroupedBuildHistoriesMap(
-				topLevelBuildJSONObjects, duration, groupingFunction,
-				startTime);
+					Function<BuildJSONObject, String> groupByTopLevelTestSuite =
+						new GroupByTopLevelTestSuite();
+
+					_addToBuildHistoriesMap(
+						topLevelBuildJSONObjects, buildHistories, duration,
+						groupByTopLevelTestSuite, startTime);
+
+					Map<String, Set<BuildJSONObject>>
+						groupedBuildDataJSONObjectsMap =
+							_getGroupedBuildDataJSONObjectsMap(
+								downstreamBuildJSONObjects,
+								groupByTopLevelTestSuite);
+
+					for (Map.Entry<String, Set<BuildJSONObject>> entry :
+							groupedBuildDataJSONObjectsMap.entrySet()) {
+
+						String key = entry.getKey();
+
+						if (!buildHistories.containsKey(key)) {
+							BuildHistory buildHistory = new BuildHistory(
+								duration, key, startTime);
+
+							buildHistories.put(key, buildHistory);
+						}
+
+						BuildHistory buildHistory = buildHistories.get(key);
+
+						buildHistory.addBuildJSONObjects(
+							groupedBuildDataJSONObjectsMap.get(key));
+					}
+				}
+
+			};
+
+		return _getBuildHistories(
+			duration, jobNamePattern, startTime, biConsumer);
+	}
+
+	private static void _addToBuildHistoriesMap(
+		Collection<BuildJSONObject> buildJSONObjects,
+		Map<String, BuildHistory> buildHistoriesMap, long duration,
+		Function<BuildJSONObject, String> groupingFunction, long startTime) {
 
 		Map<String, Set<BuildJSONObject>> groupedBuildDataJSONObjectsMap =
 			_getGroupedBuildDataJSONObjectsMap(
-				downstreamBuildJSONObjects, groupingFunction);
+				buildJSONObjects, groupingFunction);
 
 		for (Map.Entry<String, Set<BuildJSONObject>> entry :
 				groupedBuildDataJSONObjectsMap.entrySet()) {
 
-			String key = entry.getKey();
-
-			if (!groupedBuildHistoriesMap.containsKey(key)) {
+			if (!buildHistoriesMap.containsKey(entry.getKey())) {
 				BuildHistory buildHistory = new BuildHistory(
-					duration, key, startTime);
+					duration, entry.getKey(), startTime);
 
-				groupedBuildHistoriesMap.put(key, buildHistory);
+				buildHistoriesMap.put(entry.getKey(), buildHistory);
 			}
 
-			BuildHistory buildHistory = groupedBuildHistoriesMap.get(key);
+			BuildHistory buildHistory = buildHistoriesMap.get(entry.getKey());
 
-			buildHistory.addBuildJSONObjects(
-				groupedBuildDataJSONObjectsMap.get(key));
+			buildHistory.addBuildJSONObjects(entry.getValue());
 		}
-
-		return _getSortedBuildHistories(groupedBuildHistoriesMap.values());
 	}
 
-	private static Set<BuildJSONObject> _getFilteredBuildDataJSONObjects(
-		long duration, long startTime) {
+	private static Collection<BuildHistory> _getBuildHistories(
+		long duration, Pattern jobNamePattern, long startTime,
+		BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>>
+			buildHistoryBiConsumer) {
 
-		return _getFilteredBuildDataJSONObjects(duration, null, startTime);
-	}
-
-	private static Set<BuildJSONObject> _getFilteredBuildDataJSONObjects(
-		long duration, Pattern jobNamePattern, long startTime) {
-
-		Set<BuildJSONObject> buildJSONObjects = new HashSet<>();
+		Map<String, BuildHistory> buildHistoriesMap = new HashMap<>();
 
 		for (String dateString :
 				JenkinsResultsParserUtil.getDateStrings(startTime, duration)) {
 
-			if (!_buildDataJSONObjectsMap.containsKey(dateString)) {
-				System.out.println("Loading build JSONs for " + dateString);
-
-				_loadBuildJSONObjects(dateString);
-			}
+			Set<BuildJSONObject> buildJSONObjects = new HashSet<>();
 
 			for (BuildJSONObject buildJSONObject :
-					_buildDataJSONObjectsMap.get(dateString)) {
+					_getBuildJSONObjects(dateString)) {
 
 				if (jobNamePattern == null) {
 					buildJSONObjects.add(buildJSONObject);
@@ -152,6 +201,48 @@ public class BuildHistoryProcessor {
 				if (jobNameMatcher.matches()) {
 					buildJSONObjects.add(buildJSONObject);
 				}
+			}
+
+			buildHistoryBiConsumer.accept(buildJSONObjects, buildHistoriesMap);
+		}
+
+		return _getSortedBuildHistories(buildHistoriesMap.values());
+	}
+
+	private static List<BuildJSONObject> _getBuildJSONObjects(
+		String dateString) {
+
+		File dateDir = new File(_BASE_DIR, dateString);
+
+		if (dateDir.listFiles() == null) {
+			return Collections.emptyList();
+		}
+
+		List<BuildJSONObject> buildJSONObjects = new ArrayList<>();
+
+		System.out.println("Reading files from: " + dateDir.toPath());
+
+		for (File jsonFile : dateDir.listFiles()) {
+			try {
+				String jsonFileName = jsonFile.getCanonicalPath();
+
+				if (jsonFileName.contains("test-1-0") ||
+					jsonFileName.contains("test-1-41")) {
+
+					continue;
+				}
+
+				String content = JenkinsResultsParserUtil.read(jsonFile);
+
+				JSONArray jsonArray = new JSONArray(content.trim());
+
+				for (int i = 0; i < jsonArray.length(); i++) {
+					buildJSONObjects.add(
+						new BuildJSONObject(jsonArray.getJSONObject(i)));
+				}
+			}
+			catch (IOException ioException) {
+				System.out.println("Unable to read " + jsonFile);
 			}
 		}
 
@@ -183,41 +274,6 @@ public class BuildHistoryProcessor {
 		return groupedBuildDataJSONObjectsMap;
 	}
 
-	private static Collection<BuildHistory> _getGroupedBuildHistories(
-		Collection<BuildJSONObject> buildJSONObjects, long duration,
-		Function<BuildJSONObject, String> groupingFunction, long startTime) {
-
-		Map<String, BuildHistory> groupedBuildHistories =
-			_getGroupedBuildHistoriesMap(
-				buildJSONObjects, duration, groupingFunction, startTime);
-
-		return _getSortedBuildHistories(groupedBuildHistories.values());
-	}
-
-	private static Map<String, BuildHistory> _getGroupedBuildHistoriesMap(
-		Collection<BuildJSONObject> buildJSONObjects, long duration,
-		Function<BuildJSONObject, String> groupingFunction, long startTime) {
-
-		Map<String, BuildHistory> groupedBuildHistories = new HashMap<>();
-
-		Map<String, Set<BuildJSONObject>> groupedBuildDataJSONObjectsMap =
-			_getGroupedBuildDataJSONObjectsMap(
-				buildJSONObjects, groupingFunction);
-
-		for (Map.Entry<String, Set<BuildJSONObject>> entry :
-				groupedBuildDataJSONObjectsMap.entrySet()) {
-
-			BuildHistory buildHistory = new BuildHistory(
-				duration, entry.getKey(), startTime);
-
-			buildHistory.addBuildJSONObjects(entry.getValue());
-
-			groupedBuildHistories.put(entry.getKey(), buildHistory);
-		}
-
-		return groupedBuildHistories;
-	}
-
 	private static List<BuildHistory> _getSortedBuildHistories(
 		Collection<BuildHistory> buildHistories) {
 
@@ -244,47 +300,6 @@ public class BuildHistoryProcessor {
 		return buildHistoryList;
 	}
 
-	private static void _loadBuildJSONObjects(String dateString) {
-		File dateDir = new File(_BASE_DIR, dateString);
-
-		if (!dateDir.exists()) {
-			_buildDataJSONObjectsMap.put(
-				dateString, new ArrayList<BuildJSONObject>());
-		}
-
-		if (dateDir.listFiles() == null) {
-			return;
-		}
-
-		List<BuildJSONObject> buildJSONObjects = new ArrayList<>();
-
-		for (File jsonFile : dateDir.listFiles()) {
-			try {
-				String jsonFileName = jsonFile.getCanonicalPath();
-
-				if (jsonFileName.contains("test-1-0") ||
-					jsonFileName.contains("test-1-41")) {
-
-					continue;
-				}
-
-				String content = JenkinsResultsParserUtil.read(jsonFile);
-
-				JSONArray jsonArray = new JSONArray(content.trim());
-
-				for (int i = 0; i < jsonArray.length(); i++) {
-					buildJSONObjects.add(
-						new BuildJSONObject(jsonArray.getJSONObject(i)));
-				}
-			}
-			catch (IOException ioException) {
-				System.out.println("Unable to read " + jsonFile);
-			}
-		}
-
-		_buildDataJSONObjectsMap.put(dateString, buildJSONObjects);
-	}
-
 	private static BuildHistory _mergeBuildHistories(
 		List<BuildHistory> buildHistories, String name) {
 
@@ -300,9 +315,6 @@ public class BuildHistoryProcessor {
 
 	private static final File _BASE_DIR = new File(
 		"/opt/dev/projects/github/liferay-jenkins-ee/tmp/jenkins");
-
-	private static final Map<String, List<BuildJSONObject>>
-		_buildDataJSONObjectsMap = new HashMap<>();
 
 	private static class GroupByCategory
 		implements Function<BuildJSONObject, String> {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -110,7 +110,7 @@ public class BuildHistoryProcessor {
 
 			BuildHistory buildHistory = groupedBuildHistoriesMap.get(key);
 
-			buildHistory.addBuildDataJSONObjects(
+			buildHistory.addBuildJSONObjects(
 				groupedBuildDataJSONObjectsMap.get(key));
 		}
 
@@ -210,7 +210,7 @@ public class BuildHistoryProcessor {
 			BuildHistory buildHistory = new BuildHistory(
 				duration, entry.getKey(), startTime);
 
-			buildHistory.addBuildDataJSONObjects(entry.getValue());
+			buildHistory.addBuildJSONObjects(entry.getValue());
 
 			groupedBuildHistories.put(entry.getKey(), buildHistory);
 		}
@@ -231,15 +231,12 @@ public class BuildHistoryProcessor {
 				public int compare(
 					BuildHistory buildHistory1, BuildHistory buildHistory2) {
 
-					Set<BuildJSONObject> buildJSONObjects1 =
-						buildHistory1.getBuildDataJSONObjects();
-					Set<BuildJSONObject> buildJSONObjects2 =
-						buildHistory2.getBuildDataJSONObjects();
+					Integer buildCount1 =
+						(int)buildHistory1.getInvokedBuildCount();
+					Integer buildCount2 =
+						(int)buildHistory2.getInvokedBuildCount();
 
-					Integer size1 = buildJSONObjects1.size();
-					Integer size2 = buildJSONObjects2.size();
-
-					return size2.compareTo(size1);
+					return buildCount2.compareTo(buildCount1);
 				}
 
 			});
@@ -291,29 +288,14 @@ public class BuildHistoryProcessor {
 	private static BuildHistory _mergeBuildHistories(
 		List<BuildHistory> buildHistories, String name) {
 
-		Set<BuildJSONObject> buildJSONObjects = new HashSet<>();
-		long duration = 0;
-		long startTime = System.currentTimeMillis();
-		Set<String> topLevelBuildURLs = new HashSet<>();
+		BuildHistory mergedBuildHistory = new BuildHistory(
+			0, name, System.currentTimeMillis());
 
 		for (BuildHistory buildHistory : buildHistories) {
-			if (buildHistory.getDuration() > duration) {
-				duration = buildHistory.getDuration();
-			}
-
-			if (buildHistory.getStartTime() < startTime) {
-				startTime = buildHistory.getStartTime();
-			}
-
-			buildJSONObjects.addAll(buildHistory.getBuildDataJSONObjects());
-			topLevelBuildURLs.addAll(buildHistory.getTopLevelBuildURLs());
+			mergedBuildHistory.merge(buildHistory);
 		}
 
-		BuildHistory buildHistory = new BuildHistory(duration, name, startTime);
-
-		buildHistory.addBuildDataJSONObjects(buildJSONObjects);
-
-		return buildHistory;
+		return mergedBuildHistory;
 	}
 
 	private static final File _BASE_DIR = new File(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser.metrics;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.ParallelExecutor;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +21,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -209,41 +213,71 @@ public class BuildHistoryProcessor {
 		return _getSortedBuildHistories(buildHistoriesMap.values());
 	}
 
-	private static List<BuildJSONObject> _getBuildJSONObjects(
+	private static Set<BuildJSONObject> _getBuildJSONObjects(
 		String dateString) {
 
 		File dateDir = new File(_BASE_DIR, dateString);
 
 		if (dateDir.listFiles() == null) {
-			return Collections.emptyList();
+			return Collections.emptySet();
 		}
 
-		List<BuildJSONObject> buildJSONObjects = new ArrayList<>();
+		Set<BuildJSONObject> buildJSONObjects = Collections.synchronizedSet(
+			new HashSet<BuildJSONObject>());
 
 		System.out.println("Reading files from: " + dateDir.toPath());
 
-		for (File jsonFile : dateDir.listFiles()) {
-			try {
-				String jsonFileName = jsonFile.getCanonicalPath();
+		List<Callable<Void>> callables = new ArrayList<>();
 
-				if (jsonFileName.contains("test-1-0") ||
-					jsonFileName.contains("test-1-41")) {
+		for (final File jsonFile : dateDir.listFiles()) {
+			callables.add(
+				new Callable<Void>() {
 
-					continue;
-				}
+					@Override
+					public Void call() throws Exception {
+						try {
+							String jsonFileName = jsonFile.getCanonicalPath();
 
-				String content = JenkinsResultsParserUtil.read(jsonFile);
+							if (jsonFileName.contains("test-1-0") ||
+								jsonFileName.contains("test-1-41")) {
 
-				JSONArray jsonArray = new JSONArray(content.trim());
+								return null;
+							}
 
-				for (int i = 0; i < jsonArray.length(); i++) {
-					buildJSONObjects.add(
-						new BuildJSONObject(jsonArray.getJSONObject(i)));
-				}
-			}
-			catch (IOException ioException) {
-				System.out.println("Unable to read " + jsonFile);
-			}
+							String content = JenkinsResultsParserUtil.read(
+								jsonFile);
+
+							JSONArray jsonArray = new JSONArray(content.trim());
+
+							Set<BuildJSONObject> newBuildJSONObjects =
+								new HashSet<>();
+
+							for (int i = 0; i < jsonArray.length(); i++) {
+								newBuildJSONObjects.add(
+									new BuildJSONObject(
+										jsonArray.getJSONObject(i)));
+							}
+
+							buildJSONObjects.addAll(newBuildJSONObjects);
+						}
+						catch (IOException ioException) {
+							System.out.println("Unable to read " + jsonFile);
+						}
+
+						return null;
+					}
+
+				});
+		}
+
+		ParallelExecutor<Void> parallelExecutor = new ParallelExecutor<>(
+			callables, _executorService, "_getBuildJSONObjects");
+
+		try {
+			parallelExecutor.execute();
+		}
+		catch (TimeoutException timeoutException) {
+			throw new RuntimeException(timeoutException);
 		}
 
 		return buildJSONObjects;
@@ -315,6 +349,11 @@ public class BuildHistoryProcessor {
 
 	private static final File _BASE_DIR = new File(
 		"/opt/dev/projects/github/liferay-jenkins-ee/tmp/jenkins");
+
+	private static final Integer _THREAD_COUNT = 8;
+
+	private static final ExecutorService _executorService =
+		JenkinsResultsParserUtil.getNewThreadPoolExecutor(_THREAD_COUNT, true);
 
 	private static class GroupByCategory
 		implements Function<BuildJSONObject, String> {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -344,14 +344,11 @@ public class BuildHistoryProcessor {
 				return Category.PORTAL_MASTER_UPSTREAM.toString();
 			}
 
-			if (jobName.equals("test-portal-release")) {
-				return Category.PORTAL_RELEASE.toString();
-			}
-
 			if (jobName.equals("test-portal-fixpack-release") ||
-				jobName.equals("test-portal-hotfix-release")) {
+				jobName.equals("test-portal-hotfix-release") ||
+				jobName.equals("test-portal-release")) {
 
-				return Category.PORTAL_OTHER_RELEASE.toString();
+				return Category.PORTAL_RELEASE.toString();
 			}
 
 			if (jobName.contains("test-portal-")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
@@ -77,8 +77,7 @@ public class BuildHistoryReport {
 		long durationDays, File outputDir, String startDateString) {
 
 		return _newTestSuiteReport(
-			durationDays, new GroupByTopLevelTestSuiteAndUpstreamJob(),
-			_portalMasterUpstreamJobNamePattern, outputDir,
+			durationDays, _portalMasterUpstreamJobNamePattern, outputDir,
 			"liferay-portal/master Upstream History Report", startDateString);
 	}
 
@@ -189,9 +188,8 @@ public class BuildHistoryReport {
 	}
 
 	private static BuildHistoryReport _newTestSuiteReport(
-		long durationDays, Function<BuildJSONObject, String> groupingFunction,
-		Pattern jobNamePattern, File outputDir, String reportName,
-		String startDateString) {
+		long durationDays, Pattern jobNamePattern, File outputDir,
+		String reportName, String startDateString) {
 
 		BuildHistoryReport buildHistoryReport = new BuildHistoryReport(
 			outputDir);
@@ -203,8 +201,7 @@ public class BuildHistoryReport {
 
 		Collection<BuildHistory> buildHistories =
 			BuildHistoryProcessor.newTestSuiteJobHistories(
-				duration, groupingFunction, jobNamePattern,
-				_getStartTime(startDateString));
+				duration, jobNamePattern, _getStartTime(startDateString));
 
 		StringBuilder sb = new StringBuilder();
 
@@ -220,15 +217,6 @@ public class BuildHistoryReport {
 		buildHistoryReport.addFile("js/table-data.js", sb.toString());
 
 		return buildHistoryReport;
-	}
-
-	private static BuildHistoryReport _newTestSuiteReport(
-		long durationDays, Pattern jobNamePattern, File outputDir,
-		String reportName, String startDateString) {
-
-		return _newTestSuiteReport(
-			durationDays, null, jobNamePattern, outputDir, reportName,
-			startDateString);
 	}
 
 	private static final Pattern _portalMasterPullRequestJobNamePattern =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
@@ -231,44 +230,5 @@ public class BuildHistoryReport {
 
 	private final Map<File, String> _fileMap = new HashMap<>();
 	private final File _outputDir;
-
-	private static class GroupByTopLevelTestSuiteAndUpstreamJob
-		implements Function<BuildJSONObject, String> {
-
-		public String apply(BuildJSONObject buildJSONObject) {
-			String jobName = buildJSONObject.getJobName();
-
-			if (jobName.contains("acceptance-upstream-dxp")) {
-				return "acceptance-dxp";
-			}
-
-			if (buildJSONObject.isTopLevelBuild()) {
-				Map<String, String> parameters =
-					buildJSONObject.getParameters();
-
-				if (parameters.containsKey("CI_TEST_SUITE")) {
-					_topLevelBuildTestSuiteMap.put(
-						buildJSONObject.getURL(),
-						parameters.get("CI_TEST_SUITE"));
-
-					return parameters.get("CI_TEST_SUITE");
-				}
-
-				return "[Unknown]";
-			}
-
-			String topLevelBuildURL = buildJSONObject.getTopLevelBuildURL();
-
-			if (_topLevelBuildTestSuiteMap.containsKey(topLevelBuildURL)) {
-				return _topLevelBuildTestSuiteMap.get(topLevelBuildURL);
-			}
-
-			return "[Unknown]";
-		}
-
-		private final Map<String, String> _topLevelBuildTestSuiteMap =
-			new HashMap<>();
-
-	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
@@ -182,7 +182,7 @@ public class BuildHistoryReport {
 		jsonObject.put(
 			"jobTimelines", jsonArray
 		).put(
-			"time", BuildHistory.Timeline.getTimeJSONArray(duration, startTime)
+			"time", BuildHistory.getTimeJSONArray(duration, startTime)
 		);
 
 		return "var timelineData = " + jsonObject.toString();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildJSONObject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildJSONObject.java
@@ -73,6 +73,12 @@ public class BuildJSONObject extends JSONObject {
 	}
 
 	public long getStartTime() {
+		String jobName = getJobName();
+
+		if (jobName.equals("maintenance-daily")) {
+			return optLong("startTime") + optLong("queueDuration");
+		}
+
 		return optLong("startTime");
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html
@@ -19,31 +19,25 @@
 						<p>
 							<strong>liferay-portal/master PR&apos;s:</strong>
 
-							<em>This accounts for all CI builds (all test suites) related to the liferay-portal/master pull request jobs.</em>
+							<em>This accounts for all CI builds (all test suites) related to the liferay-portal/master pull request jobs. For detailed information, please see the <a href="https://test-1-0.liferay.com/userContent/reports/pull-request-report/index.html">Pull Request History Report</a>.</em>
 						</p>
 
 						<p>
 							<strong>liferay-portal/master Upstream:</strong>
 
-							<em>This accounts for all CI builds related to liferay-portal/master upstream jobs. This includes acceptance upstream, test suite upstream jobs.</em>
+							<em>This accounts for all CI builds related to liferay-portal/master upstream jobs. This includes acceptance upstream and test suite upstream jobs. For detailed information, please see the <a href="https://test-1-0.liferay.com/userContent/reports/upstream-report/index.html">Upstream History Report</a>.</em></em>
+						</p>
+
+						<p>
+							<strong>Portal Release:</strong>
+
+							<em>This accounts for all CI builds related to fixpack, hotfix and release jobs. This ncludes master and legacy branches. For detailed information, please see the <a href="https://test-1-0.liferay.com/userContent/reports/release-report/index.html">Release History Report</a>.</em>
 						</p>
 
 						<p>
 							<strong>liferay-portal-ee PR&apos;s &amp; Upstream:</strong>
 
 							<em>This accounts for all CI builds for pull request and upstream jobs related to non master branches.</em>
-						</p>
-
-						<p>
-							<strong>Portal Release:</strong>
-
-							<em>This accounts for all CI builds related to the release job. Includes master and legacy branches.</em>
-						</p>
-
-						<p>
-							<strong>Portal Fixpack &amp; Hotfix Release:</strong>
-
-							<em>This accounts for all CI builds for fixpack and hotfix jobs across all portal branches.</em>
 						</p>
 
 						<p>

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html
@@ -106,7 +106,7 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-adapter-moment/1.0.1/chartjs-adapter-moment.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js"></script>
 
-		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@cbdaa1da84693a1850cfdf792d92fadbdc4f01d5/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@376e74cbb314e622fc3703b29c2015b610de13c0/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
 
 		<script src="js/table-data.js"></script>
 		<script src="js/timeline-data.js"></script>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRCI-4145

@pyoo47, I used a bit of functional programming (BiConsumer) for the reports because it made more sense to me to isolate the logic in this way, as I'm also trying to avoid adding too many objects for report generation. This requires removing our module's Java 1.7 restriction. I tested this change against the ee-6.2.x PR tester and no issues occured