### PR TITLE
LRCI-5148 Add ability for mirrors-get to take in GCP URLs

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Enumeration;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipFile;
@@ -111,13 +112,9 @@ public class MirrorsGetTask extends Task {
 			return;
 		}
 
-		if (_src.startsWith("gs:")) {
-			matcher = _gsURLPattern.matcher(_src);
+		matcher = _gsURLPattern.matcher(_src);
 
-			if (!matcher.find()) {
-				throw new RuntimeException("Invalid src attribute: " + _src);
-			}
-
+		if (matcher.matches()) {
 			_fileName = matcher.group("fileName");
 
 			_gcpBucketName = matcher.group("bucketName");
@@ -125,28 +122,29 @@ public class MirrorsGetTask extends Task {
 			Map<String, Object> properties = project.getProperties();
 
 			for (String propertyName : properties.keySet()) {
-				Matcher gcpBucketPropertyNameMatcher =
-					_gcpBucketPropertyNamePattern.matcher(propertyName);
+				Matcher bucketHostNamePropertyMatcher =
+					_bucketHostNamePropertyPattern.matcher(propertyName);
 
-				if (!gcpBucketPropertyNameMatcher.matches()) {
+				if (!bucketHostNamePropertyMatcher.matches()) {
 					continue;
 				}
 
-				_hostName = gcpBucketPropertyNameMatcher.group("hostName");
+				if (!Objects.equals(
+						_gcpBucketName,
+						bucketHostNamePropertyMatcher.group("bucketName"))) {
+
+					continue;
+				}
+
+				_hostName = project.getProperty(propertyName);
 
 				break;
 			}
 
 			if (_hostName == null) {
 				throw new RuntimeException(
-					"Please set mirrors.gcp.bucket.name[__hostname__]");
-			}
-
-			_gcpCredentialsFile = _getGCPCredentialsFile();
-
-			if (_gcpCredentialsFile == null) {
-				throw new RuntimeException(
-					"Please set mirrors.gcp.credentials.file[__hostname__]");
+					"Please set 'mirrors.gcp.bucket.hostname[" +
+						_gcpBucketName + "]'.");
 			}
 
 			_path = matcher.group("path");
@@ -331,10 +329,25 @@ public class MirrorsGetTask extends Task {
 	}
 
 	private void _downloadGCPFile(File targetFile) {
-		File gcpCredentialsFile = _getGCPCredentialsFile();
 		String gsURL = _getGSURL();
 
-		if ((gcpCredentialsFile == null) || (gsURL == null)) {
+		if (gsURL == null) {
+			return;
+		}
+
+		File gcpCredentialsFile = _getGCPCredentialsFile();
+
+		if (gcpCredentialsFile == null) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("Unable to download from ");
+			sb.append(gsURL);
+			sb.append(" unless 'mirrors.gcp.credentials.file[");
+			sb.append(_getGCPBucketName());
+			sb.append("]' is set.");
+
+			System.out.println(sb.toString());
+
 			return;
 		}
 
@@ -522,10 +535,30 @@ public class MirrorsGetTask extends Task {
 			return _gcpBucketName;
 		}
 
-		Project project = getProject();
+		if (_hostName == null) {
+			return null;
+		}
 
-		_gcpBucketName = project.getProperty(
-			"mirrors.gcp.bucket.name[" + _hostName + "]");
+		Map<String, Object> properties = project.getProperties();
+
+		for (String propertyName : properties.keySet()) {
+			Matcher bucketHostNamePropertyMatcher =
+				_bucketHostNamePropertyPattern.matcher(propertyName);
+
+			if (!bucketHostNamePropertyMatcher.matches()) {
+				continue;
+			}
+
+			if (!Objects.equals(
+					_hostName, project.getProperty(propertyName))) {
+
+				continue;
+			}
+
+			_gcpBucketName = bucketHostNamePropertyMatcher.group("bucketName");
+
+			break;
+		}
 
 		return _gcpBucketName;
 	}
@@ -535,10 +568,16 @@ public class MirrorsGetTask extends Task {
 			return _gcpCredentialsFile;
 		}
 
+		String gcpBucketName = _getGCPBucketName();
+
+		if (gcpBucketName == null) {
+			return null;
+		}
+
 		Project project = getProject();
 
 		String gcpCredentialsFilePath = project.getProperty(
-			"mirrors.gcp.credentials.file[" + _hostName + "]");
+			"mirrors.gcp.credentials.file[" + gcpBucketName + "]");
 
 		if (gcpCredentialsFilePath == null) {
 			return null;
@@ -1065,8 +1104,9 @@ public class MirrorsGetTask extends Task {
 
 	private static final Pattern _basicAuthenticationURLPattern =
 		Pattern.compile("(https?://)([^:]+):([^@]+)@(.+)");
-	private static final Pattern _gcpBucketPropertyNamePattern =
-		Pattern.compile("mirrors.gcp.bucket.name\\[(?<hostName>[^\\]]+)\\]");
+	private static final Pattern _bucketHostNamePropertyPattern =
+		Pattern.compile(
+			"mirrors.gcp.bucket.hostname\\[(?<bucketName>[^\\]]+)\\]");
 	private static final Pattern _gsURLPattern = Pattern.compile(
 		"gs://(?<bucketName>[^/]+)/(?<path>.+/)(?<fileName>.+)");
 	private static final Pattern _httpURLPattern = Pattern.compile(

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 
 import java.util.Base64;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipFile;
@@ -110,7 +111,54 @@ public class MirrorsGetTask extends Task {
 			return;
 		}
 
-		matcher = _srcPattern.matcher(_src);
+		if (_src.startsWith("gs:")) {
+			matcher = _gsURLPattern.matcher(_src);
+
+			if (!matcher.find()) {
+				throw new RuntimeException("Invalid src attribute: " + _src);
+			}
+
+			_fileName = matcher.group("fileName");
+
+			_gcpBucketName = matcher.group("bucketName");
+
+			Map<String, Object> properties = project.getProperties();
+
+			for (String propertyName : properties.keySet()) {
+				Matcher gcpBucketPropertyNameMatcher =
+					_gcpBucketPropertyNamePattern.matcher(propertyName);
+
+				if (!gcpBucketPropertyNameMatcher.matches()) {
+					continue;
+				}
+
+				_hostName = gcpBucketPropertyNameMatcher.group("hostName");
+
+				break;
+			}
+
+			if (_hostName == null) {
+				throw new RuntimeException(
+					"Please set mirrors.gcp.bucket.name[__hostname__]");
+			}
+
+			_gcpCredentialsFile = _getGCPCredentialsFile();
+
+			if (_gcpCredentialsFile == null) {
+				throw new RuntimeException(
+					"Please set mirrors.gcp.credentials.file[__hostname__]");
+			}
+
+			_path = matcher.group("path");
+
+			while (_path.endsWith("/")) {
+				_path = _path.substring(0, _path.length() - 1);
+			}
+
+			return;
+		}
+
+		matcher = _httpURLPattern.matcher(_src);
 
 		if (!matcher.find()) {
 			throw new RuntimeException("Invalid src attribute: " + _src);
@@ -1017,13 +1065,17 @@ public class MirrorsGetTask extends Task {
 
 	private static final Pattern _basicAuthenticationURLPattern =
 		Pattern.compile("(https?://)([^:]+):([^@]+)@(.+)");
+	private static final Pattern _gcpBucketPropertyNamePattern =
+		Pattern.compile("mirrors.gcp.bucket.name\\[(?<hostName>[^\\]]+)\\]");
+	private static final Pattern _gsURLPattern = Pattern.compile(
+		"gs://(?<bucketName>[^/]+)/(?<path>.+/)(?<fileName>.+)");
+	private static final Pattern _httpURLPattern = Pattern.compile(
+		"https?://(?<mirrorsHostname>mirrors(\\.[^\\.]+\\.liferay.com)?/)?" +
+			"(?<hostName>[^/]+(/\\d+)?)/(?<path>.+/)(?<fileName>.+)");
 	private static final Pattern _mirrorsHostNamePattern = Pattern.compile(
 		"^mirrors\\.[^\\.]+\\.liferay.com/");
 	private static final Pattern _releaseHostNamePattern = Pattern.compile(
 		"(release-\\d+|release.liferay.com)/(?<id>\\d+)");
-	private static final Pattern _srcPattern = Pattern.compile(
-		"https?://(?<mirrorsHostname>mirrors(\\.[^\\.]+\\.liferay.com)?/)?" +
-			"(?<hostName>[^/]+(/\\d+)?)/(?<path>.+/)(?<fileName>.+)");
 	private static final Pattern _testHostNamePattern = Pattern.compile(
 		"test-\\d+-\\d+");
 

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -282,6 +282,54 @@ public class MirrorsGetTask extends Task {
 		_downloadFile(sourceURL, targetFile);
 	}
 
+	private void _downloadGCPFile(File targetFile) {
+		File gcpCredentialsFile = _getGCPCredentialsFile();
+		String gsURL = _getGSURL();
+
+		if ((gcpCredentialsFile == null) || (gsURL == null)) {
+			return;
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("Downloading ");
+		sb.append(gsURL);
+		sb.append(" to ");
+		sb.append(targetFile.getPath());
+		sb.append(".");
+
+		System.out.println(sb.toString());
+
+		try {
+			Process process = _executeCommands(
+				new String[] {
+					"gcloud", "auth", "activate-service-account", "--key-file",
+					gcpCredentialsFile.toString()
+				});
+
+			if (process.exitValue() != 0) {
+				System.out.println(
+					"WARNING: Failed to activated service account.");
+
+				return;
+			}
+
+			process = _executeCommands(
+				new String[] {
+					"gcloud", "storage", "cp", gsURL, targetFile.toString()
+				});
+
+			if (process.exitValue() != 0) {
+				System.out.println(
+					"WARNING: Failed to download file from " + gsURL + ".");
+			}
+		}
+		catch (Exception exception) {
+			System.out.println(
+				"WARNING: Failed to run GCP commands to download file.");
+		}
+	}
+
 	private void _execute() throws IOException {
 		if (_src.startsWith("file:")) {
 			File srcFile = new File(_src.substring("file:".length()));
@@ -331,6 +379,21 @@ public class MirrorsGetTask extends Task {
 		}
 
 		if (!mirrorsCacheFile.exists()) {
+			_downloadGCPFile(mirrorsCacheTempFile);
+
+			if (mirrorsCacheTempFile.exists()) {
+				_moveFile(mirrorsCacheTempFile, mirrorsCacheFile);
+
+				if (_dest.exists() && _dest.isDirectory()) {
+					_copyFile(mirrorsCacheFile, new File(_dest, _fileName));
+				}
+				else {
+					_copyFile(mirrorsCacheFile, _dest);
+				}
+
+				return;
+			}
+
 			String mirrorsHostname = _getMirrorsHostname();
 
 			if (_tryLocalNetwork && !mirrorsHostname.isEmpty()) {
@@ -404,6 +467,54 @@ public class MirrorsGetTask extends Task {
 		process.waitFor();
 
 		return process;
+	}
+
+	private String _getGCPBucketName() {
+		if (_gcpBucketName != null) {
+			return _gcpBucketName;
+		}
+
+		Project project = getProject();
+
+		_gcpBucketName = project.getProperty(
+			"mirrors.gcp.bucket.name[" + _hostName + "]");
+
+		return _gcpBucketName;
+	}
+
+	private File _getGCPCredentialsFile() {
+		if (_gcpCredentialsFile != null) {
+			return _gcpCredentialsFile;
+		}
+
+		Project project = getProject();
+
+		String gcpCredentialsFilePath = project.getProperty(
+			"mirrors.gcp.credentials.file[" + _hostName + "]");
+
+		if (gcpCredentialsFilePath == null) {
+			return null;
+		}
+
+		File gcpCredentialsFile = new File(gcpCredentialsFilePath);
+
+		if (!gcpCredentialsFile.exists()) {
+			return null;
+		}
+
+		_gcpCredentialsFile = gcpCredentialsFile;
+
+		return _gcpCredentialsFile;
+	}
+
+	private String _getGSURL() {
+		String gcpBucketName = _getGCPBucketName();
+
+		if (gcpBucketName == null) {
+			return null;
+		}
+
+		return "gs://" + gcpBucketName + "/" + _path + "/" + _fileName;
 	}
 
 	private URL _getLocalURL() {
@@ -919,6 +1030,8 @@ public class MirrorsGetTask extends Task {
 	private File _dest;
 	private String _fileName;
 	private boolean _force;
+	private String _gcpBucketName;
+	private File _gcpCredentialsFile;
 	private String _hostName;
 	private boolean _ignoreErrors;
 	private String _mirrorsHostname;

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -125,11 +125,8 @@ public class MirrorsGetTask extends Task {
 				Matcher bucketHostNamePropertyMatcher =
 					_bucketHostNamePropertyPattern.matcher(propertyName);
 
-				if (!bucketHostNamePropertyMatcher.matches()) {
-					continue;
-				}
-
-				if (!Objects.equals(
+				if (!bucketHostNamePropertyMatcher.matches() ||
+					!Objects.equals(
 						_gcpBucketName,
 						bucketHostNamePropertyMatcher.group("bucketName"))) {
 
@@ -545,12 +542,8 @@ public class MirrorsGetTask extends Task {
 			Matcher bucketHostNamePropertyMatcher =
 				_bucketHostNamePropertyPattern.matcher(propertyName);
 
-			if (!bucketHostNamePropertyMatcher.matches()) {
-				continue;
-			}
-
-			if (!Objects.equals(
-					_hostName, project.getProperty(propertyName))) {
+			if (!bucketHostNamePropertyMatcher.matches() ||
+				!Objects.equals(_hostName, project.getProperty(propertyName))) {
 
 				continue;
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-5148

@pyoo47 - In order to get this to work, the `build.[hostname].properties` will need the following set:
```
mirrors.gcp.bucket.hostname[files_liferay_com]=files.liferay.com
mirrors.gcp.credentials.file[files_liferay_com]=/root/.gcloud/ci-jenkins.json
```

This will allow the following usages of `mirrors-get` to work:
```
<mirrors-get
	src="gs://files_liferay_com/private/ee/fix-packs/patching-tool/LATEST-2.0.txt"
	dest="LATEST-2.0.txt"
/>

<mirrors-get
	src="http://mirrors.lax.liferay.com/files.liferay.com/private/ee/fix-packs/patching-tool/LATEST-2.0.txt"
	dest="LATEST-2.0.txt"
/>

<mirrors-get
	src="http://mirrors/files.liferay.com/private/ee/fix-packs/patching-tool/LATEST-3.0.txt"
	dest="LATEST-3.0.txt"
/>

<mirrors-get
	src="https://files.liferay.com/private/ee/fix-packs/patching-tool/LATEST-4.0.txt"
	dest="LATEST-4.0.txt"
/>
```

Please let me know if you have any questions.  Thanks!