### PR TITLE
LPD-45746 Increase numbers to improve the CPU usage on CI.

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1317,7 +1317,7 @@
     test.batch.axis.max.size[modules-integration-project-templates-jdk17_zulu]=5
     test.batch.axis.max.size[modules-integration-project-templates-jdk21_zulu]=5
     test.batch.axis.max.size[modules-integration-*]=20
-    test.batch.axis.max.size[modules-semantic-versioning]=30
+    test.batch.axis.max.size[modules-semantic-versioning]=200
     test.batch.axis.max.size[modules-unit*]=100
     test.batch.axis.max.size[modules-unit-project-templates]=25
     test.batch.axis.max.size[modules-unit-project-templates-jdk17_zulu]=15
@@ -3033,7 +3033,7 @@
 
     test.batch.target.axis.duration[functional-*]=2400000
     test.batch.target.axis.duration[modules-integration-*]=2400000
-    test.batch.target.axis.duration[modules-unit]=2400000
+    test.batch.target.axis.duration[modules-unit]=4800000
     test.batch.target.axis.duration[playwright-*]=1800000
 
     test.hotfix.changes[test-portal-hotfix-release]=true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-45746

Taking numbers from CI reports those are the results:

**modules-semantic-versioning**
* from 6 jobs to 1
* from 151 minutes to 41 minutes

**modules-unit**
* from 20 jobs to 8
* from 586 minutes to 289 minutes

This means we are saving almost 7 hours of CPU for each acceptance execution, also it improves all routines.

@pyoo47 - These changes look good to me especially if we are prioritizing throughput over speed.  I also looked through `ci:test:stable` & this change should not affect the speed of those suites.  So this should only affect release, upstream, & pr jobs.  Let me know if you have any questions about it.