### PR TITLE
LRCI-3068 Add ability to set a performance modifier that will increase or decrease projected durations

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -3685,6 +3685,14 @@ public class JenkinsResultsParserUtil {
 		return _ciNode;
 	}
 
+	public static boolean isDouble(String string) {
+		if ((string != null) && string.matches("\\d*\\.?\\d+")) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public static boolean isFileExcluded(
 		List<PathMatcher> excludesPathMatchers, File file) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -748,18 +748,33 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 			return 0;
 		}
 
-		JobProperty jobProperty = getJobProperty(
+		JobProperty targetAxisDurationJobProperty = getJobProperty(
 			"test.batch.target.axis.duration");
 
-		String jobPropertyValue = jobProperty.getValue();
+		String targetAxisDurationString =
+			targetAxisDurationJobProperty.getValue();
 
-		if ((jobPropertyValue == null) || !jobPropertyValue.matches("\\d+")) {
+		if (!JenkinsResultsParserUtil.isInteger(targetAxisDurationString)) {
 			return 0;
 		}
 
-		recordJobProperty(jobProperty);
+		recordJobProperty(targetAxisDurationJobProperty);
 
-		return Long.parseLong(jobPropertyValue);
+		long targetAxisDuration = Long.parseLong(targetAxisDurationString);
+
+		JobProperty performanceModifierJobProperty = getJobProperty(
+			"test.batch.performance.modifier");
+
+		String performanceModifier = performanceModifierJobProperty.getValue();
+
+		if (JenkinsResultsParserUtil.isDouble(performanceModifier)) {
+			targetAxisDuration = Math.round(
+				targetAxisDuration * Double.parseDouble(performanceModifier));
+
+			recordJobProperty(performanceModifierJobProperty);
+		}
+
+		return targetAxisDuration;
 	}
 
 	protected String getTestSuiteName() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PlaywrightBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PlaywrightBatchTestClassGroup.java
@@ -173,27 +173,39 @@ public class PlaywrightBatchTestClassGroup extends BatchTestClassGroup {
 			totalDuration += testClass.getAverageDuration();
 		}
 
-		if (totalDuration != 0L) {
-			JobProperty jobProperty = getJobProperty(
-				"test.batch.target.axis.duration");
-
-			String jobPropertyValue = jobProperty.getValue();
-
-			if (JenkinsResultsParserUtil.isInteger(jobPropertyValue)) {
-				recordJobProperty(jobProperty);
-
-				long testBatchTargetAxisDuration = Long.parseLong(
-					jobPropertyValue);
-
-				long axisCount =
-					Math.floorDiv(totalDuration, testBatchTargetAxisDuration) +
-						1;
-
-				return Math.toIntExact(axisCount);
-			}
+		if (totalDuration == 0L) {
+			return getAxisCount();
 		}
 
-		return getAxisCount();
+		JobProperty targetAxisDurationJobProperty = getJobProperty(
+			"test.batch.target.axis.duration");
+
+		String targetAxisDurationString =
+			targetAxisDurationJobProperty.getValue();
+
+		if (!JenkinsResultsParserUtil.isInteger(targetAxisDurationString)) {
+			return getAxisCount();
+		}
+
+		recordJobProperty(targetAxisDurationJobProperty);
+
+		long targetAxisDuration = Long.parseLong(targetAxisDurationString);
+
+		JobProperty performanceModifierJobProperty = getJobProperty(
+			"test.batch.performance.modifier");
+
+		String performanceModifier = performanceModifierJobProperty.getValue();
+
+		if (JenkinsResultsParserUtil.isDouble(performanceModifier)) {
+			targetAxisDuration = Math.round(
+				targetAxisDuration * Double.parseDouble(performanceModifier));
+
+			recordJobProperty(performanceModifierJobProperty);
+		}
+
+		long axisCount = Math.floorDiv(totalDuration, targetAxisDuration) + 1;
+
+		return Math.toIntExact(axisCount);
 	}
 
 	protected File getPlaywrightBaseDir() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3068

Hey @pyoo47,

What this change will give us is the ability to change the target duration for different axis builds.

For example, currently within `liferay-portal` in the branch `master` we are aiming for `modules-unit` to run at around `80 minutes` because of this property:

```
test.batch.target.axis.duration[modules-unit]=4800000
```

We can add a performance multiplier to this value using this property:

```
test.batch.performance.modifier[modules-unit]=1.5
```

What will result is the target duration would be around `120 minutes` instead because it'll simply multiply this value by `1.5`.

This switch can be configured for any suite, job, or batch.  And we can override this property from `liferay-jenkins-ee/commands/build.proeperties` as well.

Please let me know if you have any questions.  Thanks!