### PR TITLE
LRCI-3069 Add property to ignore target axis duration

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -739,6 +739,10 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 	}
 
 	protected long getTargetAxisDuration() {
+		if (ignoreTargetAxisDuration()) {
+			return 0;
+		}
+
 		GitWorkingDirectory gitWorkingDirectory =
 			getPortalGitWorkingDirectory();
 
@@ -791,6 +795,21 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		}
 
 		return false;
+	}
+
+	protected boolean ignoreTargetAxisDuration() {
+		JobProperty jobProperty = getJobProperty(
+			"test.batch.ignore.target.axis.duration");
+
+		String jobPropertyValue = jobProperty.getValue();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(jobPropertyValue)) {
+			return false;
+		}
+
+		recordJobProperty(jobProperty);
+
+		return Boolean.valueOf(jobPropertyValue);
 	}
 
 	protected boolean isRootCauseAnalysis() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-3069

@pyoo47 - How this will work is we can set this property in `liferay-jenkins-ee`:
```
test.batch.ignore.target.axis.duration=true
```

And then along with that we can set this property to determine how many batches we want:
```
test.batch.axis.count[modules-unit]=5
```

This will for `modules-unit` for example to all run in only 5 nodes.