### PR TITLE
LRCI-5526 Transition mysql57 batches to postgresql155 for acceptance-dxp

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -5207,6 +5207,10 @@ information. Make sure to commit in all format-javadoc results.
 		<run-functional-test app.server.type="tomcat" browser.type="chrome" database.type="postgresql" database.version="15.5" test.portal.log.assert="true" />
 	</target>
 
+	<target name="functional-smoke-tomcat90-postgresql155-jdk17_zulu">
+		<run-functional-test app.server.type="tomcat" browser.type="chrome" database.type="postgresql" database.version="15.5" test.portal.log.assert="true" />
+	</target>
+
 	<target name="functional-smoke-tomcat90-postgresql155_stable">
 		<run-functional-test app.server.type="tomcat" database.type="postgresql" database.version="15.5" test.portal.log.assert="true" />
 	</target>

--- a/test.properties
+++ b/test.properties
@@ -3098,6 +3098,7 @@
         functional-tomcat90-mariadb102,\
         functional-tomcat90-mariadb104,\
         functional-tomcat90-mariadb106,\
+        functional-tomcat90-mysql57-chrome100,\
         functional-tomcat90-postgresql134,\
         functional-tomcat90-postgresql144,\
         functional-tomcat90-postgresql153,\

--- a/test.properties
+++ b/test.properties
@@ -3079,40 +3079,40 @@
     test.batch.dist.app.servers[acceptance-ce]=${test.batch.dist.app.servers}
 
     test.batch.names[acceptance-ce]=\
-        archived-module-smoke-mysql57,\
-        archived-modules-test-mysql57,\
+        archived-module-smoke-postgresql155,\
+        archived-modules-test-postgresql155,\
         build-lib-versions,\
-        bundle-blacklist-restart-mysql57,\
+        bundle-blacklist-restart-postgresql155,\
         compile-jsp,\
-        empty-osgi-core-dir-mysql57,\
+        empty-osgi-core-dir-postgresql155,\
         #format-javadoc-test,\
         #functional-tomcat-mysql57,\
-        functional-smoke-jboss74-mysql57,\
+        functional-smoke-jboss74-postgresql155,\
         functional-smoke-tomcat90-mariadb102,\
-        functional-smoke-tomcat90-mysql57-jdk17_zulu,\
         functional-smoke-tomcat90-mysql80,\
+        functional-smoke-tomcat90-postgresql155-jdk17_zulu,\
         functional-smoke-tomcat90-postgresql163,\
-        functional-smoke-weblogic141-mysql57,\
+        functional-smoke-weblogic141-postgresql155,\
         functional-smoke-wildfly261-mariadb106,\
         functional-tomcat90-hypersonic20,\
         functional-tomcat90-mariadb102,\
         functional-tomcat90-mariadb104,\
         functional-tomcat90-mariadb106,\
-        functional-tomcat90-mysql57-chrome100,\
         functional-tomcat90-postgresql134,\
         functional-tomcat90-postgresql144,\
         functional-tomcat90-postgresql153,\
+        functional-tomcat90-postgresql155-chrome100,\
         functional-tomcat90-postgresql163,\
-        functional-upgrade-tomcat90-mysql57,\
-        gogo-shell-client-mysql57,\
+        functional-upgrade-tomcat90-postgresql155,\
+        gogo-shell-client-postgresql155,\
         javadoc-test,\
         js-unit,\
-        jsp-runtime-compile-mysql57,\
-        lpkg-container-mysql57,\
-        lpkg-controller-mysql57,\
-        lpkg-override-mysql57,\
-        lpkg-persistence-mysql57,\
-        lpkg-startup-mysql57,\
+        jsp-runtime-compile-postgresql155,\
+        lpkg-container-postgresql155,\
+        lpkg-controller-postgresql155,\
+        lpkg-override-postgresql155,\
+        lpkg-persistence-postgresql155,\
+        lpkg-startup-postgresql155,\
         modules-functional,\
         modules-integration-mysql57,\
         modules-integration-postgresql155,\
@@ -3120,17 +3120,17 @@
         modules-semantic-versioning,\
         modules-unit,\
         modules-unit-project-templates,\
-        patching-tool-mysql57,\
+        patching-tool-postgresql155,\
         playwright-js-tomcat90-mysql57,\
         playwright-js-tomcat90-postgresql155,\
         #portal-frontend-js-lint,\
-        portal-renamed-tomcat-in-path-mysql57,\
-        portal-second-startup-space-in-path-mysql57,\
-        portal-startup-space-in-path-mysql57,\
+        portal-renamed-tomcat-in-path-postgresql155,\
+        portal-second-startup-space-in-path-postgresql155,\
+        portal-startup-space-in-path-postgresql155,\
         poshi-validation,\
-        release-osgi-state-exploded-test-mysql57,\
-        release-osgi-state-lpkg-change-directory-test-mysql57,\
-        release-osgi-state-lpkg-test-mysql57,\
+        release-osgi-state-exploded-test-postgresql155,\
+        release-osgi-state-lpkg-change-directory-test-postgresql155,\
+        release-osgi-state-lpkg-test-postgresql155,\
         ruby-sass-compiler,\
         semantic-versioning,\
         source-format,\
@@ -3162,7 +3162,7 @@
         functional-tomcat90-db2111,\
         functional-tomcat90-oracle193,\
         functional-tomcat90-sqlserver2017,\
-        portal-license-smoke-mysql57
+        portal-license-smoke-postgresql155
 
     #
     # Analytics Cloud Acceptance


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-5526

For safer transition, we have decided to keep the main batches for both mysql and postgresql
`functional-tomcat90-mysql57-chrome100,\
functional-tomcat90-postgresql155-chrome100,\
modules-integration-mysql57,\
modules-integration-postgresql155,\
playwright-js-tomcat90-mysql57,\
playwright-js-tomcat90-postgresql155,\`
Once teams transition over to postgresql, we can remove the mysql57 batches from acceptance-dxp.

cc: @brianwulbern