### PR TITLE
LRCI-5597 Fail the batch when necessary

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -6850,7 +6850,7 @@ information. Make sure to commit in all format-javadoc results.
 	<target name="js-unit">
 		<run-batch-test>
 			<test-action>
-				<property name="failure.count" value="0" />
+				<property name="js.unit.failure.count" value="0" />
 
 				<for delimiter=" " list="${modules.test.class.group}" param="modules.test.class" trim="true">
 					<sequential>
@@ -6866,10 +6866,10 @@ information. Make sure to commit in all format-javadoc results.
 								<echo>${gradle.failure}</echo>
 
 								<math
-									operand1="${failure.count}"
+									operand1="${js.unit.failure.count}"
 									operand2="1"
 									operation="+"
-									result="failure.count"
+									result="js.unit.failure.count"
 								/>
 							</catch>
 						</trycatch>
@@ -6892,10 +6892,10 @@ information. Make sure to commit in all format-javadoc results.
 
 				<if>
 					<not>
-						<equals arg1="${failure.count}" arg2="0" />
+						<equals arg1="${js.unit.failure.count}" arg2="0" />
 					</not>
 					<then>
-						<fail message="${failure.count} JS unit tests have failed." />
+						<fail message="${js.unit.failure.count} JS unit tests have failed." />
 					</then>
 				</if>
 			</test-action>

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -6850,6 +6850,8 @@ information. Make sure to commit in all format-javadoc results.
 	<target name="js-unit">
 		<run-batch-test>
 			<test-action>
+				<property name="failure.count" value="0" />
+
 				<for delimiter=" " list="${modules.test.class.group}" param="modules.test.class" trim="true">
 					<sequential>
 						<echo>Executing Gradle tasks: @{modules.test.class}.</echo>
@@ -6862,6 +6864,13 @@ information. Make sure to commit in all format-javadoc results.
 							</try>
 							<catch>
 								<echo>${gradle.failure}</echo>
+
+								<math
+									operand1="${failure.count}"
+									operand2="1"
+									operation="+"
+									result="failure.count"
+								/>
 							</catch>
 						</trycatch>
 					</sequential>
@@ -6880,6 +6889,15 @@ information. Make sure to commit in all format-javadoc results.
 						<replacevalue><![CDATA[]]></replacevalue>
 					</replacefilter>
 				</replace>
+
+				<if>
+					<not>
+						<equals arg1="${failure.count}" arg2="0" />
+					</not>
+					<then>
+						<fail message="${failure.count} JS unit tests have failed." />
+					</then>
+				</if>
 			</test-action>
 
 			<test-set-up>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-5597

Hi Brian, I tried to use local as you requested, but that did not work because the for loop's sequential block creates a new scope and doesn't properly pass the failure count outside the scope.