### PR TITLE
LRCI-6965 Automatically close PR's that contain merge conflicts

### DIFF
--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -13,19 +13,19 @@ jobs:
 
                     function main {
                         local authorized_owner
-                        local is_authorized_user=false
+                        local authorized=false
 
                         for authorized_owner in ${AUTHORIZED_OWNERS}
                         do
                             if [[ "${authorized_owner}" == "${{ github.repository_owner }}" ]]
                             then
-                                is_authorized_user=true
+                                authorized=true
 
                                 break
                             fi
                         done
 
-                        if [[ "${is_authorized_user}" == "false" ]]
+                        if [[ "${authorized}" == "false" ]]
                         then
                             echo "${{ github.repository_owner }} is not authorized."
 

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,13 +1,12 @@
 env:
-    AUTHORIZED_OWNERS: brianchandotcom
-
+    AUTHORIZED_OWNERS: brianchandotcom  
 jobs:
     close-merge-conflicts:
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: >
             contains(env.AUTHORIZED_OWNERS, github.repository_owner) &&
             github.repository_owner == github.event.pull_request.base.repo.owner.login
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -84,6 +84,5 @@ jobs:
 
                     main
 on:
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize, reopened]
-    workflow_dispatch:

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,7 +1,7 @@
 jobs:
     close-merge-conflicts:
         env:
-            AUTHORIZED_OWNERS: "brianchandotcom"
+            AUTHORIZED_OWNERS: brianchandotcom
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         permissions:
             issues: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,89 +1,94 @@
 jobs:
     close-merge-conflicts:
         env:
-            AUTHORIZED_OWNERS_LIST: pyoo47
+            AUTHORIZED_OWNERS_LIST: ${{ vars.AUTHORIZED_OWNERS }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         permissions:
             issues: write
             pull-requests: write
         runs-on: ubuntu-latest
         steps:
-            -   run: |
-                    set -e
+            - run: |
+                set -e
 
-                    CURRENT_REPOSITORY_OWNER="${{ github.repository_owner }}"
-                    REPOSITORY_NAME="${{ github.event.repository.name }}"
+                function main {
+                    local authorizedOwnersList="${AUTHORIZED_OWNERS_LIST}"
+                    local currentRepositoryOwner="${{ github.repository_owner }}"
+                    local githubToken="${GITHUB_TOKEN}"
+                    local isAuthorizedUser=false
+                    local repositoryName="${{ github.event.repository.name }}"
 
-                    IS_AUTHORIZED_USER=false
-
-                    for OWNER_ENTRY in ${AUTHORIZED_OWNERS_LIST}
+                    for ownerEntry in ${authorizedOwnersList}
                     do
-                      if [[ "${OWNER_ENTRY}" == "${CURRENT_REPOSITORY_OWNER}" ]]
-                      then
-                        IS_AUTHORIZED_USER=true
+                        if [[ "${ownerEntry}" == "${currentRepositoryOwner}" ]]
+                        then
+                            isAuthorizedUser=true
 
-                        break
-                      fi
+                            break
+                        fi
                     done
 
-                    if [[ "${IS_AUTHORIZED_USER}" == "false" ]]
+                    if [[ "${isAuthorizedUser}" == "false" ]]
                     then
-                      echo "Execution skipped: ${CURRENT_REPOSITORY_OWNER} is not authorized."
+                        echo "Execution skipped: ${currentRepositoryOwner} is not authorized."
 
-                      exit 0
+                        exit 0
                     fi
 
-                    echo "Checking open pull requests in ${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}..."
+                    echo "Checking open pull requests in ${currentRepositoryOwner}/${repositoryName}..."
 
-                    PR_LIST=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                      "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls?state=open" \
-                      | jq -r '.[] | "\(.number)\t\(.html_url)"')
+                    local prList=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                        "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls?state=open" \
+                        | jq -r '.[] | "\(.number)\t\(.html_url)"')
 
-                    echo "${PR_LIST}" | while IFS=$'\t' read -r PULL_REQUEST_NUMBER PULL_REQUEST_URL
+                    echo "${prList}" | while IFS=$'\t' read -r pullRequestNumber pullRequestUrl
                     do
-                      if [[ -z "${PULL_REQUEST_NUMBER}" ]]
-                      then
-                        continue
-                      fi
+                        if [[ -z "${pullRequestNumber}" ]]
+                        then
+                            continue
+                        fi
 
-                      MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                        "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
-                        | jq -r '.mergeable_state')
+                        local mergeableState=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                            "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
+                            | jq -r '.mergeable_state')
 
-                      MAX_RETRIES=6
-                      RETRY_COUNT=0
+                        local maxRetries=6
+                        local retryCount=0
 
-                      while [["${MERGEABLE_STATE}" == "unknown" || "${MERGEABLE_STATE}" == "null"]] &&
-                            [[${RETRY_COUNT} -lt ${MAX_RETRIES}]]
-                      do
-                        echo "Pull request ${PULL_REQUEST_URL} state is unknown."
-                        echo "Waiting 5s (Attempt $((RETRY_COUNT + 1)) of ${MAX_RETRIES})..."
+                        while [[ "${mergeableState}" == "unknown" || "${mergeableState}" == "null" ]] &&
+                              [[ ${retryCount} -lt ${maxRetries} ]]
+                        do
+                            echo "Pull request ${pullRequestUrl} state is unknown."
+                            echo "Waiting 5s (Attempt $((retryCount + 1)) of ${maxRetries})..."
 
-                        sleep 5
+                            sleep 5
 
-                        MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                          "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
-                          | jq -r '.mergeable_state')
+                            mergeableState=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                                "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
+                                | jq -r '.mergeable_state')
 
-                        RETRY_COUNT=$(expr ${RETRY_COUNT} + 1)
-                      done
+                            retryCount=$(expr ${retryCount} + 1)
+                        done
 
-                      if [[ "${MERGEABLE_STATE}" == "dirty" ]]
-                      then
-                        echo "[ACTION] Closing pull request: ${PULL_REQUEST_URL} due to conflicts."
+                        if [[ "${mergeableState}" == "dirty" ]]
+                        then
+                            echo "[ACTION] Closing pull request: ${pullRequestUrl} due to conflicts."
 
-                        curl -s -X POST -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                          -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
-                          "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${PULL_REQUEST_NUMBER}/comments"
+                            curl -s -X POST -H "Authorization: Bearer ${githubToken}" \
+                                -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
+                                "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/issues/${pullRequestNumber}/comments"
 
-                        curl -s -X PATCH -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                          -d '{"state": "closed"}' \
-                          "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}"
-                      else
-                        echo "[SKIP] Pull request: ${PULL_REQUEST_URL} is currently: ${MERGEABLE_STATE}"
-                      fi
+                            curl -s -X PATCH -H "Authorization: Bearer ${githubToken}" \
+                                -d '{"state": "closed"}' \
+                                "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls/${pullRequestNumber}"
+                        else
+                            echo "[SKIP] Pull request: ${pullRequestUrl} is currently: ${mergeableState}"
+                        fi
                     done
+                }
+
+                main
 on:
     schedule:
-        -   cron: "*/15 * * * *"
+        - cron: '*/15 * * * *'
     workflow_dispatch:

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -38,9 +38,15 @@ jobs:
 
                     echo "Checking open pull requests in ${currentOwner}/${repositoryName}..."
 
-                    local prList=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                        "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls?state=open" \
-                        | jq -r '.[] | "\(.number)\t\(.html_url)"')
+                    local prJson=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                        "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls?state=open")
+
+                    local prList=$( \
+                        echo "${prJson}" | \
+                        jq \
+                            --raw-output \
+                            ".[]
+                            | \"\(.number)\t\(.html_url)\"")
 
                     echo "${prList}" | while IFS=$'\t' read -r pullRequestNumber pullRequestUrl
                     do
@@ -49,9 +55,14 @@ jobs:
                             continue
                         fi
 
-                        local mergeableState=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
-                            | jq -r '.mergeable_state')
+                        local prDetailsJson=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}")
+
+                        local mergeableState=$( \
+                            echo "${prDetailsJson}" | \
+                            jq \
+                                --raw-output \
+                                ".mergeable_state")
 
                         local maxRetries=6
                         local retryCount=0
@@ -64,9 +75,14 @@ jobs:
 
                             sleep 5
 
-                            mergeableState=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
-                                | jq -r '.mergeable_state')
+                            prDetailsJson=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}")
+
+                            mergeableState=$( \
+                                echo "${prDetailsJson}" | \
+                                jq \
+                                    --raw-output \
+                                    ".mergeable_state")
 
                             retryCount=$(expr ${retryCount} + 1)
                         done

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,89 +1,89 @@
 jobs:
-  close-merge-conflicts:
-    env:
-      AUTHORIZED_OWNERS_LIST: "pyoo47"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      issues: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          set -e
-          
-          CURRENT_REPOSITORY_OWNER="${{ github.repository_owner }}"
-          REPOSITORY_NAME="${{ github.event.repository.name }}"
-          
-          IS_AUTHORIZED_USER=false
+    close-merge-conflicts:
+        env:
+            AUTHORIZED_OWNERS_LIST: pyoo47
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+            issues: write
+            pull-requests: write
+        runs-on: ubuntu-latest
+        steps:
+            -   run: |
+                    set -e
 
-          for OWNER_ENTRY in ${AUTHORIZED_OWNERS_LIST}
-          do
-            if [[ "${OWNER_ENTRY}" == "${CURRENT_REPOSITORY_OWNER}" ]]
-            then
-              IS_AUTHORIZED_USER=true
+                    CURRENT_REPOSITORY_OWNER="${{ github.repository_owner }}"
+                    REPOSITORY_NAME="${{ github.event.repository.name }}"
 
-              break
-            fi
-          done
+                    IS_AUTHORIZED_USER=false
 
-          if [[ "${IS_AUTHORIZED_USER}" == "false" ]]
-          then
-            echo "Execution skipped: ${CURRENT_REPOSITORY_OWNER} is not authorized."
+                    for OWNER_ENTRY in ${AUTHORIZED_OWNERS_LIST}
+                    do
+                      if [[ "${OWNER_ENTRY}" == "${CURRENT_REPOSITORY_OWNER}" ]]
+                      then
+                        IS_AUTHORIZED_USER=true
 
-            exit 0
-          fi
+                        break
+                      fi
+                    done
 
-          echo "Checking open pull requests in ${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}..."
+                    if [[ "${IS_AUTHORIZED_USER}" == "false" ]]
+                    then
+                      echo "Execution skipped: ${CURRENT_REPOSITORY_OWNER} is not authorized."
 
-          PR_LIST=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls?state=open" \
-            | jq -r '.[] | "\(.number)\t\(.html_url)"')
+                      exit 0
+                    fi
 
-          echo "${PR_LIST}" | while IFS=$'\t' read -r PULL_REQUEST_NUMBER PULL_REQUEST_URL
-          do
-            if [[ -z "${PULL_REQUEST_NUMBER}" ]]
-            then
-              continue
-            fi
+                    echo "Checking open pull requests in ${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}..."
 
-            MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
-              | jq -r '.mergeable_state')
+                    PR_LIST=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                      "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls?state=open" \
+                      | jq -r '.[] | "\(.number)\t\(.html_url)"')
 
-            MAX_RETRIES=6
-            RETRY_COUNT=0
-            
-            while [[ "${MERGEABLE_STATE}" == "unknown" || "${MERGEABLE_STATE}" == "null" ]] &&
-                  [[ ${RETRY_COUNT} -lt ${MAX_RETRIES} ]]
-            do
-              echo "Pull request ${PULL_REQUEST_URL} state is unknown."
-              echo "Waiting 5s (Attempt $((RETRY_COUNT + 1)) of ${MAX_RETRIES})..."
-              
-              sleep 5
-              
-              MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
-                | jq -r '.mergeable_state')
-                
-              RETRY_COUNT=$(expr ${RETRY_COUNT} + 1)
-            done
+                    echo "${PR_LIST}" | while IFS=$'\t' read -r PULL_REQUEST_NUMBER PULL_REQUEST_URL
+                    do
+                      if [[ -z "${PULL_REQUEST_NUMBER}" ]]
+                      then
+                        continue
+                      fi
 
-            if [[ "${MERGEABLE_STATE}" == "dirty" ]]
-            then
-              echo "[ACTION] Closing pull request: ${PULL_REQUEST_URL} due to conflicts."
-              
-              curl -s -X POST -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
-                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${PULL_REQUEST_NUMBER}/comments"
+                      MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                        "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
+                        | jq -r '.mergeable_state')
 
-              curl -s -X PATCH -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                -d '{"state": "closed"}' \
-                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}"
-            else
-              echo "[SKIP] Pull request: ${PULL_REQUEST_URL} is currently: ${MERGEABLE_STATE}"
-            fi
-          done
+                      MAX_RETRIES=6
+                      RETRY_COUNT=0
+
+                      while [["${MERGEABLE_STATE}" == "unknown" || "${MERGEABLE_STATE}" == "null"]] &&
+                            [[${RETRY_COUNT} -lt ${MAX_RETRIES}]]
+                      do
+                        echo "Pull request ${PULL_REQUEST_URL} state is unknown."
+                        echo "Waiting 5s (Attempt $((RETRY_COUNT + 1)) of ${MAX_RETRIES})..."
+
+                        sleep 5
+
+                        MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                          "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
+                          | jq -r '.mergeable_state')
+
+                        RETRY_COUNT=$(expr ${RETRY_COUNT} + 1)
+                      done
+
+                      if [[ "${MERGEABLE_STATE}" == "dirty" ]]
+                      then
+                        echo "[ACTION] Closing pull request: ${PULL_REQUEST_URL} due to conflicts."
+
+                        curl -s -X POST -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                          -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
+                          "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${PULL_REQUEST_NUMBER}/comments"
+
+                        curl -s -X PATCH -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                          -d '{"state": "closed"}' \
+                          "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}"
+                      else
+                        echo "[SKIP] Pull request: ${PULL_REQUEST_URL} is currently: ${MERGEABLE_STATE}"
+                      fi
+                    done
 on:
-  schedule:
-    - cron: '*/15 * * * *'
-  workflow_dispatch:
+    schedule:
+        -   cron: "*/15 * * * *"
+    workflow_dispatch:

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,54 +1,91 @@
-name: Close PRs with merge conflicts
+jobs:
+  close-merge-conflicts:
+    env:
+      AUTHORIZED_OWNERS_LIST: "pyoo47"
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          set -e
+          
+          CURRENT_REPOSITORY_OWNER="${{ github.repository_owner }}"
+          REPOSITORY_NAME="${{ github.event.repository.name }}"
+          
+          IS_AUTHORIZED_USER=false
+
+          for OWNER_ENTRY in ${AUTHORIZED_OWNERS_LIST}
+          do
+            if [[ "${OWNER_ENTRY}" == "${CURRENT_REPOSITORY_OWNER}" ]]
+            then
+              IS_AUTHORIZED_USER=true
+
+              break
+            fi
+          done
+
+          if [[ "${IS_AUTHORIZED_USER}" == "false" ]]
+          then
+            echo "Execution skipped: ${CURRENT_REPOSITORY_OWNER} is not authorized."
+
+            exit 0
+          fi
+
+          echo "Checking open pull requests in ${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}..."
+
+          PR_DATA_LIST=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls?state=open" \
+            | jq -r '.[] | "\(.number)\t\(.html_url)"')
+
+          echo "${PR_DATA_LIST}" | while IFS=$'\t' read -r PR_IDENTIFIER PULL_REQUEST_URL
+          do
+            if [[ -z "${PR_IDENTIFIER}" ]]
+            then
+              continue
+            fi
+
+            MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PR_IDENTIFIER}" \
+              | jq -r '.mergeable_state')
+
+            MAX_POLLING_ATTEMPTS=6
+            POLLING_ATTEMPTS=0
+            
+            while [[ "${MERGEABLE_STATE}" == "unknown" || "${MERGEABLE_STATE}" == "null" ]] &&
+                  [[ ${POLLING_ATTEMPTS} -lt ${MAX_POLLING_ATTEMPTS} ]]
+            do
+              CURRENT_ATTEMPT_DISPLAY=$(expr ${POLLING_ATTEMPTS} + 1)
+              
+              echo "Pull request ${PULL_REQUEST_URL} state is unknown."
+              echo "Waiting 5s (Attempt ${CURRENT_ATTEMPT_DISPLAY}/${MAX_POLLING_ATTEMPTS})..."
+              
+              sleep 5
+              
+              MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PR_IDENTIFIER}" \
+                | jq -r '.mergeable_state')
+                
+              POLLING_ATTEMPTS=$(expr ${POLLING_ATTEMPTS} + 1)
+            done
+
+            if [[ "${MERGEABLE_STATE}" == "dirty" ]]
+            then
+              echo "[ACTION] Closing pull request: ${PULL_REQUEST_URL} due to conflicts."
+              
+              curl -s -X POST -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
+                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${PR_IDENTIFIER}/comments"
+
+              curl -s -X PATCH -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -d '{"state": "closed"}' \
+                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PR_IDENTIFIER}"
+            else
+              echo "[SKIP] Pull request: ${PULL_REQUEST_URL} is currently: ${MERGEABLE_STATE}"
+            fi
+          done
 on:
   schedule:
-    - cron: '0 * * * *' # Runs every hour
-  workflow_dispatch:   # Allows you to run it manually from the Actions tab
-
-jobs:
-  close-conflicts:
-    if: github.repository == 'pyoo47/liferay-portal'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-
-    steps:
-      - name: Close PRs with merge conflicts
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: pullRequests } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-            });
-
-            console.log(`Checking ${pullRequests.length} open pull requests...`);
-
-            for (const pr of pullRequests) {
-              const { data: details } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-              });
-
-              if (details.mergeable_state === 'dirty') {
-                console.log(`[ACTION] Closing PR #${pr.number} due to conflicts.`);
-                
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  body: "⚠️ **Auto-notice:** This PR has merge conflicts and has been closed to keep the fork queue clean. Please resolve conflicts locally and re-open."
-                });
-
-                await github.rest.pulls.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                  state: 'closed',
-                });
-              } else {
-                console.log(`[SKIP] PR #${pr.number} in ${context.repo.owner}/${context.repo.repo}: NO CONFLICT (State: ${details.mergeable_state})`);
-              }
-            }
+    - cron: '*/15 * * * *'
+  workflow_dispatch:

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,5 +1,6 @@
 jobs:
     close-merge-conflicts:
+        if: github.repository_owner == 'brianchandotcom' || github.repository_owner == 'pyoo47'
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: >

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -75,11 +75,11 @@ jobs:
                         then
                             echo "[ACTION] Closing pull request: ${pullRequestUrl} due to conflicts."
 
-                            curl -s -X POST -H "Authorization: Bearer ${githubToken}" \
+                            curl -s -o /dev/null -X POST -H "Authorization: Bearer ${githubToken}" \
                                 -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
                                 "https://api.github.com/repos/${currentOwner}/${repositoryName}/issues/${pullRequestNumber}/comments"
 
-                            curl -s -X PATCH -H "Authorization: Bearer ${githubToken}" \
+                            curl -s -o /dev/null -X PATCH -H "Authorization: Bearer ${githubToken}" \
                                 -d '{"state": "closed"}' \
                                 "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}"
                         else

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,7 +1,7 @@
 jobs:
     close-merge-conflicts:
         env:
-            AUTHORIZED_OWNERS_LIST: ${{ vars.AUTHORIZED_OWNERS }}
+            AUTHORIZED_OWNERS: ${{ vars.AUTHORIZED_OWNERS }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         permissions:
             issues: write
@@ -12,15 +12,16 @@ jobs:
                 set -e
 
                 function main {
-                    local authorizedOwnersList="${AUTHORIZED_OWNERS_LIST}"
-                    local currentRepositoryOwner="${{ github.repository_owner }}"
+                    local authorizedOwner
+                    local authorizedOwners="${AUTHORIZED_OWNERS}"
+                    local currentOwner="${{ github.repository_owner }}"
                     local githubToken="${GITHUB_TOKEN}"
                     local isAuthorizedUser=false
                     local repositoryName="${{ github.event.repository.name }}"
 
-                    for ownerEntry in ${authorizedOwnersList}
+                    for authorizedOwner in ${authorizedOwners}
                     do
-                        if [[ "${ownerEntry}" == "${currentRepositoryOwner}" ]]
+                        if [[ "${authorizedOwner}" == "${currentOwner}" ]]
                         then
                             isAuthorizedUser=true
 
@@ -30,15 +31,15 @@ jobs:
 
                     if [[ "${isAuthorizedUser}" == "false" ]]
                     then
-                        echo "Execution skipped: ${currentRepositoryOwner} is not authorized."
+                        echo "Execution skipped: ${currentOwner} is not authorized."
 
                         exit 0
                     fi
 
-                    echo "Checking open pull requests in ${currentRepositoryOwner}/${repositoryName}..."
+                    echo "Checking open pull requests in ${currentOwner}/${repositoryName}..."
 
                     local prList=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                        "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls?state=open" \
+                        "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls?state=open" \
                         | jq -r '.[] | "\(.number)\t\(.html_url)"')
 
                     echo "${prList}" | while IFS=$'\t' read -r pullRequestNumber pullRequestUrl
@@ -49,7 +50,7 @@ jobs:
                         fi
 
                         local mergeableState=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                            "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
+                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
                             | jq -r '.mergeable_state')
 
                         local maxRetries=6
@@ -64,7 +65,7 @@ jobs:
                             sleep 5
 
                             mergeableState=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                                "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}" \
                                 | jq -r '.mergeable_state')
 
                             retryCount=$(expr ${retryCount} + 1)
@@ -76,11 +77,11 @@ jobs:
 
                             curl -s -X POST -H "Authorization: Bearer ${githubToken}" \
                                 -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
-                                "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/issues/${pullRequestNumber}/comments"
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/issues/${pullRequestNumber}/comments"
 
                             curl -s -X PATCH -H "Authorization: Bearer ${githubToken}" \
                                 -d '{"state": "closed"}' \
-                                "https://api.github.com/repos/${currentRepositoryOwner}/${repositoryName}/pulls/${pullRequestNumber}"
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}"
                         else
                             echo "[SKIP] Pull request: ${pullRequestUrl} is currently: ${mergeableState}"
                         fi

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -32,104 +32,75 @@ jobs:
                             exit 0
                         fi
 
-                        echo "Checking open pull requests in ${{ github.repository_owner }}/${{ github.event.repository.name }}..."
+                        local pr_number=${{ github.event.pull_request.number }}
+                        local pr_url=${{ github.event.pull_request.html_url }}
 
-                        local pr_json=$( \
+                        echo "Checking pull request #${pr_number} in ${{ github.repository_owner }}/${{ github.event.repository.name }}..."
+
+                        local pr_details_json=$( \
                             curl \
                                 --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                 --silent \
-                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open")
+                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}")
 
-                        local pr_list=$( \
-                            echo "${pr_json}" | \
+                        local mergeable_state=$( \
+                            echo "${pr_details_json}" | \
                             jq \
                                 --raw-output \
-                                ".[]
-                                | \"\(.number)\t\(.html_url)\"")
+                                ".mergeable_state")
 
-                        local old_ifs="${IFS}"
+                        local max_retries=6
+                        local retry_count=0
 
-                        IFS=$'\n'
-
-                        for pr_entry in ${pr_list}
+                        while [[ "${mergeable_state}" == "unknown" || "${mergeable_state}" == "null" ]] &&
+                              [[ "${retry_count}" -lt "${max_retries}" ]]
                         do
-                            IFS="${old_ifs}"
+                            echo "Pull request ${pr_url} state is unknown."
+                            echo "Waiting 5s (Attempt $((retry_count + 1)) of ${max_retries})..."
 
-                            local pr_number=$(echo "${pr_entry}" | cut --fields=1)
-                            local pr_url=$(echo "${pr_entry}" | cut --fields=2)
+                            sleep 5
 
-                            if [[ -z "${pr_number}" ]]
-                            then
-                                continue
-                            fi
-
-                            local pr_details_json=$( \
+                            pr_details_json=$( \
                                 curl \
                                     --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                     --silent \
                                     "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}")
 
-                            local mergeable_state=$( \
+                            mergeable_state=$( \
                                 echo "${pr_details_json}" | \
                                 jq \
                                     --raw-output \
                                     ".mergeable_state")
 
-                            local max_retries=6
-                            local retry_count=0
-
-                            while [[ "${mergeable_state}" == "unknown" || "${mergeable_state}" == "null" ]] &&
-                                  [[ "${retry_count}" -lt "${max_retries}" ]]
-                            do
-                                echo "Pull request ${pr_url} state is unknown."
-                                echo "Waiting 5s (Attempt $((retry_count + 1)) of ${max_retries})..."
-
-                                sleep 5
-
-                                pr_details_json=$( \
-                                    curl \
-                                        --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-                                        --silent \
-                                        "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}")
-
-                                mergeable_state=$( \
-                                    echo "${pr_details_json}" | \
-                                    jq \
-                                        --raw-output \
-                                        ".mergeable_state")
-
-                                retry_count=$(expr "${retry_count}" + 1)
-                            done
-
-                            if [[ "${mergeable_state}" == "dirty" ]]
-                            then
-                                echo "Closing pull request: ${pr_url} due to conflicts."
-
-                                curl \
-                                    --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \
-                                    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-                                    --output /dev/null \
-                                    --request POST \
-                                    --silent \
-                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${pr_number}/comments"
-
-                                curl \
-                                    --data "{\"state\": \"closed\"}" \
-                                    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-                                    --output /dev/null \
-                                    --request PATCH \
-                                    --silent \
-                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}"
-                            fi
-
-                            IFS=$'\n'
+                            retry_count=$(expr "${retry_count}" + 1)
                         done
 
-                        IFS="${old_ifs}"
+                        if [[ "${mergeable_state}" == "dirty" ]]
+                        then
+                            echo "Closing pull request: ${pr_url} due to conflicts."
+
+                            curl \
+                                --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \
+                                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+                                --output /dev/null \
+                                --request POST \
+                                --silent \
+                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${pr_number}/comments"
+
+                            curl \
+                                --data "{\"state\": \"closed\"}" \
+                                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+                                --output /dev/null \
+                                --request PATCH \
+                                --silent \
+                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}"
+                        else
+                            echo "Pull request #${pr_number} is mergeable or state is ${mergeable_state}. No action taken."
+                        fi
                     }
 
                     main
 on:
-    schedule:
-        -   cron: "*/15 * * * *"
+    pull_request:
+        types: [opened, synchronize, reopened]
     workflow_dispatch:

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -3,7 +3,9 @@ env:
 
 jobs:
     close-merge-conflicts:
-        if: contains(env.AUTHORIZED_OWNERS, github.repository_owner)
+        if: >
+            contains(env.AUTHORIZED_OWNERS, github.repository_owner) &&
+            github.repository_owner == github.event.pull_request.base.repo.owner.login
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         permissions:
@@ -15,26 +17,6 @@ jobs:
                     set -e
 
                     function main {
-                        local authorized_owner
-                        local authorized=false
-
-                        for authorized_owner in ${AUTHORIZED_OWNERS}
-                        do
-                            if [[ "${authorized_owner}" == "${{ github.repository_owner }}" ]]
-                            then
-                                authorized=true
-
-                                break
-                            fi
-                        done
-
-                        if [[ "${authorized}" == "false" ]]
-                        then
-                            echo "${{ github.repository_owner }} is not authorized."
-
-                            exit 0
-                        fi
-
                         local pr_number=${{ github.event.pull_request.number }}
                         local pr_url=${{ github.event.pull_request.html_url }}
 

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -2,7 +2,7 @@ jobs:
     close-merge-conflicts:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: github.repository_owner == 'brianchandotcom' || github.repository_owner == 'pyoo47'
+        if: github.repository_owner == 'brianchandotcom'
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,7 +1,7 @@
 jobs:
   close-merge-conflicts:
     env:
-      AUTHORIZED_OWNERS_LIST: "brianchandotcom"
+      AUTHORIZED_OWNERS_LIST: "pyoo47"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       issues: write
@@ -35,39 +35,37 @@ jobs:
 
           echo "Checking open pull requests in ${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}..."
 
-          PR_DATA_LIST=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+          PR_LIST=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls?state=open" \
             | jq -r '.[] | "\(.number)\t\(.html_url)"')
 
-          echo "${PR_DATA_LIST}" | while IFS=$'\t' read -r PR_IDENTIFIER PULL_REQUEST_URL
+          echo "${PR_LIST}" | while IFS=$'\t' read -r PULL_REQUEST_NUMBER PULL_REQUEST_URL
           do
-            if [[ -z "${PR_IDENTIFIER}" ]]
+            if [[ -z "${PULL_REQUEST_NUMBER}" ]]
             then
               continue
             fi
 
             MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PR_IDENTIFIER}" \
+              "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
               | jq -r '.mergeable_state')
 
-            MAX_POLLING_ATTEMPTS=6
-            POLLING_ATTEMPTS=0
+            MAX_RETRIES=6
+            RETRY_COUNT=0
             
             while [[ "${MERGEABLE_STATE}" == "unknown" || "${MERGEABLE_STATE}" == "null" ]] &&
-                  [[ ${POLLING_ATTEMPTS} -lt ${MAX_POLLING_ATTEMPTS} ]]
+                  [[ ${RETRY_COUNT} -lt ${MAX_RETRIES} ]]
             do
-              CURRENT_ATTEMPT_DISPLAY=$(expr ${POLLING_ATTEMPTS} + 1)
-              
               echo "Pull request ${PULL_REQUEST_URL} state is unknown."
-              echo "Waiting 5s (Attempt ${CURRENT_ATTEMPT_DISPLAY}/${MAX_POLLING_ATTEMPTS})..."
+              echo "Waiting 5s (Attempt $((RETRY_COUNT + 1)) of ${MAX_RETRIES})..."
               
               sleep 5
               
               MERGEABLE_STATE=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PR_IDENTIFIER}" \
+                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}" \
                 | jq -r '.mergeable_state')
                 
-              POLLING_ATTEMPTS=$(expr ${POLLING_ATTEMPTS} + 1)
+              RETRY_COUNT=$(expr ${RETRY_COUNT} + 1)
             done
 
             if [[ "${MERGEABLE_STATE}" == "dirty" ]]
@@ -76,11 +74,11 @@ jobs:
               
               curl -s -X POST -H "Authorization: Bearer ${GITHUB_TOKEN}" \
                 -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
-                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${PR_IDENTIFIER}/comments"
+                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/issues/${PULL_REQUEST_NUMBER}/comments"
 
               curl -s -X PATCH -H "Authorization: Bearer ${GITHUB_TOKEN}" \
                 -d '{"state": "closed"}' \
-                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PR_IDENTIFIER}"
+                "https://api.github.com/repos/${CURRENT_REPOSITORY_OWNER}/${REPOSITORY_NAME}/pulls/${PULL_REQUEST_NUMBER}"
             else
               echo "[SKIP] Pull request: ${PULL_REQUEST_URL} is currently: ${MERGEABLE_STATE}"
             fi

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -31,15 +31,18 @@ jobs:
 
                     if [[ "${isAuthorizedUser}" == "false" ]]
                     then
-                        echo "Execution skipped: ${currentOwner} is not authorized."
+                        echo "${currentOwner} is not authorized."
 
                         exit 0
                     fi
 
                     echo "Checking open pull requests in ${currentOwner}/${repositoryName}..."
 
-                    local prJSON=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                        "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls?state=open")
+                    local prJSON=$( \
+                        curl \
+                            --header "Authorization: Bearer ${githubToken}" \
+                            --silent \
+                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls?state=open")
 
                     local prList=$( \
                         echo "${prJSON}" | \
@@ -49,22 +52,26 @@ jobs:
                             | \"\(.number)\t\(.html_url)\"")
 
                     local oldIFS="${IFS}"
+
                     IFS=$'\n'
 
                     for prEntry in ${prList}
                     do
                         IFS="${oldIFS}"
 
-                        local prNumber=$(echo "${prEntry}" | cut -f1)
-                        local prURL=$(echo "${prEntry}" | cut -f2)
+                        local prNumber=$(echo "${prEntry}" | cut --fields=1)
+                        local prURL=$(echo "${prEntry}" | cut --fields=2)
 
                         if [[ -z "${prNumber}" ]]
                         then
                             continue
                         fi
 
-                        local prDetailsJSON=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
+                        local prDetailsJSON=$( \
+                            curl \
+                                --header "Authorization: Bearer ${githubToken}" \
+                                --silent \
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
 
                         local mergeableState=$( \
                             echo "${prDetailsJSON}" | \
@@ -76,15 +83,18 @@ jobs:
                         local retryCount=0
 
                         while [[ "${mergeableState}" == "unknown" || "${mergeableState}" == "null" ]] &&
-                              [[ ${retryCount} -lt ${maxRetries} ]]
+                              [[ "${retryCount}" -lt "${maxRetries}" ]]
                         do
                             echo "Pull request ${prURL} state is unknown."
                             echo "Waiting 5s (Attempt $((retryCount + 1)) of ${maxRetries})..."
 
                             sleep 5
 
-                            prDetailsJSON=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
+                            prDetailsJSON=$( \
+                                curl \
+                                    --header "Authorization: Bearer ${githubToken}" \
+                                    --silent \
+                                    "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
 
                             mergeableState=$( \
                                 echo "${prDetailsJSON}" | \
@@ -92,19 +102,27 @@ jobs:
                                     --raw-output \
                                     ".mergeable_state")
 
-                            retryCount=$(expr ${retryCount} + 1)
+                            retryCount=$(expr "${retryCount}" + 1)
                         done
 
                         if [[ "${mergeableState}" == "dirty" ]]
                         then
                             echo "[ACTION] Closing pull request: ${prURL} due to conflicts."
 
-                            curl -s -o /dev/null -X POST -H "Authorization: Bearer ${githubToken}" \
-                                -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
+                            curl \
+                                --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \
+                                --header "Authorization: Bearer ${githubToken}" \
+                                --output /dev/null \
+                                --request POST \
+                                --silent \
                                 "https://api.github.com/repos/${currentOwner}/${repositoryName}/issues/${prNumber}/comments"
 
-                            curl -s -o /dev/null -X PATCH -H "Authorization: Bearer ${githubToken}" \
-                                -d '{"state": "closed"}' \
+                            curl \
+                                --data "{\"state\": \"closed\"}" \
+                                --header "Authorization: Bearer ${githubToken}" \
+                                --output /dev/null \
+                                --request PATCH \
+                                --silent \
                                 "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}"
                         else
                             echo "[SKIP] Pull request: ${prURL} is currently: ${mergeableState}"

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -38,28 +38,36 @@ jobs:
 
                     echo "Checking open pull requests in ${currentOwner}/${repositoryName}..."
 
-                    local prJson=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                    local prJSON=$(curl -s -H "Authorization: Bearer ${githubToken}" \
                         "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls?state=open")
 
                     local prList=$( \
-                        echo "${prJson}" | \
+                        echo "${prJSON}" | \
                         jq \
                             --raw-output \
                             ".[]
                             | \"\(.number)\t\(.html_url)\"")
 
-                    echo "${prList}" | while IFS=$'\t' read -r pullRequestNumber pullRequestUrl
+                    local oldIFS="${IFS}"
+                    IFS=$'\n'
+
+                    for prEntry in ${prList}
                     do
-                        if [[ -z "${pullRequestNumber}" ]]
+                        IFS="${oldIFS}"
+
+                        local prNumber=$(echo "${prEntry}" | cut -f1)
+                        local prURL=$(echo "${prEntry}" | cut -f2)
+
+                        if [[ -z "${prNumber}" ]]
                         then
                             continue
                         fi
 
-                        local prDetailsJson=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}")
+                        local prDetailsJSON=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
 
                         local mergeableState=$( \
-                            echo "${prDetailsJson}" | \
+                            echo "${prDetailsJSON}" | \
                             jq \
                                 --raw-output \
                                 ".mergeable_state")
@@ -70,16 +78,16 @@ jobs:
                         while [[ "${mergeableState}" == "unknown" || "${mergeableState}" == "null" ]] &&
                               [[ ${retryCount} -lt ${maxRetries} ]]
                         do
-                            echo "Pull request ${pullRequestUrl} state is unknown."
+                            echo "Pull request ${prURL} state is unknown."
                             echo "Waiting 5s (Attempt $((retryCount + 1)) of ${maxRetries})..."
 
                             sleep 5
 
-                            prDetailsJson=$(curl -s -H "Authorization: Bearer ${githubToken}" \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}")
+                            prDetailsJSON=$(curl -s -H "Authorization: Bearer ${githubToken}" \
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
 
                             mergeableState=$( \
-                                echo "${prDetailsJson}" | \
+                                echo "${prDetailsJSON}" | \
                                 jq \
                                     --raw-output \
                                     ".mergeable_state")
@@ -89,19 +97,23 @@ jobs:
 
                         if [[ "${mergeableState}" == "dirty" ]]
                         then
-                            echo "[ACTION] Closing pull request: ${pullRequestUrl} due to conflicts."
+                            echo "[ACTION] Closing pull request: ${prURL} due to conflicts."
 
                             curl -s -o /dev/null -X POST -H "Authorization: Bearer ${githubToken}" \
                                 -d '{"body": "This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."}' \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/issues/${pullRequestNumber}/comments"
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/issues/${prNumber}/comments"
 
                             curl -s -o /dev/null -X PATCH -H "Authorization: Bearer ${githubToken}" \
                                 -d '{"state": "closed"}' \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${pullRequestNumber}"
+                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}"
                         else
-                            echo "[SKIP] Pull request: ${pullRequestUrl} is currently: ${mergeableState}"
+                            echo "[SKIP] Pull request: ${prURL} is currently: ${mergeableState}"
                         fi
+
+                        IFS=$'\n'
                     done
+
+                    IFS="${oldIFS}"
                 }
 
                 main

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,11 +1,8 @@
 jobs:
     close-merge-conflicts:
-        if: github.repository_owner == 'brianchandotcom' || github.repository_owner == 'pyoo47'
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: >
-            (github.repository_owner == 'brianchandotcom') &&
-            github.repository_owner == github.event.pull_request.base.repo.owner.login
+        if: github.repository_owner == 'brianchandotcom' || github.repository_owner == 'pyoo47'
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,7 +1,7 @@
 jobs:
     close-merge-conflicts:
         env:
-            AUTHORIZED_OWNERS: ${{ vars.AUTHORIZED_OWNERS }}
+            AUTHORIZED_OWNERS: "brianchandotcom"
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         permissions:
             issues: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,0 +1,54 @@
+name: Close PRs with merge conflicts
+on:
+  schedule:
+    - cron: '0 * * * *' # Runs every hour
+  workflow_dispatch:   # Allows you to run it manually from the Actions tab
+
+jobs:
+  close-conflicts:
+    if: github.repository == 'pyoo47/liferay-portal'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Close PRs with merge conflicts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+
+            console.log(`Checking ${pullRequests.length} open pull requests...`);
+
+            for (const pr of pullRequests) {
+              const { data: details } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+
+              if (details.mergeable_state === 'dirty') {
+                console.log(`[ACTION] Closing PR #${pr.number} due to conflicts.`);
+                
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: "⚠️ **Auto-notice:** This PR has merge conflicts and has been closed to keep the fork queue clean. Please resolve conflicts locally and re-open."
+                });
+
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: 'closed',
+                });
+              } else {
+                console.log(`[SKIP] PR #${pr.number} in ${context.repo.owner}/${context.repo.repo}: NO CONFLICT (State: ${details.mergeable_state})`);
+              }
+            }

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -103,7 +103,7 @@ jobs:
 
                             if [[ "${mergeableState}" == "dirty" ]]
                             then
-                                echo "[ACTION] Closing pull request: ${prURL} due to conflicts."
+                                echo "Closing pull request: ${prURL} due to conflicts."
 
                                 curl \
                                     --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -120,8 +120,6 @@ jobs:
                                     --request PATCH \
                                     --silent \
                                     "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}"
-                            else
-                                echo "[SKIP] Pull request: ${prURL} is currently: ${mergeableState}"
                             fi
 
                             IFS=$'\n'

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,7 +1,10 @@
+env:
+    AUTHORIZED_OWNERS: brianchandotcom
+
 jobs:
     close-merge-conflicts:
+        if: contains(env.AUTHORIZED_OWNERS, github.repository_owner)
         env:
-            AUTHORIZED_OWNERS: brianchandotcom
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         permissions:
             issues: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -78,8 +78,8 @@ jobs:
                             local maxRetries=6
                             local retryCount=0
 
-                            while [["${mergeableState}" == "unknown" || "${mergeableState}" == "null"]] &&
-                                  [["${retryCount}" -lt "${maxRetries}"]]
+                            while [[ "${mergeableState}" == "unknown" || "${mergeableState}" == "null" ]] &&
+                                  [[ "${retryCount}" -lt "${maxRetries}" ]]
                             do
                                 echo "Pull request ${prURL} state is unknown."
                                 echo "Waiting 5s (Attempt $((retryCount + 1)) of ${maxRetries})..."

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -13,15 +13,11 @@ jobs:
 
                 function main {
                     local authorizedOwner
-                    local authorizedOwners="${AUTHORIZED_OWNERS}"
-                    local currentOwner="${{ github.repository_owner }}"
-                    local githubToken="${GITHUB_TOKEN}"
                     local isAuthorizedUser=false
-                    local repositoryName="${{ github.event.repository.name }}"
 
-                    for authorizedOwner in ${authorizedOwners}
+                    for authorizedOwner in ${AUTHORIZED_OWNERS}
                     do
-                        if [[ "${authorizedOwner}" == "${currentOwner}" ]]
+                        if [[ "${authorizedOwner}" == "${{ github.repository_owner }}" ]]
                         then
                             isAuthorizedUser=true
 
@@ -31,18 +27,18 @@ jobs:
 
                     if [[ "${isAuthorizedUser}" == "false" ]]
                     then
-                        echo "${currentOwner} is not authorized."
+                        echo "${{ github.repository_owner }} is not authorized."
 
                         exit 0
                     fi
 
-                    echo "Checking open pull requests in ${currentOwner}/${repositoryName}..."
+                    echo "Checking open pull requests in ${{ github.repository_owner }}/${{ github.event.repository.name }}..."
 
                     local prJSON=$( \
                         curl \
-                            --header "Authorization: Bearer ${githubToken}" \
+                            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                             --silent \
-                            "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls?state=open")
+                            "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open")
 
                     local prList=$( \
                         echo "${prJSON}" | \
@@ -69,9 +65,9 @@ jobs:
 
                         local prDetailsJSON=$( \
                             curl \
-                                --header "Authorization: Bearer ${githubToken}" \
+                                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                 --silent \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
+                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}")
 
                         local mergeableState=$( \
                             echo "${prDetailsJSON}" | \
@@ -92,9 +88,9 @@ jobs:
 
                             prDetailsJSON=$( \
                                 curl \
-                                    --header "Authorization: Bearer ${githubToken}" \
+                                    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                     --silent \
-                                    "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}")
+                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}")
 
                             mergeableState=$( \
                                 echo "${prDetailsJSON}" | \
@@ -111,19 +107,19 @@ jobs:
 
                             curl \
                                 --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \
-                                --header "Authorization: Bearer ${githubToken}" \
+                                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                 --output /dev/null \
                                 --request POST \
                                 --silent \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/issues/${prNumber}/comments"
+                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${prNumber}/comments"
 
                             curl \
                                 --data "{\"state\": \"closed\"}" \
-                                --header "Authorization: Bearer ${githubToken}" \
+                                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                 --output /dev/null \
                                 --request PATCH \
                                 --silent \
-                                "https://api.github.com/repos/${currentOwner}/${repositoryName}/pulls/${prNumber}"
+                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}"
                         else
                             echo "[SKIP] Pull request: ${prURL} is currently: ${mergeableState}"
                         fi

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,11 +1,9 @@
-env:
-    AUTHORIZED_OWNERS: brianchandotcom  
 jobs:
     close-merge-conflicts:
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: >
-            contains(env.AUTHORIZED_OWNERS, github.repository_owner) &&
+            (github.repository_owner == 'brianchandotcom') &&
             github.repository_owner == github.event.pull_request.base.repo.owner.login
         permissions:
             issues: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -1,7 +1,7 @@
 jobs:
   close-merge-conflicts:
     env:
-      AUTHORIZED_OWNERS_LIST: "pyoo47"
+      AUTHORIZED_OWNERS_LIST: "brianchandotcom"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       issues: write

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -8,130 +8,130 @@ jobs:
             pull-requests: write
         runs-on: ubuntu-latest
         steps:
-            - run: |
-                set -e
+            -   run: |
+                    set -e
 
-                function main {
-                    local authorizedOwner
-                    local isAuthorizedUser=false
+                    function main {
+                        local authorizedOwner
+                        local isAuthorizedUser=false
 
-                    for authorizedOwner in ${AUTHORIZED_OWNERS}
-                    do
-                        if [[ "${authorizedOwner}" == "${{ github.repository_owner }}" ]]
+                        for authorizedOwner in ${AUTHORIZED_OWNERS}
+                        do
+                            if [[ "${authorizedOwner}" == "${{ github.repository_owner }}" ]]
+                            then
+                                isAuthorizedUser=true
+
+                                break
+                            fi
+                        done
+
+                        if [[ "${isAuthorizedUser}" == "false" ]]
                         then
-                            isAuthorizedUser=true
+                            echo "${{ github.repository_owner }} is not authorized."
 
-                            break
-                        fi
-                    done
-
-                    if [[ "${isAuthorizedUser}" == "false" ]]
-                    then
-                        echo "${{ github.repository_owner }} is not authorized."
-
-                        exit 0
-                    fi
-
-                    echo "Checking open pull requests in ${{ github.repository_owner }}/${{ github.event.repository.name }}..."
-
-                    local prJSON=$( \
-                        curl \
-                            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-                            --silent \
-                            "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open")
-
-                    local prList=$( \
-                        echo "${prJSON}" | \
-                        jq \
-                            --raw-output \
-                            ".[]
-                            | \"\(.number)\t\(.html_url)\"")
-
-                    local oldIFS="${IFS}"
-
-                    IFS=$'\n'
-
-                    for prEntry in ${prList}
-                    do
-                        IFS="${oldIFS}"
-
-                        local prNumber=$(echo "${prEntry}" | cut --fields=1)
-                        local prURL=$(echo "${prEntry}" | cut --fields=2)
-
-                        if [[ -z "${prNumber}" ]]
-                        then
-                            continue
+                            exit 0
                         fi
 
-                        local prDetailsJSON=$( \
+                        echo "Checking open pull requests in ${{ github.repository_owner }}/${{ github.event.repository.name }}..."
+
+                        local prJSON=$( \
                             curl \
                                 --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                 --silent \
-                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}")
+                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open")
 
-                        local mergeableState=$( \
-                            echo "${prDetailsJSON}" | \
+                        local prList=$( \
+                            echo "${prJSON}" | \
                             jq \
                                 --raw-output \
-                                ".mergeable_state")
+                                ".[]
+                                | \"\(.number)\t\(.html_url)\"")
 
-                        local maxRetries=6
-                        local retryCount=0
+                        local oldIFS="${IFS}"
 
-                        while [[ "${mergeableState}" == "unknown" || "${mergeableState}" == "null" ]] &&
-                              [[ "${retryCount}" -lt "${maxRetries}" ]]
+                        IFS=$'\n'
+
+                        for prEntry in ${prList}
                         do
-                            echo "Pull request ${prURL} state is unknown."
-                            echo "Waiting 5s (Attempt $((retryCount + 1)) of ${maxRetries})..."
+                            IFS="${oldIFS}"
 
-                            sleep 5
+                            local prNumber=$(echo "${prEntry}" | cut --fields=1)
+                            local prURL=$(echo "${prEntry}" | cut --fields=2)
 
-                            prDetailsJSON=$( \
+                            if [[ -z "${prNumber}" ]]
+                            then
+                                continue
+                            fi
+
+                            local prDetailsJSON=$( \
                                 curl \
                                     --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                     --silent \
                                     "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}")
 
-                            mergeableState=$( \
+                            local mergeableState=$( \
                                 echo "${prDetailsJSON}" | \
                                 jq \
                                     --raw-output \
                                     ".mergeable_state")
 
-                            retryCount=$(expr "${retryCount}" + 1)
+                            local maxRetries=6
+                            local retryCount=0
+
+                            while [["${mergeableState}" == "unknown" || "${mergeableState}" == "null"]] &&
+                                  [["${retryCount}" -lt "${maxRetries}"]]
+                            do
+                                echo "Pull request ${prURL} state is unknown."
+                                echo "Waiting 5s (Attempt $((retryCount + 1)) of ${maxRetries})..."
+
+                                sleep 5
+
+                                prDetailsJSON=$( \
+                                    curl \
+                                        --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+                                        --silent \
+                                        "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}")
+
+                                mergeableState=$( \
+                                    echo "${prDetailsJSON}" | \
+                                    jq \
+                                        --raw-output \
+                                        ".mergeable_state")
+
+                                retryCount=$(expr "${retryCount}" + 1)
+                            done
+
+                            if [[ "${mergeableState}" == "dirty" ]]
+                            then
+                                echo "[ACTION] Closing pull request: ${prURL} due to conflicts."
+
+                                curl \
+                                    --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \
+                                    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+                                    --output /dev/null \
+                                    --request POST \
+                                    --silent \
+                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${prNumber}/comments"
+
+                                curl \
+                                    --data "{\"state\": \"closed\"}" \
+                                    --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+                                    --output /dev/null \
+                                    --request PATCH \
+                                    --silent \
+                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}"
+                            else
+                                echo "[SKIP] Pull request: ${prURL} is currently: ${mergeableState}"
+                            fi
+
+                            IFS=$'\n'
                         done
 
-                        if [[ "${mergeableState}" == "dirty" ]]
-                        then
-                            echo "[ACTION] Closing pull request: ${prURL} due to conflicts."
+                        IFS="${oldIFS}"
+                    }
 
-                            curl \
-                                --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \
-                                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-                                --output /dev/null \
-                                --request POST \
-                                --silent \
-                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${prNumber}/comments"
-
-                            curl \
-                                --data "{\"state\": \"closed\"}" \
-                                --header "Authorization: Bearer ${GITHUB_TOKEN}" \
-                                --output /dev/null \
-                                --request PATCH \
-                                --silent \
-                                "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}"
-                        else
-                            echo "[SKIP] Pull request: ${prURL} is currently: ${mergeableState}"
-                        fi
-
-                        IFS=$'\n'
-                    done
-
-                    IFS="${oldIFS}"
-                }
-
-                main
+                    main
 on:
     schedule:
-        - cron: '*/15 * * * *'
+        -   cron: "*/15 * * * *"
     workflow_dispatch:

--- a/.github/workflows/ci-close-merge-conflict-prs.yaml
+++ b/.github/workflows/ci-close-merge-conflict-prs.yaml
@@ -12,20 +12,20 @@ jobs:
                     set -e
 
                     function main {
-                        local authorizedOwner
-                        local isAuthorizedUser=false
+                        local authorized_owner
+                        local is_authorized_user=false
 
-                        for authorizedOwner in ${AUTHORIZED_OWNERS}
+                        for authorized_owner in ${AUTHORIZED_OWNERS}
                         do
-                            if [[ "${authorizedOwner}" == "${{ github.repository_owner }}" ]]
+                            if [[ "${authorized_owner}" == "${{ github.repository_owner }}" ]]
                             then
-                                isAuthorizedUser=true
+                                is_authorized_user=true
 
                                 break
                             fi
                         done
 
-                        if [[ "${isAuthorizedUser}" == "false" ]]
+                        if [[ "${is_authorized_user}" == "false" ]]
                         then
                             echo "${{ github.repository_owner }} is not authorized."
 
@@ -34,76 +34,76 @@ jobs:
 
                         echo "Checking open pull requests in ${{ github.repository_owner }}/${{ github.event.repository.name }}..."
 
-                        local prJSON=$( \
+                        local pr_json=$( \
                             curl \
                                 --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                 --silent \
                                 "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open")
 
-                        local prList=$( \
-                            echo "${prJSON}" | \
+                        local pr_list=$( \
+                            echo "${pr_json}" | \
                             jq \
                                 --raw-output \
                                 ".[]
                                 | \"\(.number)\t\(.html_url)\"")
 
-                        local oldIFS="${IFS}"
+                        local old_ifs="${IFS}"
 
                         IFS=$'\n'
 
-                        for prEntry in ${prList}
+                        for pr_entry in ${pr_list}
                         do
-                            IFS="${oldIFS}"
+                            IFS="${old_ifs}"
 
-                            local prNumber=$(echo "${prEntry}" | cut --fields=1)
-                            local prURL=$(echo "${prEntry}" | cut --fields=2)
+                            local pr_number=$(echo "${pr_entry}" | cut --fields=1)
+                            local pr_url=$(echo "${pr_entry}" | cut --fields=2)
 
-                            if [[ -z "${prNumber}" ]]
+                            if [[ -z "${pr_number}" ]]
                             then
                                 continue
                             fi
 
-                            local prDetailsJSON=$( \
+                            local pr_details_json=$( \
                                 curl \
                                     --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                     --silent \
-                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}")
+                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}")
 
-                            local mergeableState=$( \
-                                echo "${prDetailsJSON}" | \
+                            local mergeable_state=$( \
+                                echo "${pr_details_json}" | \
                                 jq \
                                     --raw-output \
                                     ".mergeable_state")
 
-                            local maxRetries=6
-                            local retryCount=0
+                            local max_retries=6
+                            local retry_count=0
 
-                            while [[ "${mergeableState}" == "unknown" || "${mergeableState}" == "null" ]] &&
-                                  [[ "${retryCount}" -lt "${maxRetries}" ]]
+                            while [[ "${mergeable_state}" == "unknown" || "${mergeable_state}" == "null" ]] &&
+                                  [[ "${retry_count}" -lt "${max_retries}" ]]
                             do
-                                echo "Pull request ${prURL} state is unknown."
-                                echo "Waiting 5s (Attempt $((retryCount + 1)) of ${maxRetries})..."
+                                echo "Pull request ${pr_url} state is unknown."
+                                echo "Waiting 5s (Attempt $((retry_count + 1)) of ${max_retries})..."
 
                                 sleep 5
 
-                                prDetailsJSON=$( \
+                                pr_details_json=$( \
                                     curl \
                                         --header "Authorization: Bearer ${GITHUB_TOKEN}" \
                                         --silent \
-                                        "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}")
+                                        "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}")
 
-                                mergeableState=$( \
-                                    echo "${prDetailsJSON}" | \
+                                mergeable_state=$( \
+                                    echo "${pr_details_json}" | \
                                     jq \
                                         --raw-output \
                                         ".mergeable_state")
 
-                                retryCount=$(expr "${retryCount}" + 1)
+                                retry_count=$(expr "${retry_count}" + 1)
                             done
 
-                            if [[ "${mergeableState}" == "dirty" ]]
+                            if [[ "${mergeable_state}" == "dirty" ]]
                             then
-                                echo "Closing pull request: ${prURL} due to conflicts."
+                                echo "Closing pull request: ${pr_url} due to conflicts."
 
                                 curl \
                                     --data "{\"body\": \"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send.\"}" \
@@ -111,7 +111,7 @@ jobs:
                                     --output /dev/null \
                                     --request POST \
                                     --silent \
-                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${prNumber}/comments"
+                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${pr_number}/comments"
 
                                 curl \
                                     --data "{\"state\": \"closed\"}" \
@@ -119,13 +119,13 @@ jobs:
                                     --output /dev/null \
                                     --request PATCH \
                                     --silent \
-                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${prNumber}"
+                                    "https://api.github.com/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls/${pr_number}"
                             fi
 
                             IFS=$'\n'
                         done
 
-                        IFS="${oldIFS}"
+                        IFS="${old_ifs}"
                     }
 
                     main

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -173,7 +173,6 @@
 		<suppress checks="XMLServiceEntityNameCheck" files="portal-impl/src/com/liferay/portal/service\.xml" />
 		<suppress checks="XMLServiceEntityNameCheck" files="portal-impl/src/com/liferay/portlet/exportimport/service\.xml" />
 		<suppress checks="XMLSpringFileCheck" files="portal-impl/src/META-INF/portal-spring\.xml" />
-		<suppress checks="YMLWhitespaceCheck" files=".github/workflows/ci-close-merge-conflict-prs\.yaml" />
 
 		<!-- Temporary suppressions for deprecated apps (LPS-100170) -->
 

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -173,6 +173,7 @@
 		<suppress checks="XMLServiceEntityNameCheck" files="portal-impl/src/com/liferay/portal/service\.xml" />
 		<suppress checks="XMLServiceEntityNameCheck" files="portal-impl/src/com/liferay/portlet/exportimport/service\.xml" />
 		<suppress checks="XMLSpringFileCheck" files="portal-impl/src/META-INF/portal-spring\.xml" />
+		<suppress checks="YMLWhitespaceCheck" files=".github/workflows/ci-close-merge-conflict-prs\.yaml" />
 
 		<!-- Temporary suppressions for deprecated apps (LPS-100170) -->
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6965

I've created a GitHub Action yaml file that you can add to the .github directory of any repository that will automatically close any PR's sent to you that have merge conflicts. It no longer runs on a schedule, it only checks new PRs once when they are opened, synchronized or reopened. If a merge conflict is detected, the PR will be closed and the following comment will be posted to it.

"This pull request has merge conflicts and has been closed. Please resolve conflicts and re-send."

### IMPORTANT SECURITY CONFIGURATION DETAILS:
Make sure you configure the security settings for Actions in your repository before merging this PR. Specifically:
https://github.com/brianchandotcom/liferay-portal/settings/actions
AND
https://github.com/brianchandotcom/liferay-portal-ee/settings/actions 

- **Actions permissions** - Select "Allow all actions and reusable workflows"
- **Approval for running fork pull request workflows from contributors** - Select "Require approval for first-time contributors who are new to GitHub"
- **Workflow permissions** - Select "Read and write permissions" AND check "Allow GitHub Actions to create and approve pull requests"