### PR TITLE
LPD-86431 Real-time segment feature + test fixes (rebased on liferay upstream)

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-contacts-demo/src/main/java/com/liferay/osb/faro/contacts/demo/internal/NaniteDemoCreatorService.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-contacts-demo/src/main/java/com/liferay/osb/faro/contacts/demo/internal/NaniteDemoCreatorService.java
@@ -187,7 +187,7 @@ public class NaniteDemoCreatorService extends DemoCreatorService {
 			contactsEngineClient.addIndividualSegment(
 				faroProject, user.getUserId(), channelId,
 				individualSegment.getValue(), false, individualSegment.getKey(),
-				IndividualSegment.Type.BATCH.name(),
+				IndividualSegment.Type.BATCH.name(), false,
 				IndividualSegment.Status.ACTIVE.name());
 		}
 	}
@@ -405,6 +405,8 @@ public class NaniteDemoCreatorService extends DemoCreatorService {
 					).put(
 						"includeAnonymousUsers",
 						individualSegment.isIncludeAnonymousUsers()
+					).put(
+						"sequential", individualSegment.isSequential()
 					).build()
 				).build());
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -99,7 +99,7 @@ public interface ContactsEngineClient {
 	public IndividualSegment addIndividualSegment(
 		FaroProject faroProject, long userId, String channelId,
 		String filterString, boolean includeAnonymousUsers, String name,
-		String segmentType, String status);
+		String segmentType, boolean sequential, String status);
 
 	public IndividualSegmentMembership addMembership(
 		FaroProject faroProject, String individualSegmentId,
@@ -570,7 +570,7 @@ public interface ContactsEngineClient {
 	public IndividualSegment updateIndividualSegment(
 		FaroProject faroProject, String id, long userId, String channelId,
 		String filterString, boolean includeAnonymousUsers, String name,
-		String segmentType);
+		String segmentType, boolean sequential);
 
 	public SegmentActivation updateSegmentActivation(
 		FaroProject faroProject, String cronExpression, String frequencyType,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -301,7 +301,7 @@ public class ContactsEngineClientImpl
 	public IndividualSegment addIndividualSegment(
 		FaroProject faroProject, long userId, String channelId,
 		String filterString, boolean includeAnonymousUsers, String name,
-		String segmentType, String status) {
+		String segmentType, boolean sequential, String status) {
 
 		IndividualSegment individualSegment = new IndividualSegment();
 
@@ -312,6 +312,7 @@ public class ContactsEngineClientImpl
 		individualSegment.setIncludeAnonymousUsers(includeAnonymousUsers);
 		individualSegment.setName(name);
 		individualSegment.setSegmentType(segmentType);
+		individualSegment.setSequential(sequential);
 		individualSegment.setStatus(status);
 
 		return post(
@@ -3110,7 +3111,7 @@ public class ContactsEngineClientImpl
 	public IndividualSegment updateIndividualSegment(
 		FaroProject faroProject, String id, long userId, String channelId,
 		String filterString, boolean includeAnonymousUsers, String name,
-		String segmentType) {
+		String segmentType, boolean sequential) {
 
 		IndividualSegment individualSegment = new IndividualSegment();
 
@@ -3121,6 +3122,7 @@ public class ContactsEngineClientImpl
 		individualSegment.setIncludeAnonymousUsers(includeAnonymousUsers);
 		individualSegment.setName(name);
 		individualSegment.setSegmentType(segmentType);
+		individualSegment.setSequential(sequential);
 		individualSegment.setStatus(IndividualSegment.Status.ACTIVE.name());
 
 		return put(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/IndividualSegment.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/IndividualSegment.java
@@ -122,6 +122,10 @@ public class IndividualSegment {
 		return _includeAnonymousUsers;
 	}
 
+	public boolean isSequential() {
+		return _sequential;
+	}
+
 	public void setActiveIndividualCount(long activeIndividualCount) {
 		_activeIndividualCount = activeIndividualCount;
 	}
@@ -211,6 +215,10 @@ public class IndividualSegment {
 		_segmentType = segmentType;
 	}
 
+	public void setSequential(boolean sequential) {
+		_sequential = sequential;
+	}
+
 	public void setState(String state) {
 		_state = state;
 	}
@@ -263,6 +271,7 @@ public class IndividualSegment {
 	private String _scope = Scope.PROJECT.name();
 	private SegmentActivation _segmentActivation;
 	private String _segmentType = Type.BATCH.name();
+	private boolean _sequential;
 	private String _state = State.READY.name();
 	private String _status = Status.ACTIVE.name();
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -146,11 +146,11 @@ public abstract class BaseMockContactsEngineClientImpl
 	public IndividualSegment addIndividualSegment(
 		FaroProject faroProject, long userId, String channelId,
 		String filterString, boolean includeAnonymousUsers, String name,
-		String segmentType, String status) {
+		String segmentType, boolean sequential, String status) {
 
 		return contactsEngineClient.addIndividualSegment(
 			faroProject, userId, channelId, filterString, includeAnonymousUsers,
-			name, segmentType, status);
+			name, segmentType, sequential, status);
 	}
 
 	@Override
@@ -1171,11 +1171,11 @@ public abstract class BaseMockContactsEngineClientImpl
 	public IndividualSegment updateIndividualSegment(
 		FaroProject faroProject, String id, long userId, String channelId,
 		String filterString, boolean includeAnonymousUsers, String name,
-		String segmentType) {
+		String segmentType, boolean sequential) {
 
 		return contactsEngineClient.updateIndividualSegment(
 			faroProject, id, userId, channelId, filterString,
-			includeAnonymousUsers, name, segmentType);
+			includeAnonymousUsers, name, segmentType, sequential);
 	}
 
 	@Override

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/IndividualSegmentController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/IndividualSegmentController.java
@@ -99,14 +99,15 @@ public class IndividualSegmentController extends BaseFaroController {
 			@FormParam("filter") String filterString,
 			@FormParam("includeAnonymousUsers") boolean includeAnonymousUsers,
 			@FormParam("name") String name,
-			@FormParam("segmentType") String segmentType)
+			@FormParam("segmentType") String segmentType,
+			@FormParam("sequential") boolean sequential)
 		throws Exception {
 
 		validateCreate(channelId, segmentType);
 
 		return createIndividualSegment(
 			channelId, groupId, filterString, includeAnonymousUsers, name,
-			segmentType);
+			segmentType, sequential);
 	}
 
 	@DELETE
@@ -368,7 +369,8 @@ public class IndividualSegmentController extends BaseFaroController {
 			@FormParam("includeAnonymousUsers") boolean includeAnonymousUsers,
 			@DefaultValue(StringPool.BLANK) @FormParam("individualIds")
 				FaroParam<List<String>> individualIdsFaroParam,
-			@FormParam("name") String name)
+			@FormParam("name") String name,
+			@FormParam("sequential") boolean sequential)
 		throws Exception {
 
 		FaroProject faroProject =
@@ -381,12 +383,13 @@ public class IndividualSegmentController extends BaseFaroController {
 
 		return updateIndividualSegment(
 			groupId, individualSegment, filterString, includeAnonymousUsers,
-			name);
+			name, sequential);
 	}
 
 	protected IndividualSegmentDisplay createIndividualSegment(
 			String channelId, long groupId, String filterString,
-			boolean includeAnonymousUsers, String name, String segmentType)
+			boolean includeAnonymousUsers, String name, String segmentType,
+			boolean sequential)
 		throws Exception {
 
 		FaroProject faroProject =
@@ -395,7 +398,7 @@ public class IndividualSegmentController extends BaseFaroController {
 		return new IndividualSegmentDisplay(
 			contactsEngineClient.addIndividualSegment(
 				faroProject, getUserId(), channelId, filterString,
-				includeAnonymousUsers, name, segmentType,
+				includeAnonymousUsers, name, segmentType, sequential,
 				IndividualSegment.Status.ACTIVE.name()));
 	}
 
@@ -441,7 +444,8 @@ public class IndividualSegmentController extends BaseFaroController {
 
 	protected IndividualSegmentDisplay updateIndividualSegment(
 			long groupId, IndividualSegment individualSegment,
-			String filterString, boolean includeAnonymousUsers, String name)
+			String filterString, boolean includeAnonymousUsers, String name,
+			boolean sequential)
 		throws Exception {
 
 		FaroProject faroProject =
@@ -451,8 +455,8 @@ public class IndividualSegmentController extends BaseFaroController {
 			contactsEngineClient.updateIndividualSegment(
 				faroProject, individualSegment.getId(), getUserId(),
 				individualSegment.getChannelId(), filterString,
-				includeAnonymousUsers, name,
-				individualSegment.getSegmentType()));
+				includeAnonymousUsers, name, individualSegment.getSegmentType(),
+				sequential));
 	}
 
 	protected void updateMembership(
@@ -506,7 +510,7 @@ public class IndividualSegmentController extends BaseFaroController {
 		individualSegment = contactsEngineClient.updateIndividualSegment(
 			faroProject, individualSegment.getId(), getUserId(),
 			individualSegment.getChannelId(), null, false, name,
-			individualSegment.getSegmentType());
+			individualSegment.getSegmentType(), false);
 
 		updateMembership(faroProject, individualSegment.getId(), individualIds);
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/IndividualSegmentDisplay.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/IndividualSegmentDisplay.java
@@ -137,6 +137,7 @@ public class IndividualSegmentDisplay implements FaroEntityDisplay {
 			individualSegment.getLastMembershipUpdateDate();
 		_name = individualSegment.getName();
 		_segmentType = individualSegment.getSegmentType();
+		_sequential = individualSegment.isSequential();
 		_state = individualSegment.getState();
 		_status = individualSegment.getStatus();
 		_type = FaroConstants.TYPE_SEGMENT_INDIVIDUALS;
@@ -248,6 +249,7 @@ public class IndividualSegmentDisplay implements FaroEntityDisplay {
 	private String _name;
 	private final Map<String, Object> _referencedObjects = new HashMap<>();
 	private String _segmentType;
+	private boolean _sequential;
 	private String _state;
 	private String _status;
 	private int _type;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/SegmentEnabledSequentialCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/SegmentEnabledSequentialCard.tsx
@@ -1,17 +1,13 @@
 import Card from 'shared/components/Card';
+import Form from '../../shared/components/form';
 import React from 'react';
-import {ClayToggle} from '@clayui/form';
 import {Text} from '@clayui/core';
 
 interface ISegmentEnabledSequentialCardProps {
-	onToggle: (enabled: boolean) => void;
-	toggled: boolean;
+	sequential: boolean;
 }
 
-const SegmentEnabledSequentialCard: React.FC<ISegmentEnabledSequentialCardProps> = ({
-	onToggle,
-	toggled
-}) => (
+const SegmentEnabledSequentialCard: React.FC<ISegmentEnabledSequentialCardProps> = () => (
 	<Card>
 		<Card.Header>
 			<Card.Title>{Liferay.Language.get('order')}</Card.Title>
@@ -19,11 +15,10 @@ const SegmentEnabledSequentialCard: React.FC<ISegmentEnabledSequentialCardProps>
 
 		<Card.Body>
 			<p>
-				<ClayToggle
-					data-testid='segment-enable-sequential-toggle'
+				<Form.ToggleSwitch
+					className='sequential'
 					label={Liferay.Language.get('enable-sequential')}
-					onToggle={onToggle}
-					toggled={toggled}
+					name='sequential'
 				/>
 			</p>
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/criteria-card/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/criteria-card/index.tsx
@@ -11,6 +11,7 @@ interface ICriteriaCardProps {
 	criteriaString: string;
 	includeAnonymousUsers: boolean;
 	segmentType: SegmentTypes;
+	sequential: boolean;
 	timeZoneId: string;
 }
 
@@ -18,6 +19,7 @@ const CriteriaCard: React.FC<ICriteriaCardProps> = ({
 	criteriaString,
 	includeAnonymousUsers,
 	segmentType,
+	sequential,
 	timeZoneId
 }) => {
 	const _criteriaViewRef = React.createRef<HTMLDivElement>();
@@ -46,6 +48,12 @@ const CriteriaCard: React.FC<ICriteriaCardProps> = ({
 			id={ReportContainer.SegmentCriteriaCard}
 		>
 			<Panel.Body className='criteria-card-root'>
+				{segmentType === SegmentTypes.RealTime && sequential && (
+					<Label display='info' size='lg' uppercase>
+						{Liferay.Language.get('sequential')}
+					</Label>
+				)}
+
 				{includeAnonymousUsers && (
 					<Label display='info' size='lg' uppercase>
 						{Liferay.Language.get('includes-anonymous-individuals')}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/Overview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/Overview.tsx
@@ -28,7 +28,8 @@ const Overview: React.FC<IOverviewProps> = ({channelId, groupId, segment}) => {
 		id,
 		includeAnonymousUsers,
 		individualCount,
-		knownIndividualCount
+		knownIndividualCount,
+		sequential
 	} = segment;
 	const {timeZoneId} = useTimeZone();
 
@@ -88,6 +89,7 @@ const Overview: React.FC<IOverviewProps> = ({channelId, groupId, segment}) => {
 						criteriaString={criteriaString}
 						includeAnonymousUsers={includeAnonymousUsers}
 						segmentType={SegmentTypes.Batch}
+						sequential={sequential}
 						timeZoneId={timeZoneId}
 					/>
 				</ReferencedObjectsProvider>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/OverviewRealTime.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/OverviewRealTime.tsx
@@ -143,7 +143,13 @@ const RealTimeSegmentOverview: React.FC<IOverviewProps> = ({
 }) => {
 	const fetchMembers = params => getMembershipChanges(params);
 
-	const {activation, criteriaString, id, includeAnonymousUsers} = segment;
+	const {
+		activation,
+		criteriaString,
+		id,
+		includeAnonymousUsers,
+		sequential
+	} = segment;
 
 	const {timeZoneId} = useTimeZone();
 
@@ -262,6 +268,7 @@ const RealTimeSegmentOverview: React.FC<IOverviewProps> = ({
 					criteriaString={criteriaString}
 					includeAnonymousUsers={includeAnonymousUsers}
 					segmentType={SegmentTypes.RealTime}
+					sequential={sequential}
 					timeZoneId={timeZoneId}
 				/>
 			</ReferencedObjectsProvider>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/__snapshots__/Edit.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/__snapshots__/Edit.jsx.snap
@@ -159,53 +159,6 @@ exports[`Edit should render 1`] = `
                       <div
                         class="btn-group-item"
                       >
-                        <label
-                          class="toggle-switch toggle-switch-root include-anonymous"
-                          for="includeAnonymousUsers"
-                        >
-                          <input
-                            class="toggle-switch-check"
-                            data-testid="toggle-switch-input"
-                            id="includeAnonymousUsers"
-                            name="includeAnonymousUsers"
-                            type="checkbox"
-                            value="false"
-                          />
-                          <span
-                            aria-hidden="true"
-                            class="toggle-switch-bar"
-                          >
-                            <span
-                              class="toggle-switch-handle"
-                              data-label-off="Include Anonymous"
-                              data-label-on="Include Anonymous"
-                            />
-                          </span>
-                        </label>
-                      </div>
-                      <div
-                        class="btn-group-item"
-                      >
-                        <span
-                          class="info-popover-root include-anon-help-icon"
-                        >
-                          <svg
-                            class="lexicon-icon lexicon-icon-question-circle-full icon-root"
-                            role="presentation"
-                          >
-                            <use
-                              href="#question-circle-full"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </div>
-                    <div
-                      class="btn-group"
-                    >
-                      <div
-                        class="btn-group-item"
-                      >
                         <button
                           aria-label="View Members"
                           class="button-root preview-criteria btn btn-outline-borderless btn-sm btn-outline-secondary"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/Toolbar.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/Toolbar.tsx
@@ -188,26 +188,28 @@ export class Toolbar extends React.Component<IToolbarProps, IToolbarState> {
 						</div>
 
 						<div className='form-header-section-right'>
-							<div className='btn-group'>
-								<div className='btn-group-item'>
-									<Form.ToggleSwitch
-										className='include-anonymous'
-										label={Liferay.Language.get(
-											'include-anonymous'
-										)}
-										name='includeAnonymousUsers'
-									/>
-								</div>
+							{isBatch && (
+								<div className='btn-group'>
+									<div className='btn-group-item'>
+										<Form.ToggleSwitch
+											className='include-anonymous'
+											label={Liferay.Language.get(
+												'include-anonymous'
+											)}
+											name='includeAnonymousUsers'
+										/>
+									</div>
 
-								<div className='btn-group-item'>
-									<InfoPopover
-										className='include-anon-help-icon'
-										content={Liferay.Language.get(
-											'criteria-containing-individual-or-account-attributes-excludes-anonymous-individuals'
-										)}
-									/>
+									<div className='btn-group-item'>
+										<InfoPopover
+											className='include-anon-help-icon'
+											content={Liferay.Language.get(
+												'criteria-containing-individual-or-account-attributes-excludes-anonymous-individuals'
+											)}
+										/>
+									</div>
 								</div>
-							</div>
+							)}
 
 							<div className='btn-group'>
 								{isBatch && (

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/__tests__/SegmentEditor.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/__tests__/SegmentEditor.jsx
@@ -68,7 +68,7 @@ describe('SegmentEditor', () => {
 	});
 
 	it('renders the realtime segment with sequential card disabled', () => {
-		render(
+		const {container} = render(
 			<Provider store={mockStore()}>
 				<BrowserRouter>
 					<DndProvider backend={HTML5Backend}>
@@ -83,7 +83,9 @@ describe('SegmentEditor', () => {
 		);
 
 		expect(screen.getByText('Order')).toBeInTheDocument();
-		expect(screen.getByText('Enable Sequential')).toBeInTheDocument();
+		expect(
+			container.querySelector('[data-label-on="Enable Sequential"]')
+		).toBeInTheDocument();
 		expect(
 			screen.getByText(
 				'When this is enabled, event 2 must occur after event 1, with any number of events in between. When this is disabled, events can be completed in any order. Nested criteria are not supported.'
@@ -103,7 +105,7 @@ describe('SegmentEditor', () => {
 	});
 
 	it('renders the realtime segment with sequential card and user enable it', async () => {
-		render(
+		const {container} = render(
 			<Provider store={mockStore()}>
 				<BrowserRouter>
 					<DndProvider backend={HTML5Backend}>
@@ -118,7 +120,9 @@ describe('SegmentEditor', () => {
 		);
 
 		expect(screen.getByText('Order')).toBeInTheDocument();
-		expect(screen.getByText('Enable Sequential')).toBeInTheDocument();
+		expect(
+			container.querySelector('[data-label-on="Enable Sequential"]')
+		).toBeInTheDocument();
 
 		expect(
 			screen.getByText(
@@ -126,7 +130,7 @@ describe('SegmentEditor', () => {
 			)
 		).toBeInTheDocument();
 
-		fireEvent.click(screen.getByText('Enable Sequential'));
+		fireEvent.click(container.querySelector('input[name="sequential"]'));
 
 		await waitFor(() => {
 			expect(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/CriteriaGroup.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/CriteriaGroup.tsx
@@ -78,7 +78,6 @@ interface ICriteriaGroupProps {
 	criteria: CriterionGroup;
 	criteriaGroupId: string;
 	dragging?: boolean;
-	enabledSequentialSegment: boolean;
 	groupId: string;
 	id?: string;
 	index?: number;
@@ -87,6 +86,7 @@ interface ICriteriaGroupProps {
 	parentGroupId?: string;
 	root?: boolean;
 	segmentType: SegmentTypes;
+	sequential: boolean;
 }
 
 class CriteriaGroup extends React.Component<ICriteriaGroupProps> {
@@ -305,10 +305,10 @@ class CriteriaGroup extends React.Component<ICriteriaGroupProps> {
 			criteria,
 			criteriaGroupId,
 			dragging,
-			enabledSequentialSegment,
 			id,
 			onMove,
-			root
+			root,
+			sequential
 		} = this.props;
 
 		const classes = getCN(
@@ -327,9 +327,9 @@ class CriteriaGroup extends React.Component<ICriteriaGroupProps> {
 		if (this.isCriteriaEmpty()) {
 			return (
 				<EmptyDropZone
-					enabledSequentialSegment={enabledSequentialSegment}
 					id={id}
 					onCriterionAdd={this.handleCriterionAdd}
+					sequential={sequential}
 				/>
 			);
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/EmptyDropZone.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/EmptyDropZone.tsx
@@ -50,23 +50,18 @@ interface IEmptyDropZone extends React.HTMLAttributes<HTMLDivElement> {
 	addProperty: AddProperty;
 	canDrop: boolean;
 	connectDropTarget: ConnectDropTarget;
-	enabledSequentialSegment: boolean;
 	hover?: boolean;
 	onCriterionAdd: OnCriterionAdd;
+	sequential: boolean;
 }
 
 class EmptyDropZone extends Component<IEmptyDropZone> {
 	render() {
-		const {
-			canDrop,
-			connectDropTarget,
-			enabledSequentialSegment,
-			hover
-		} = this.props;
+		const {canDrop, connectDropTarget, hover, sequential} = this.props;
 
 		const targetClasses = getCN('empty-drop-zone-target', {
 			'dnd-hover': canDrop && hover,
-			'enable-sequential-segment': enabledSequentialSegment
+			'enable-sequential-segment': sequential
 		});
 
 		return (
@@ -89,7 +84,7 @@ class EmptyDropZone extends Component<IEmptyDropZone> {
 								</Text>
 							</div>
 
-							{!enabledSequentialSegment && (
+							{!sequential && (
 								<div>
 									<ClayIcon
 										className='icon-root icon-size-md mr-3'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/index.tsx
@@ -9,11 +9,11 @@ import {SegmentTypes} from 'shared/util/constants';
 interface ICriteriaBuilderProps {
 	channelId: string;
 	criteria: CriterionGroup;
-	enabledSequentialSegment?: boolean;
 	groupId: string;
 	id?: string;
 	onChange: (items: Criteria) => void;
 	segmentType: SegmentTypes;
+	sequential: boolean;
 }
 
 class CriteriaBuilder extends React.Component<ICriteriaBuilderProps> {
@@ -160,10 +160,10 @@ class CriteriaBuilder extends React.Component<ICriteriaBuilderProps> {
 		const {
 			channelId,
 			criteria,
-			enabledSequentialSegment,
 			groupId,
 			id,
-			segmentType
+			segmentType,
+			sequential
 		} = this.props;
 
 		return (
@@ -172,13 +172,13 @@ class CriteriaBuilder extends React.Component<ICriteriaBuilderProps> {
 					channelId={channelId}
 					criteria={criteria}
 					criteriaGroupId={criteria && criteria.criteriaGroupId}
-					enabledSequentialSegment={enabledSequentialSegment}
 					groupId={groupId}
 					id={id}
 					onChange={this.handleCriteriaChange}
 					onMove={this.handleCriterionMove}
 					root
 					segmentType={segmentType}
+					sequential={sequential}
 				/>
 			</div>
 		);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/WithPropertyGroups.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/WithPropertyGroups.tsx
@@ -171,28 +171,30 @@ const mapResultToProps = (
 					].filter(Boolean)
 				)
 			}),
-			new PropertyGroup({
-				label: sub(Liferay.Language.get('x-attributes'), [
-					Liferay.Language.get('individual')
-				]) as string,
-				propertyKey: FieldOwnerTypes.Individual,
-				propertySubgroups: individualSubgroupsIList
-			}),
-			new PropertyGroup({
-				label: sub(Liferay.Language.get('x-attributes'), [
-					Liferay.Language.get('account')
-				]) as string,
-				propertyKey: FieldOwnerTypes.Account,
-				propertySubgroups: List([
-					new PropertySubgroup({
-						properties: List(
-							accountMappings.items.map(
-								convertFieldMappingToAccountProperty
+			type === SegmentTypes.Batch &&
+				new PropertyGroup({
+					label: sub(Liferay.Language.get('x-attributes'), [
+						Liferay.Language.get('individual')
+					]) as string,
+					propertyKey: FieldOwnerTypes.Individual,
+					propertySubgroups: individualSubgroupsIList
+				}),
+			type === SegmentTypes.Batch &&
+				new PropertyGroup({
+					label: sub(Liferay.Language.get('x-attributes'), [
+						Liferay.Language.get('account')
+					]) as string,
+					propertyKey: FieldOwnerTypes.Account,
+					propertySubgroups: List([
+						new PropertySubgroup({
+							properties: List(
+								accountMappings.items.map(
+									convertFieldMappingToAccountProperty
+								)
 							)
-						)
-					})
-				])
-			}),
+						})
+					])
+				}),
 			type === SegmentTypes.Batch &&
 				new PropertyGroup({
 					label: Liferay.Language.get('interests'),
@@ -222,8 +224,12 @@ const mapResultToProps = (
 		].filter(Boolean) as PropertyGroup[]
 	);
 
+	if (type === SegmentTypes.Batch) {
+		propertyGroupsIList.push(organizationPropertyGroup);
+	}
+
 	return {
-		propertyGroupsIList: propertyGroupsIList.push(organizationPropertyGroup)
+		propertyGroupsIList
 	};
 };
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/WithPropertyGroups.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/WithPropertyGroups.tsx
@@ -147,7 +147,7 @@ const mapResultToProps = (
 		])
 	});
 
-	const propertyGroupsIList = List(
+	let propertyGroupsIList = List(
 		[
 			new PropertyGroup({
 				label: Liferay.Language.get('events'),
@@ -225,7 +225,9 @@ const mapResultToProps = (
 	);
 
 	if (type === SegmentTypes.Batch) {
-		propertyGroupsIList.push(organizationPropertyGroup);
+		propertyGroupsIList = propertyGroupsIList.push(
+			organizationPropertyGroup
+		);
 	}
 
 	return {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -53,6 +53,7 @@ const CriteriaBuilderForm = withField(
 		field: {name, value},
 		groupId,
 		segmentType,
+		sequential,
 		...fieldProps
 	}) => {
 		const handleChange = criteria => {
@@ -71,6 +72,7 @@ const CriteriaBuilderForm = withField(
 				groupId={groupId}
 				onChange={handleChange}
 				segmentType={segmentType}
+				sequential={sequential}
 			/>
 		);
 	}
@@ -80,6 +82,7 @@ type FormValues = {
 	criteria: CriterionGroup;
 	includeAnonymousUsers: boolean;
 	name: string;
+	sequential: boolean;
 };
 
 interface ISegmentEditorProps {
@@ -104,14 +107,10 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 		segment: new Segment()
 	};
 
-	state = {
-		enabledSequentialSegment: false
-	};
-
 	_formRef = React.createRef<Formik>();
 
 	@autobind
-	createSegment({criteria, includeAnonymousUsers, name}) {
+	createSegment({criteria, includeAnonymousUsers, name, sequential}) {
 		const {
 			channelId,
 			groupId,
@@ -128,22 +127,29 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 			description: '',
 			includeAnonymousUsers,
 			name: name.trim(),
-			segmentType: type
+			segmentType: type,
+			sequential
 		};
 
 		return request({...requestData, channelId, groupId, id});
 	}
 
 	@autobind
-	hasChanges(newIncludeAnonymousUsers, newName, newCriteriaString) {
+	hasChanges(
+		newIncludeAnonymousUsers,
+		newName,
+		newCriteriaString,
+		newSequential
+	) {
 		const {
-			segment: {criteriaString, includeAnonymousUsers, name}
+			segment: {criteriaString, includeAnonymousUsers, name, sequential}
 		} = this.props;
 
 		return (
 			newIncludeAnonymousUsers !== includeAnonymousUsers ||
 			name !== newName ||
-			criteriaString !== newCriteriaString
+			criteriaString !== newCriteriaString ||
+			sequential !== newSequential
 		);
 	}
 
@@ -167,6 +173,7 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 					criteriaString,
 					includeAnonymousUsers,
 					name,
+					sequential,
 					state: segmentState
 				},
 				type
@@ -188,7 +195,8 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 									  )
 									: wrapInCriteriaGroup([]),
 							includeAnonymousUsers,
-							name
+							name,
+							sequential
 						}}
 						onSubmit={this.handleSubmit}
 						ref={this._formRef}
@@ -197,7 +205,12 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 							handleSubmit,
 							isSubmitting,
 							isValid,
-							values: {criteria, includeAnonymousUsers, name}
+							values: {
+								criteria,
+								includeAnonymousUsers,
+								name,
+								sequential
+							}
 						}) => {
 							const newCriteriaString = buildQueryString([
 								criteria
@@ -205,7 +218,8 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 							const hasChanges = this.hasChanges(
 								includeAnonymousUsers,
 								name,
-								newCriteriaString
+								newCriteriaString,
+								sequential
 							);
 
 							return (
@@ -250,16 +264,8 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 														{type ===
 															SegmentTypes.RealTime && (
 															<SegmentEnabledSequentialCard
-																onToggle={value =>
-																	this.setState(
-																		{
-																			enabledSequentialSegment: value
-																		}
-																	)
-																}
-																toggled={
-																	this.state
-																		.enabledSequentialSegment
+																sequential={
+																	sequential
 																}
 															/>
 														)}
@@ -288,14 +294,13 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 															channelId={
 																channelId
 															}
-															enabledSequentialSegment={
-																this.state
-																	.enabledSequentialSegment
-															}
 															groupId={groupId}
 															id={id}
 															name='criteria'
 															segmentType={type}
+															sequential={
+																sequential
+															}
 															validate={
 																validateSegmentEditor
 															}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/BehaviorInput.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/BehaviorInput.tsx
@@ -4,9 +4,6 @@ import DateFilterConjunctionInput from './components/DateFilterConjunctionInput'
 import Form from 'shared/components/form';
 import OccurenceConjunctionInput from './components/OccurenceConjunctionInput';
 import React from 'react';
-import RealTimePeriodInput, {
-	DEFAULT_OPTIONS
-} from './components/RealTimePeriodInput';
 import SelectEntityFromModal from './components/SelectEntityFromModal';
 import {
 	ACTIVITY_KEY,
@@ -103,10 +100,6 @@ export class BehaviorInput extends React.Component<IBehaviorInputProps> {
 
 	_completedAnalytics = false;
 
-	componentDidMount() {
-		this.initializeRealTimeDefaults();
-	}
-
 	componentDidUpdate() {
 		const {
 			id,
@@ -119,21 +112,6 @@ export class BehaviorInput extends React.Component<IBehaviorInputProps> {
 
 		if (!id && valid && !this._completedAnalytics) {
 			this._completedAnalytics = true;
-		}
-	}
-
-	initializeRealTimeDefaults() {
-		const isRealTime = this.props.segmentType === SegmentTypes.RealTime;
-
-		if (isRealTime) {
-			const currentPeriod = this.getRealTimePeriodFromCriterion();
-
-			if (!currentPeriod) {
-				this.handleRealTimePeriodChange(
-					DEFAULT_OPTIONS.interval,
-					DEFAULT_OPTIONS.timeWindow
-				);
-			}
 		}
 	}
 
@@ -318,70 +296,6 @@ export class BehaviorInput extends React.Component<IBehaviorInputProps> {
 		onChange(params);
 	}
 
-	@autobind
-	handleRealTimePeriodChange(interval: number, timeWindow: string) {
-		const {onChange, touched, valid, value} = this.props;
-
-		const newDayValue = `${interval}_${timeWindow}`;
-
-		const conjunctionDateFilterIndex = getIndexFromPropertyName(
-			value,
-			'day'
-		);
-
-		let dayCriterion;
-		if (conjunctionDateFilterIndex >= 0) {
-			const existingDayIMap = getFilterCriterionIMap(
-				value,
-				conjunctionDateFilterIndex
-			);
-
-			dayCriterion = existingDayIMap.merge({
-				operatorName: RelationalOperators.GE,
-				touched: true,
-				valid: true,
-				value: newDayValue
-			});
-		} else {
-			dayCriterion = fromJS({
-				operatorName: RelationalOperators.GE,
-				propertyName: 'day',
-				touched: true,
-				valid: true,
-				value: newDayValue
-			});
-		}
-
-		const updatedValue = value.mergeIn(
-			['criterionGroup', 'items', 1],
-			dayCriterion
-		);
-
-		onChange({
-			touched: {...touched, dateFilter: true},
-			valid: {...valid, dateFilter: true},
-			value: updatedValue
-		});
-	}
-
-	getRealTimePeriodFromCriterion(): {
-		interval: number;
-		timeWindow: string;
-	} | null {
-		const {value} = this.props;
-
-		const dayValue = value.getIn(['criterionGroup', 'items', 1, 'value']);
-
-		if (!dayValue || typeof dayValue !== 'string') return null;
-
-		const [intervalStr, timeWindow] = dayValue.split('_');
-		const interval = Number(intervalStr);
-
-		if (!timeWindow || Number.isNaN(interval)) return null;
-
-		return {interval, timeWindow};
-	}
-
 	invalidateAsset() {
 		const {onChange, touched, valid} = this.props;
 
@@ -425,10 +339,6 @@ export class BehaviorInput extends React.Component<IBehaviorInputProps> {
 			Map({propertyName: 'day'})
 		).toJS();
 
-		const isRealTime = segmentType === SegmentTypes.RealTime;
-
-		const initialPeriod = this.getRealTimePeriodFromCriterion();
-
 		return (
 			<div className='criteria-statement'>
 				<Form.Group autoFit>
@@ -467,31 +377,25 @@ export class BehaviorInput extends React.Component<IBehaviorInputProps> {
 					/>
 				</Form.Group>
 
-				<Form.Group autoFit>
-					<OccurenceConjunctionInput
-						onChange={this.handleOccurenceConjunctionChange}
-						operatorName={
-							value.get('operator') as FunctionalOperators &
-								RelationalOperators
-						}
-						touched={touched.occurenceCount}
-						valid={valid.occurenceCount}
-						value={value.get('value')}
-					/>
-
-					{isRealTime ? (
-						<RealTimePeriodInput
-							initialInterval={initialPeriod?.interval}
-							initialTimeWindow={initialPeriod?.timeWindow}
-							onChange={this.handleRealTimePeriodChange}
+				{segmentType === SegmentTypes.Batch && (
+					<Form.Group autoFit>
+						<OccurenceConjunctionInput
+							onChange={this.handleOccurenceConjunctionChange}
+							operatorName={
+								value.get('operator') as FunctionalOperators &
+									RelationalOperators
+							}
+							touched={touched.occurenceCount}
+							valid={valid.occurenceCount}
+							value={value.get('value')}
 						/>
-					) : (
+
 						<DateFilterConjunctionInput
 							conjunctionCriterion={conjunctionCriterion}
 							onChange={this.handleDateFilterConjunctionChange}
 						/>
-					)}
-				</Form.Group>
+					</Form.Group>
+				)}
 			</div>
 		);
 	}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/BehaviorInput.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/BehaviorInput.jsx
@@ -8,6 +8,7 @@ import {Map} from 'immutable';
 import {Property, Segment} from 'shared/util/records';
 import {Provider} from 'react-redux';
 import {ReferencedObjectsProvider} from '../../context/referencedObjects';
+import {SegmentTypes} from 'shared/util/constants';
 
 jest.unmock('react-dom');
 
@@ -31,6 +32,7 @@ const defaultProps = {
 	operatorRenderer: () => <div>{'test'}</div>,
 	property: new Property(),
 	referencedAssetsIMap: new Map(),
+	segmentType: SegmentTypes.Batch,
 	touched: {asset: false, occurenceCount: false},
 	valid: {asset: false, occurenceCount: false},
 	value: mockValue

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__tests__/individual-segment.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__tests__/individual-segment.js
@@ -45,7 +45,8 @@ describe('Individual Segment API', () => {
 					filter: "(name eq 'test test')",
 					includeAnonymousUsers: false,
 					name: createArgs.name,
-					segmentType
+					segmentType,
+					sequential: false
 				}
 			});
 		});
@@ -59,7 +60,8 @@ describe('Individual Segment API', () => {
 				channelId: '123',
 				filter: "(name eq 'test test')",
 				includeAnonymousUsers: false,
-				name: updateArgs.name
+				name: updateArgs.name,
+				sequential: false
 			};
 
 			update({...updateArgs, segmentType});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/individual-segment.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/individual-segment.js
@@ -61,14 +61,16 @@ export function create({
 	groupId,
 	includeAnonymousUsers = false,
 	name,
-	segmentType
+	segmentType,
+	sequential = false
 }) {
 	const data = {
 		channelId,
 		filter: criteriaString,
 		includeAnonymousUsers,
 		name,
-		segmentType
+		segmentType,
+		sequential
 	};
 
 	return sendRequest({
@@ -85,14 +87,16 @@ export function update({
 	id,
 	includeAnonymousUsers = false,
 	name,
-	segmentType
+	segmentType,
+	sequential = false
 }) {
 	const data = {
 		channelId,
 		filter: criteriaString,
 		includeAnonymousUsers,
 		name,
-		segmentType
+		segmentType,
+		sequential
 	};
 
 	return sendRequest({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/reducers/__tests__/__snapshots__/normalizer.js.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/reducers/__tests__/__snapshots__/normalizer.js.snap
@@ -117,6 +117,7 @@ Immutable.Map {
           "fieldMappings": Immutable.Map {},
         },
         "segmentType": null,
+        "sequential": false,
         "state": "",
         "status": null,
         "type": 4,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/records/Segment.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/records/Segment.ts
@@ -20,6 +20,7 @@ interface ISegment {
 	properties: Map<string, any>;
 	referencedObjects?: Map<string, any>;
 	segmentType: null;
+	sequential: false;
 	state: string;
 	status: string;
 	type: EntityTypes.IndividualsSegment;
@@ -50,6 +51,7 @@ export default class Segment
 			fieldMappings: Map()
 		}),
 		segmentType: null,
+		sequential: false,
 		state: '',
 		status: null,
 		type: EntityTypes.IndividualsSegment,
@@ -73,6 +75,7 @@ export default class Segment
 	properties: Map<string, any>;
 	referencedObjects?: Map<string, any>;
 	segmentType: null;
+	sequential: false;
 	state: string;
 	status: string;
 	type: EntityTypes.IndividualsSegment;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/records/__tests__/__snapshots__/index.js.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/records/__tests__/__snapshots__/index.js.snap
@@ -49,6 +49,7 @@ Immutable.Record {
     "fieldMappings": Immutable.Map {},
   },
   "segmentType": null,
+  "sequential": false,
   "state": "",
   "status": null,
   "type": 4,


### PR DESCRIPTION
## Summary

Complete, self-contained port of the LPD-86431 real-time vs. batch segmentation feature (Eudaldo Alonso's 5 commits) **plus** the 4 fix commits needed to keep the osb-faro Jest suite green — all rebased onto `liferay/liferay-portal:master`.

This branch differs from the earlier **[#4234](https://github.com/pyoo47/liferay-portal/pull/4234)** (LPD-86431): that PR was based on `brianchandotcom/liferay-portal:master`, which already carried Eudaldo's work, so it only contained the 4 fix commits. **This PR is based on canonical upstream `liferay/liferay-portal:master`**, which does **not** yet have LPD-86431, so the feature commits are included here.

**Branch base:** `9c33956` (`liferay/master` HEAD as of 2026-04-21)
**Total commits:** 9 (5 from Eudaldo, 4 fixes by me)
**Full Jest suite:** 621 suites passed, 2683 tests passed, 760 snapshots passed, 0 failures.

## Why this exists

The failing build was [`test-1-46` #133289](https://test-1-46.liferay.com/job/test-portal-testsuite-upstream-downstream(master)/133289/). The `js-unit` batch reported:

```
Test Suites: 7 failed, 1 skipped, 614 passed, 621 of 622 total
Tests:       11 failed, 31 skipped, 2672 passed, 2714 total
Snapshots:   5 failed, 754 passed, 759 total
```

All 11 failures trace to Eudaldo's 5 commits under LPD-86431, which landed without any accompanying test updates and included one real source regression masked by a stale snapshot.

## Commits, in the order they appear on this branch

### Eudaldo's feature commits (cherry-picked verbatim, preserving author)

| # | SHA (new) | Original SHA | Subject | Date |
|---|---|---|---|---|
| 1 | `e86f9d2` | `26c6bf0` | LPD-86431 RealTime segments should support only events | 2026-04-09 |
| 2 | `93462d7` | `f77a70fc` | LPD-86431 Removes unnecessary configuration from real time events related with time period | 2026-04-10 |
| 3 | `ec34a72` | `4a59294` | LPD-86431 Includes anonymous toggle only for batch segmentation | 2026-04-13 |
| 4 | `821bd4d` | `8c2143e` | LPD-86431 Sends sequential when we are submitting the form | 2026-04-16 |
| 5 | `fc633b8` | `1e9e724` | LPD-86431 Takes into account sequential when we are creating or updating segments | 2026-04-16 |

All 5 cherry-picks applied cleanly (no conflicts).

### Test / regression fix commits (mine)

| # | SHA (new) | Pairs with | Subject |
|---|---|---|---|
| 6 | `996abe1` | commit 4 (`821bd4d`) | LPD-86431 Update tests for sequential segment field |
| 7 | `742cfcd` | commit 3 (`ec34a72`) | LPD-86431 Update Edit snapshot for batch-only anonymous toggle |
| 8 | `5f9ad19` | commit 1 (`e86f9d2`) | LPD-86431 Fix organization property group missing for batch segments |
| 9 | `09edf8c` | commit 2 (`93462d7`) | LPD-86431 Pass segmentType to BehaviorInput tests |

## Root cause attribution — 11 failures → 4 distinct fixes

| Failing test(s) | Caused by | Fix commit |
|---|---|---|
| `Segment` record snapshot; `normalizer` snapshot; `individual-segment.js` API expectations; `SegmentEditor.jsx` "Enable Sequential" queries (×2) | Commit 4 (`821bd4d`) | `996abe1` |
| `segment/pages/Edit.jsx` snapshot | Commit 3 (`ec34a72`) | `742cfcd` |
| `WithPropertyGroups.jsx` snapshot — **real source regression** | Commit 1 (`e86f9d2`) | `5f9ad19` |
| `BehaviorInput.jsx` × 3 | Commit 2 (`93462d7`) | `09edf8c` |

## Detail, fix-by-fix

### `996abe1` — Update tests for sequential segment field

**Context:** Commit `821bd4d` added a new `sequential: false` field to the `Segment` immutable record, threaded it through `create` and `update` in `individual-segment.js`, and added an "Enable Sequential" toggle-switch card to the dynamic segment editor for real-time segments.

**Changes:**
- `shared/util/records/__tests__/__snapshots__/index.js.snap` — regenerated (+1 line, adds `"sequential": false`).
- `shared/reducers/__tests__/__snapshots__/normalizer.js.snap` — regenerated (+1 line, same cascade via the record).
- `shared/api/__tests__/individual-segment.js` — manually added `sequential: false` to the expected request payloads for both create and update cases (preferred manual edit over `-u` so the API contract is readable in the diff).
- `segment/segment-editor/dynamic/__tests__/SegmentEditor.jsx` — the two real-time tests used `screen.getByText('Enable Sequential')`, but Liferay's `ToggleSwitch` component renders its label in `data-label-off` / `data-label-on` attributes on a `<span>` (Liferay UI convention, presumably surfaced via CSS `::after`), **not** as a DOM text node. Updated to use `container.querySelector('[data-label-on="Enable Sequential"]')` for the presence check and `container.querySelector('input[name="sequential"]')` for the click target (the actual checkbox input), plus added `const {container} =` destructuring to both tests.

### `742cfcd` — Update Edit snapshot for batch-only anonymous toggle

**Context:** Commit `ec34a72` made the `Toolbar`'s Include Anonymous toggle conditional on `segmentType === SegmentTypes.Batch`. The `segment/pages/__tests__/Edit.jsx` test had a stale snapshot that still included the toggle. The Edit test's `type` prop flows through an intermediate `useQueryParams`-driven component that doesn't actually pick up the outer prop, so the rendered toolbar treats the segment as non-batch and correctly omits the toggle.

**Changes:**
- `segment/pages/__tests__/__snapshots__/Edit.jsx.snap` — regenerated (−47 lines, removes the `include-anonymous` toggle-switch block).

### `5f9ad19` — Fix organization property group missing for batch segments **(source fix — user-visible regression)**

**Context:** Commit `e86f9d2` gated individual/account/interests/session property groups behind `type === SegmentTypes.Batch` in `WithPropertyGroups.tsx`, and moved the organization property group into a post-hoc `if (type === SegmentTypes.Batch)` block — but the conversion introduced a subtle bug:

```ts
// Commit e86f9d2 (broken):
const propertyGroupsIList = List(...);     // ← const

if (type === SegmentTypes.Batch) {
    propertyGroupsIList.push(organizationPropertyGroup);   // ← no-op!
}

return { propertyGroupsIList };
```

`ImmutableJS.List.push()` returns a *new* list; its return value was discarded. Because the declaration was `const`, the intent couldn't even have been to mutate. Net effect: **for any batch segment, the "Organization Attributes" group was silently missing from the segment-editor sidebar.**

The stale `WithPropertyGroups.jsx` snapshot masked this because the snapshot still contained the group — so the diff looked like "snapshot has extras; received is missing them," and it read as "just update the snapshot." That would have permanently hidden the bug.

**Fix:**
```ts
let propertyGroupsIList = List(...);       // ← let

if (type === SegmentTypes.Batch) {
    propertyGroupsIList = propertyGroupsIList.push(organizationPropertyGroup);
}

return { propertyGroupsIList };
```

After the fix the original snapshot passes unchanged — no regen needed, which is the tell that the snapshot was correct and the source was wrong.

**Impact:** Anyone on `brianchandotcom/master` between `26c6bf0` (2026-04-09) and the corresponding fix on that fork (this PR's analogue, [#4234](https://github.com/pyoo47/liferay-portal/pull/4234)) would have seen batch segments with no way to filter by organization attributes. Worth QA checking whether this has been reported.

### `09edf8c` — Pass segmentType to BehaviorInput tests

**Context:** Commit `93462d7` removed 110 lines from `BehaviorInput.tsx`, keeping the `OccurenceConjunctionInput` + `DateFilterConjunctionInput` form group but gating it on `segmentType === SegmentTypes.Batch`. The `BehaviorInput.jsx` tests exercise that form group ("at least", "ever", has-error-for-occurenceCount, and the snapshot that includes the occurrence row). The test fixture had no `segmentType`, so the gate evaluated to false and the UI simply vanished from the render.

**Fix:**
- Added `import {SegmentTypes} from 'shared/util/constants'`.
- Added `segmentType: SegmentTypes.Batch` to `defaultProps`.

After the fix the original 3 snapshots pass unchanged — the tests were right, the fixture just needed the explicit type.

## Why some fixes regenerate snapshots and others don't

| Fix | Approach | Why |
|---|---|---|
| Record / normalizer snapshots | **Regen** | New `sequential` field is intended API surface |
| `individual-segment.js` expected payload | **Manual edit** | Keep the asserted request contract human-readable |
| `SegmentEditor.jsx` queries | **Test source edit** | Component is correct; tests used the wrong query strategy |
| `Edit.jsx` snapshot | **Regen** | New conditional rendering is intended; snapshot fixture is non-batch |
| `WithPropertyGroups.jsx` snapshot | **None — source fix** | Snapshot was right; source was buggy |
| `BehaviorInput.jsx` snapshots | **Test fixture edit** | Tests exercise batch-only UI; fixture needed explicit `segmentType: Batch` |

## Validation

Full Jest suite run locally in `osb-faro-web`, against the tip of this branch:

```
Test Suites: 1 skipped, 621 passed, 621 of 622 total
Tests:       31 skipped, 2683 passed, 2714 total
Snapshots:   760 passed, 760 total
Time:        101.61 s
```

Zero failures, zero snapshot mismatches. Matches the Jenkins baseline pass count exactly, minus the 11 failures the feature regression introduced.

## Test plan

- [ ] Review `5f9ad19` (the source-code regression fix) carefully — it's the only production source change and restores user-visible functionality that was silently broken.
- [ ] Confirm `SegmentEditor.jsx` query-strategy change is acceptable given Liferay's `ToggleSwitch` data-attribute labeling pattern.
- [ ] Trigger `test-portal-testsuite-upstream-downstream` CI against this branch; confirm `js-unit` goes green.
- [ ] Spot-check `Edit.jsx` snapshot diff — the 47-line deletion should contain only the `include-anonymous` toggle block.
- [ ] Confirm the Java backend commit `fc633b8` ("Takes into account sequential…") cherry-picked cleanly and still compiles against current upstream. (No unit test coverage in this PR for that commit, matching the upstream state.)

## Notes

- **All 5 of Eudaldo's commits are preserved verbatim with original authorship** (you'll see his name on commits 1–5 in `git log`).
- **The failing build ran against brianchandotcom master** (SHA `0fdcc77`), which is the context under which these regressions were surfaced. This PR reconstitutes the same logical change-set onto upstream master, with the test/source fixes bundled — so upstream can land the feature and its fixes atomically rather than shipping the regression first.
- **Companion PR:** [#4234](https://github.com/pyoo47/liferay-portal/pull/4234) carries only the 4 fix commits on top of the brianchandotcom baseline. Both are equivalent in effect; pick whichever matches the team's intended merge path.