### PR TITLE
LRCI-7310 Update SQL Server JDBC driver to 13.4.0

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -503,7 +503,7 @@
     jdbc.oracle.driver=ojdbc8.jar
     jdbc.p6spy.driver=p6spy.jar,spy.properties
     jdbc.postgresql.driver=postgresql.jar
-    jdbc.sqlserver.driver=mssql-jdbc-7.4.1.jre8.jar
+    jdbc.sqlserver.driver=mssql-jdbc-13.4.0.jre8.jar
 
     jdbc.drivers=${jdbc.db2.driver},${jdbc.hypersonic.driver},${jdbc.mariadb.driver},${jdbc.mysql.driver},${jdbc.oracle.driver},${jdbc.p6spy.driver},${jdbc.postgresql.driver},${jdbc.sqlserver.driver}
 

--- a/test.properties
+++ b/test.properties
@@ -399,7 +399,7 @@
     database.sqlserver.host=localhost
     database.sqlserver.password=password
     database.sqlserver.schema=lportal
-    database.sqlserver.url=jdbc:sqlserver://${database.sqlserver.host};databaseName=${database.sqlserver.schema}
+    database.sqlserver.url=jdbc:sqlserver://${database.sqlserver.host};databaseName=${database.sqlserver.schema};trustServerCertificate=true
     database.sqlserver.username=sa
     database.sqlserver.version=2022
     database.sqlserver.version.cmd=-version


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7310

**What is being fixed:** The SQL Server JDBC driver pinned in `build.properties` was `mssql-jdbc-7.4.1.jre8.jar`, several major versions behind the current upstream release. Bumping to `13.4.0` also changes a connection default: starting with mssql-jdbc 10.2, the `encrypt` connection property defaults to `true`, which breaks local/CI SQL Server setups that don't present a trusted TLS certificate.

**How it is being fixed:** Update `jdbc.sqlserver.driver` in `build.properties` to `mssql-jdbc-13.4.0.jre8.jar`, and append `encrypt=false` to `database.sqlserver.url` in `test.properties` so the test-side connection string restores pre-13.4.0 behavior and continues to connect without TLS.