### PR TITLE
LRCI-7205 Touch persistent resources on top-level build archive

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -23,6 +23,7 @@ import com.liferay.jenkins.results.parser.failure.message.generator.PoshiTestFai
 import com.liferay.jenkins.results.parser.failure.message.generator.PoshiValidationFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.RebaseFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.RelevantRuleValidationFailureMessageGenerator;
+import com.liferay.jenkins.results.parser.persistent.resource.PersistentResourceFactory;
 import com.liferay.jenkins.results.parser.testray.TestrayBuild;
 
 import java.io.File;
@@ -928,6 +929,19 @@ public abstract class BaseTopLevelBuild
 				@Override
 				public Object call() {
 					_archiveProperties();
+
+					return null;
+				}
+
+			});
+
+		archiveCallables.add(
+			new Callable<Object>() {
+
+				@Override
+				public Object call() {
+					PersistentResourceFactory.touchUsedPersistentResources(
+						getExecutorService());
 
 					return null;
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -456,6 +456,19 @@ public class CloudBucketUtil {
 				"Touched ", s3Path, " in ",
 				JenkinsResultsParserUtil.toDurationString(
 					System.currentTimeMillis() - start)));
+
+		if (!s3Path.endsWith(_CHECKSUM_FILE_EXTENSION)) {
+			String s3ChecksumPath = s3Path + _CHECKSUM_FILE_EXTENSION;
+
+			try {
+				if (_exists(s3ChecksumPath)) {
+					touchS3File(s3ChecksumPath);
+				}
+			}
+			catch (TimeoutException timeoutException) {
+				throw new IOException(timeoutException);
+			}
+		}
 	}
 
 	public static void uploadS3File(String s3DestinationPath, File sourceFile)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -89,6 +89,11 @@ public abstract class BasePersistentResource implements PersistentResource {
 	}
 
 	@Override
+	public boolean isTouched() {
+		return _touched;
+	}
+
+	@Override
 	public void touch() {
 		if (_touched) {
 			return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -52,8 +52,6 @@ public abstract class BasePersistentResource implements PersistentResource {
 			CloudBucketUtil.downloadS3File(
 				new File(destinationDir, artifactName),
 				artifact.getS3ObjectPath());
-
-			touch();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -169,8 +167,6 @@ public abstract class BasePersistentResource implements PersistentResource {
 			}
 			else if (status == Status.SUCCESS) {
 				print(statusMessage);
-
-				touch();
 
 				return;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -52,6 +52,8 @@ public abstract class BasePersistentResource implements PersistentResource {
 			CloudBucketUtil.downloadS3File(
 				new File(destinationDir, artifactName),
 				artifact.getS3ObjectPath());
+
+			touch();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -86,6 +88,44 @@ public abstract class BasePersistentResource implements PersistentResource {
 	@Override
 	public Status getStatus() {
 		return _status;
+	}
+
+	@Override
+	public void touch() {
+		if (_touched) {
+			return;
+		}
+
+		synchronized (this) {
+			if (_touched) {
+				return;
+			}
+
+			_touched = true;
+		}
+
+		if (!isBuildCachingEnabled()) {
+			return;
+		}
+
+		try {
+			if (CloudBucketUtil.isS3ObjectPathAvailable(
+					_getDataS3ObjectPath())) {
+
+				CloudBucketUtil.touchS3File(_getDataS3ObjectPath());
+			}
+
+			for (Artifact artifact : getArtifacts()) {
+				if (artifact.isAvailable()) {
+					CloudBucketUtil.touchS3File(artifact.getS3ObjectPath());
+				}
+			}
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"WARNING: Failed to touch " + getType() + " S3 resource: " +
+					ioException.getMessage());
+		}
 	}
 
 	@Override
@@ -129,6 +169,8 @@ public abstract class BasePersistentResource implements PersistentResource {
 			}
 			else if (status == Status.SUCCESS) {
 				print(statusMessage);
+
+				touch();
 
 				return;
 			}
@@ -367,5 +409,6 @@ public abstract class BasePersistentResource implements PersistentResource {
 	private long _producerQueueId;
 	private Properties _startProperties;
 	private Status _status;
+	private volatile boolean _touched;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
@@ -40,6 +40,8 @@ public interface PersistentResource {
 
 	public Type getType();
 
+	public void touch();
+
 	public void upload(File baseDir);
 
 	public void waitForUpdate(long waitTime);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
@@ -40,6 +40,8 @@ public interface PersistentResource {
 
 	public Type getType();
 
+	public boolean isTouched();
+
 	public void touch();
 
 	public void upload(File baseDir);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
@@ -69,21 +69,24 @@ public class PersistentResourceFactory {
 		List<Callable<Object>> touchCallables = new ArrayList<>();
 
 		for (PersistentResource persistentResource : persistentResources) {
-			if (persistentResource.getStatus() ==
-					PersistentResource.Status.SUCCESS) {
+			if (persistentResource.isTouched() ||
+				(persistentResource.getStatus() !=
+					PersistentResource.Status.SUCCESS)) {
 
-				touchCallables.add(
-					new Callable<Object>() {
-
-						@Override
-						public Object call() {
-							persistentResource.touch();
-
-							return null;
-						}
-
-					});
+				continue;
 			}
+
+			touchCallables.add(
+				new Callable<Object>() {
+
+					@Override
+					public Object call() {
+						persistentResource.touch();
+
+						return null;
+					}
+
+				});
 		}
 
 		if (touchCallables.isEmpty()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
@@ -6,10 +6,16 @@
 package com.liferay.jenkins.results.parser.persistent.resource;
 
 import com.liferay.jenkins.results.parser.BuildDatabase;
+import com.liferay.jenkins.results.parser.ParallelExecutor;
 import com.liferay.jenkins.results.parser.TopLevelBuild;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author Michael Hashimoto
@@ -46,6 +52,55 @@ public class PersistentResourceFactory {
 		}
 
 		return persistentResource;
+	}
+
+	public static void touchUsedPersistentResources(
+		ExecutorService executorService) {
+
+		PersistentResource[] persistentResources;
+
+		synchronized (PersistentResourceFactory.class) {
+			persistentResources = _persistentResources.values(
+			).toArray(
+				new PersistentResource[_persistentResources.size()]
+			);
+		}
+
+		List<Callable<Object>> touchCallables = new ArrayList<>();
+
+		for (PersistentResource persistentResource : persistentResources) {
+			if (persistentResource.getStatus() ==
+					PersistentResource.Status.SUCCESS) {
+
+				touchCallables.add(
+					new Callable<Object>() {
+
+						@Override
+						public Object call() {
+							persistentResource.touch();
+
+							return null;
+						}
+
+					});
+			}
+		}
+
+		if (touchCallables.isEmpty()) {
+			return;
+		}
+
+		ParallelExecutor<Object> parallelExecutor = new ParallelExecutor<>(
+			touchCallables, executorService, "touch persistent resources");
+
+		try {
+			parallelExecutor.execute();
+		}
+		catch (TimeoutException timeoutException) {
+			System.out.println(
+				"WARNING: Failed to touch persistent resources: " +
+					timeoutException.getMessage());
+		}
 	}
 
 	private static final Map<String, PersistentResource> _persistentResources =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7205

**What is being fixed:** Persistent resources stored in S3 (portal bundles, faro bundles, asah bundles, and their artifacts) need to be cleaned up when old, but artifacts that a top-level build actually depends on must stay alive for the lifetime of that build. The cleanup side is handled by an S3 lifecycle rule that expires objects in the `persistent-resources` prefix after seven days. This change adds the complementary logic on the Java side: re-stamping the objects a build consumed so they survive the expiration window.

**How it is being fixed:** `PersistentResource` gains a `touch()` lifecycle method, implemented in `BasePersistentResource`, that calls `CloudBucketUtil.touchS3File` on the data object and on every available artifact, guarded by a volatile `_touched` flag so the work only happens once per JVM session. `CloudBucketUtil.touchS3File` also touches the sibling `.sha512` checksum when one exists, so the data file and its checksum stay aligned on the same expiration timeline. `PersistentResourceFactory.touchUsedPersistentResources` iterates the registered resources and fans out the touches through a `ParallelExecutor` labeled `"touch persistent resources"`, so the S3 calls run concurrently rather than serially. The entry point is a single archive callable registered from `BaseTopLevelBuild.getArchiveCallables`, so touches only execute on top-level builds — not on every download or every status update — per reviewer feedback. Because `getArchiveCallables` is invoked on every archive cycle of a top-level build, the factory also filters out resources whose `isTouched()` already returns true before building the callables list; the existing empty-list early-return then skips the `ParallelExecutor` invocation entirely on subsequent cycles, avoiding the per-cycle overhead and log noise.