### PR TITLE
LRCI-7205 Touch used persistent resources during archiving

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -23,6 +23,7 @@ import com.liferay.jenkins.results.parser.failure.message.generator.PoshiTestFai
 import com.liferay.jenkins.results.parser.failure.message.generator.PoshiValidationFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.RebaseFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.RelevantRuleValidationFailureMessageGenerator;
+import com.liferay.jenkins.results.parser.persistent.resource.PersistentResourceFactory;
 import com.liferay.jenkins.results.parser.testray.TestrayBuild;
 
 import java.io.File;
@@ -928,6 +929,19 @@ public abstract class BaseTopLevelBuild
 				@Override
 				public Object call() {
 					_archiveProperties();
+
+					return null;
+				}
+
+			});
+
+		archiveCallables.add(
+			new Callable<Object>() {
+
+				@Override
+				public Object call() {
+					PersistentResourceFactory.touchUsedPersistentResources(
+						getExecutorService());
 
 					return null;
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -456,6 +456,19 @@ public class CloudBucketUtil {
 				"Touched ", s3Path, " in ",
 				JenkinsResultsParserUtil.toDurationString(
 					System.currentTimeMillis() - start)));
+
+		if (!s3Path.endsWith(_CHECKSUM_FILE_EXTENSION)) {
+			String s3ChecksumPath = s3Path + _CHECKSUM_FILE_EXTENSION;
+
+			try {
+				if (_exists(s3ChecksumPath)) {
+					touchS3File(s3ChecksumPath);
+				}
+			}
+			catch (TimeoutException timeoutException) {
+				throw new IOException(timeoutException);
+			}
+		}
 	}
 
 	public static void uploadS3File(String s3DestinationPath, File sourceFile)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -89,6 +89,11 @@ public abstract class BasePersistentResource implements PersistentResource {
 	}
 
 	@Override
+	public boolean isTouched() {
+		return _touched;
+	}
+
+	@Override
 	public void touch() {
 		if (_touched) {
 			return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -100,10 +100,14 @@ public abstract class BasePersistentResource implements PersistentResource {
 		}
 
 		synchronized (this) {
-			if (_touched) {
+			if (_touched || _touching) {
 				return;
 			}
 
+			_touching = true;
+		}
+
+		try {
 			if (!isBuildCachingEnabled()) {
 				_touched = true;
 
@@ -142,13 +146,17 @@ public abstract class BasePersistentResource implements PersistentResource {
 
 					System.out.println(
 						"WARNING: Failed to touch " + getType() +
-							" S3 artifact: " + ioException.getMessage());
+							" S3 artifact " + artifact.getName() + ": " +
+								ioException.getMessage());
 				}
 			}
 
 			if (allSucceeded) {
 				_touched = true;
 			}
+		}
+		finally {
+			_touching = false;
 		}
 	}
 
@@ -432,5 +440,6 @@ public abstract class BasePersistentResource implements PersistentResource {
 	private Properties _startProperties;
 	private Status _status;
 	private volatile boolean _touched;
+	private volatile boolean _touching;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -119,9 +119,7 @@ public abstract class BasePersistentResource implements PersistentResource {
 			String dataS3ObjectPath = _getDataS3ObjectPath();
 
 			try {
-				if (CloudBucketUtil.isS3ObjectPathAvailable(
-						dataS3ObjectPath)) {
-
+				if (CloudBucketUtil.isS3ObjectPathAvailable(dataS3ObjectPath)) {
 					CloudBucketUtil.touchS3File(dataS3ObjectPath);
 				}
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -104,30 +104,51 @@ public abstract class BasePersistentResource implements PersistentResource {
 				return;
 			}
 
-			_touched = true;
-		}
+			if (!isBuildCachingEnabled()) {
+				_touched = true;
 
-		if (!isBuildCachingEnabled()) {
-			return;
-		}
+				return;
+			}
 
-		try {
-			if (CloudBucketUtil.isS3ObjectPathAvailable(
-					_getDataS3ObjectPath())) {
+			boolean allSucceeded = true;
 
-				CloudBucketUtil.touchS3File(_getDataS3ObjectPath());
+			String dataS3ObjectPath = _getDataS3ObjectPath();
+
+			try {
+				if (CloudBucketUtil.isS3ObjectPathAvailable(
+						dataS3ObjectPath)) {
+
+					CloudBucketUtil.touchS3File(dataS3ObjectPath);
+				}
+			}
+			catch (IOException ioException) {
+				allSucceeded = false;
+
+				System.out.println(
+					"WARNING: Failed to touch " + getType() + " S3 resource: " +
+						ioException.getMessage());
 			}
 
 			for (Artifact artifact : getArtifacts()) {
-				if (artifact.isAvailable()) {
+				if (!artifact.isAvailable()) {
+					continue;
+				}
+
+				try {
 					CloudBucketUtil.touchS3File(artifact.getS3ObjectPath());
 				}
+				catch (IOException ioException) {
+					allSucceeded = false;
+
+					System.out.println(
+						"WARNING: Failed to touch " + getType() +
+							" S3 artifact: " + ioException.getMessage());
+				}
 			}
-		}
-		catch (IOException ioException) {
-			System.out.println(
-				"WARNING: Failed to touch " + getType() + " S3 resource: " +
-					ioException.getMessage());
+
+			if (allSucceeded) {
+				_touched = true;
+			}
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -151,7 +151,9 @@ public abstract class BasePersistentResource implements PersistentResource {
 				}
 			}
 
-			if (allSucceeded) {
+			_attempts++;
+
+			if (allSucceeded || (_attempts >= _MAX_TOUCH_ATTEMPTS)) {
 				_touched = true;
 			}
 		}
@@ -424,12 +426,15 @@ public abstract class BasePersistentResource implements PersistentResource {
 			getBaseS3ObjectPath(), "/data.json.gz");
 	}
 
+	private static final int _MAX_TOUCH_ATTEMPTS = 2;
+
 	private static final long _MAX_WAIT_TIME = 1000 * 60 * 120;
 
 	private static final Pattern _buildURLPattern = Pattern.compile(
 		"https?://.+/job/(?<jobName>[^/]+)/(?<buildNumber>\\d+)");
 
 	private final Map<String, Artifact> _artifacts = new HashMap<>();
+	private volatile int _attempts;
 	private Boolean _buildCachingEnabled;
 	private final BuildDatabase _buildDatabase;
 	private String _controllerBuildURL;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -52,8 +52,6 @@ public abstract class BasePersistentResource implements PersistentResource {
 			CloudBucketUtil.downloadS3File(
 				new File(destinationDir, artifactName),
 				artifact.getS3ObjectPath());
-
-			touch();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -169,8 +167,6 @@ public abstract class BasePersistentResource implements PersistentResource {
 			}
 			else if (status == Status.SUCCESS) {
 				print(statusMessage);
-
-				touch();
 
 				return;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BasePersistentResource.java
@@ -52,6 +52,8 @@ public abstract class BasePersistentResource implements PersistentResource {
 			CloudBucketUtil.downloadS3File(
 				new File(destinationDir, artifactName),
 				artifact.getS3ObjectPath());
+
+			touch();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -86,6 +88,44 @@ public abstract class BasePersistentResource implements PersistentResource {
 	@Override
 	public Status getStatus() {
 		return _status;
+	}
+
+	@Override
+	public void touch() {
+		if (_touched) {
+			return;
+		}
+
+		synchronized (this) {
+			if (_touched) {
+				return;
+			}
+
+			_touched = true;
+		}
+
+		if (!isBuildCachingEnabled()) {
+			return;
+		}
+
+		try {
+			if (CloudBucketUtil.isS3ObjectPathAvailable(
+					_getDataS3ObjectPath())) {
+
+				CloudBucketUtil.touchS3File(_getDataS3ObjectPath());
+			}
+
+			for (Artifact artifact : getArtifacts()) {
+				if (artifact.isAvailable()) {
+					CloudBucketUtil.touchS3File(artifact.getS3ObjectPath());
+				}
+			}
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"WARNING: Failed to touch " + getType() + " S3 resource: " +
+					ioException.getMessage());
+		}
 	}
 
 	@Override
@@ -129,6 +169,8 @@ public abstract class BasePersistentResource implements PersistentResource {
 			}
 			else if (status == Status.SUCCESS) {
 				print(statusMessage);
+
+				touch();
 
 				return;
 			}
@@ -367,5 +409,6 @@ public abstract class BasePersistentResource implements PersistentResource {
 	private long _producerQueueId;
 	private Properties _startProperties;
 	private Status _status;
+	private volatile boolean _touched;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
@@ -40,6 +40,8 @@ public interface PersistentResource {
 
 	public Type getType();
 
+	public void touch();
+
 	public void upload(File baseDir);
 
 	public void waitForUpdate(long waitTime);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResource.java
@@ -40,6 +40,8 @@ public interface PersistentResource {
 
 	public Type getType();
 
+	public boolean isTouched();
+
 	public void touch();
 
 	public void upload(File baseDir);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
@@ -69,21 +69,24 @@ public class PersistentResourceFactory {
 		List<Callable<Object>> touchCallables = new ArrayList<>();
 
 		for (PersistentResource persistentResource : persistentResources) {
-			if (persistentResource.getStatus() ==
-					PersistentResource.Status.SUCCESS) {
+			if (persistentResource.isTouched() ||
+				(persistentResource.getStatus() !=
+					PersistentResource.Status.SUCCESS)) {
 
-				touchCallables.add(
-					new Callable<Object>() {
-
-						@Override
-						public Object call() {
-							persistentResource.touch();
-
-							return null;
-						}
-
-					});
+				continue;
 			}
+
+			touchCallables.add(
+				new Callable<Object>() {
+
+					@Override
+					public Object call() {
+						persistentResource.touch();
+
+						return null;
+					}
+
+				});
 		}
 
 		if (touchCallables.isEmpty()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/PersistentResourceFactory.java
@@ -6,10 +6,16 @@
 package com.liferay.jenkins.results.parser.persistent.resource;
 
 import com.liferay.jenkins.results.parser.BuildDatabase;
+import com.liferay.jenkins.results.parser.ParallelExecutor;
 import com.liferay.jenkins.results.parser.TopLevelBuild;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author Michael Hashimoto
@@ -46,6 +52,55 @@ public class PersistentResourceFactory {
 		}
 
 		return persistentResource;
+	}
+
+	public static void touchUsedPersistentResources(
+		ExecutorService executorService) {
+
+		PersistentResource[] persistentResources;
+
+		synchronized (PersistentResourceFactory.class) {
+			persistentResources = _persistentResources.values(
+			).toArray(
+				new PersistentResource[_persistentResources.size()]
+			);
+		}
+
+		List<Callable<Object>> touchCallables = new ArrayList<>();
+
+		for (PersistentResource persistentResource : persistentResources) {
+			if (persistentResource.getStatus() ==
+					PersistentResource.Status.SUCCESS) {
+
+				touchCallables.add(
+					new Callable<Object>() {
+
+						@Override
+						public Object call() {
+							persistentResource.touch();
+
+							return null;
+						}
+
+					});
+			}
+		}
+
+		if (touchCallables.isEmpty()) {
+			return;
+		}
+
+		ParallelExecutor<Object> parallelExecutor = new ParallelExecutor<>(
+			touchCallables, executorService, "touch persistent resources");
+
+		try {
+			parallelExecutor.execute();
+		}
+		catch (TimeoutException timeoutException) {
+			System.out.println(
+				"WARNING: Failed to touch persistent resources: " +
+					timeoutException.getMessage());
+		}
 	}
 
 	private static final Map<String, PersistentResource> _persistentResources =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7205

**What is being fixed:** Persistent resources stored in S3 are subject
to object-lifecycle eviction. When a build reuses a cached resource
without updating it, the S3 object's last-modified timestamp is never
refreshed, so actively-used resources (and their checksum files) can
still be evicted. The PersistentResource lifecycle previously had no
mechanism to keep consumed resources alive.

**How it is being fixed:** A new `touch()` operation is added to the
PersistentResource contract and implemented in BasePersistentResource,
which touches the resource's data object and each available artifact
in S3. BaseTopLevelBuild now queues a `touchUsedPersistentResources`
callable alongside its other archive callables, and
PersistentResourceFactory walks the registered resources, skips
anything already touched or not in SUCCESS, and runs the remaining
touches in parallel through ParallelExecutor. CloudBucketUtil.touchS3File
also touches the corresponding checksum object when one exists, so
checksum files do not age out independently. Several refinements
harden the flow: the `_touched` flag is only set on full success (or
after the retry cap) so transient S3 failures can retry on the next
archive cycle, per-artifact touches are isolated in their own
try/catch so one failure does not abort the others, the synchronized
block is narrowed to a `_touching` flag so S3 work does not block
`getStartProperties()` callers on the same monitor, failed-artifact
warnings now include the artifact name, and total attempts are capped
at two to prevent a persistently failing resource from flooding the
log.