### PR TITLE
LRCI-7287 Add service-and-rest-builder batch support (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -3392,6 +3393,18 @@ public abstract class BaseBuild implements Build {
 		return jenkinsReportTableRowElements;
 	}
 
+	private String _getSuiteClassName(JSONObject suiteJSONObject) {
+		JSONArray casesJSONArray = suiteJSONObject.optJSONArray("cases");
+
+		if ((casesJSONArray == null) || casesJSONArray.isEmpty()) {
+			return suiteJSONObject.getString("name");
+		}
+
+		JSONObject caseJSONObject = casesJSONArray.getJSONObject(0);
+
+		return caseJSONObject.getString("className");
+	}
+
 	private synchronized void _initTestClassResults() {
 		if (!isCompleted() || (_testClassResults != null)) {
 			return;
@@ -3442,17 +3455,58 @@ public abstract class BaseBuild implements Build {
 			}
 		}
 
+		Map<String, JSONObject> mergedSuiteJSONObjects = new LinkedHashMap<>();
+
 		for (JSONArray suitesJSONArray : suitesJSONArrays) {
 			for (int i = 0; i < suitesJSONArray.length(); i++) {
 				JSONObject suiteJSONObject = suitesJSONArray.getJSONObject(i);
 
-				TestClassResult testClassResult =
-					TestClassResultFactory.newTestClassResult(
-						this, suiteJSONObject);
+				String suiteClassName = _getSuiteClassName(suiteJSONObject);
 
-				_testClassResults.put(
-					testClassResult.getClassName(), testClassResult);
+				JSONObject mergedSuiteJSONObject = mergedSuiteJSONObjects.get(
+					suiteClassName);
+
+				if (mergedSuiteJSONObject == null) {
+					mergedSuiteJSONObject = new JSONObject();
+
+					mergedSuiteJSONObject.put(
+						"cases", new JSONArray()
+					).put(
+						"duration", 0
+					).put(
+						"name", suiteJSONObject.opt("name")
+					);
+
+					mergedSuiteJSONObjects.put(
+						suiteClassName, mergedSuiteJSONObject);
+				}
+
+				JSONArray casesJSONArray = suiteJSONObject.optJSONArray(
+					"cases");
+
+				if (casesJSONArray != null) {
+					JSONArray mergedCasesJSONArray =
+						mergedSuiteJSONObject.getJSONArray("cases");
+
+					for (int j = 0; j < casesJSONArray.length(); j++) {
+						mergedCasesJSONArray.put(casesJSONArray.get(j));
+					}
+				}
+
+				mergedSuiteJSONObject.put(
+					"duration",
+					mergedSuiteJSONObject.optDouble("duration", 0) +
+						suiteJSONObject.optDouble("duration", 0));
 			}
+		}
+
+		for (JSONObject suiteJSONObject : mergedSuiteJSONObjects.values()) {
+			TestClassResult testClassResult =
+				TestClassResultFactory.newTestClassResult(
+					this, suiteJSONObject);
+
+			_testClassResults.put(
+				testClassResult.getClassName(), testClassResult);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -3488,9 +3488,7 @@ public abstract class BaseBuild implements Build {
 					JSONArray mergedCasesJSONArray =
 						mergedSuiteJSONObject.getJSONArray("cases");
 
-					for (int j = 0; j < casesJSONArray.length(); j++) {
-						mergedCasesJSONArray.put(casesJSONArray.get(j));
-					}
+					mergedCasesJSONArray.putAll(casesJSONArray);
 				}
 
 				mergedSuiteJSONObject.put(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -18,6 +18,7 @@ import com.liferay.jenkins.results.parser.failure.message.generator.PMDFailureMe
 import com.liferay.jenkins.results.parser.failure.message.generator.PlaywrightCompilationFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.PlaywrightTimeoutFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.PluginGitIDFailureMessageGenerator;
+import com.liferay.jenkins.results.parser.failure.message.generator.RESTBuilderFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.SemanticVersioningFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.ServiceBuilderFailureMessageGenerator;
 import com.liferay.jenkins.results.parser.failure.message.generator.SourceFormatFailureMessageGenerator;
@@ -1267,6 +1268,7 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 		new PlaywrightCompilationFailureMessageGenerator(),
 		new PlaywrightTimeoutFailureMessageGenerator(),
 		new PluginGitIDFailureMessageGenerator(),
+		new RESTBuilderFailureMessageGenerator(),
 		new SemanticVersioningFailureMessageGenerator(),
 		new ServiceBuilderFailureMessageGenerator(),
 		new SourceFormatFailureMessageGenerator(),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildFactory.java
@@ -94,6 +94,7 @@ public class BuildFactory {
 						 jobVariant.startsWith("playwright-js") ||
 						 jobVariant.startsWith("rest-builder") ||
 						 jobVariant.startsWith("semantic-versioning") ||
+						 jobVariant.startsWith("service-and-rest-builder") ||
 						 jobVariant.startsWith("service-builder")) {
 
 					return new JUnitDownstreamBuild(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -4288,30 +4288,6 @@ public class JenkinsResultsParserUtil {
 		return _topLevelJobNames.contains(jobName);
 	}
 
-	public static boolean isUnifiedBuilderSupported(String upstreamBranchName) {
-		if (Objects.equals(upstreamBranchName, "master")) {
-			return true;
-		}
-
-		if (upstreamBranchName == null) {
-			return false;
-		}
-
-		Matcher matcher = _quarterlyReleaseYearPattern.matcher(
-			upstreamBranchName);
-
-		if (matcher.matches()) {
-			int year = Integer.parseInt(matcher.group(1));
-			int quarter = Integer.parseInt(matcher.group(2));
-
-			if ((year > 2026) || ((year == 2026) && (quarter >= 2))) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
 	public static boolean isURL(String urlString) {
 		if (isNullOrEmpty(urlString) || !urlString.matches("https?://.+")) {
 			return false;
@@ -7549,8 +7525,6 @@ public class JenkinsResultsParserUtil {
 		"\\$\\{([^\\}]+)\\}");
 	private static final Pattern _poshiFileNamePattern = Pattern.compile(
 		".*\\.(function|macro|path|prose|testcase)");
-	private static final Pattern _quarterlyReleaseYearPattern = Pattern.compile(
-		"release-(\\d{4})\\.q(\\d+).*");
 	private static final Set<String> _redactTokens = new HashSet<>();
 	private static final Pattern _remoteURLAuthorityPattern1 = Pattern.compile(
 		"https://(test-[0-9]+-[0])-aws.liferay.com/");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RootCauseAnalysisToolTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RootCauseAnalysisToolTopLevelBuildRunner.java
@@ -493,6 +493,7 @@ public class RootCauseAnalysisToolTopLevelBuildRunner
 			portalBatchName.startsWith("modules-compile") ||
 			portalBatchName.startsWith("modules-semantic-versioning") ||
 			portalBatchName.startsWith("rest-builder") ||
+			portalBatchName.startsWith("service-and-rest-builder") ||
 			portalBatchName.startsWith("service-builder")) {
 
 			return true;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestBatchFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestBatchFactory.java
@@ -39,6 +39,7 @@ public class TestBatchFactory {
 					 batchName.startsWith("modules-compile") ||
 					 batchName.startsWith("modules-semantic-versioning") ||
 					 batchName.startsWith("rest-builder") ||
+					 batchName.startsWith("service-and-rest-builder") ||
 					 batchName.startsWith("service-builder")) {
 
 				testBatch = new ModulesPortalTestBatch(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestReportFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestReportFactory.java
@@ -36,6 +36,7 @@ public class TestReportFactory {
 		else if (batchName.startsWith("modules-compile") ||
 				 batchName.startsWith("modules-semantic-versioning") ||
 				 batchName.startsWith("rest-builder") ||
+				 batchName.startsWith("service-and-rest-builder") ||
 				 batchName.startsWith("service-builder") ||
 				 batchName.startsWith("workspaces-compile")) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RESTBuilderFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RESTBuilderFailureMessageGenerator.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RESTBuilderFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/RESTBuilderFailureMessageGenerator.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.failure.message.generator;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class RESTBuilderFailureMessageGenerator
+	extends BaseFailureMessageGenerator {
+
+	@Override
+	public String getMessage(String consoleText) {
+		int start = consoleText.lastIndexOf(
+			_TOKEN_ERROR_PROCESSING_REST_CONFIG);
+
+		if (start != -1) {
+			start = consoleText.lastIndexOf("\n", start);
+
+			int end = start + CHARS_CONSOLE_TEXT_SNIPPET_SIZE_MAX;
+
+			end = consoleText.lastIndexOf("\n", end);
+
+			return getConsoleTextSnippet(consoleText, false, start, end);
+		}
+
+		if (consoleText.contains(_TOKEN_DETECTED_REST_BUILDER_CHANGES)) {
+			start = consoleText.indexOf(_TOKEN_GIT_DIFF_VERSION);
+
+			start = consoleText.lastIndexOf("\n", start);
+
+			int end = start + CHARS_CONSOLE_TEXT_SNIPPET_SIZE_MAX;
+
+			end = consoleText.lastIndexOf("\n", end);
+
+			return getConsoleTextSnippet(consoleText, false, start, end);
+		}
+
+		return null;
+	}
+
+	private static final String _TOKEN_DETECTED_REST_BUILDER_CHANGES =
+		"Detected REST builder changes";
+
+	private static final String _TOKEN_ERROR_PROCESSING_REST_CONFIG =
+		"Error processing REST config files";
+
+	private static final String _TOKEN_GIT_DIFF_VERSION = "--- a";
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
@@ -61,7 +61,7 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 			return null;
 		}
 
-		if (_cachedTestClassReportSearched) {
+		if (!_cachedTestClassReportSearched) {
 			getCachedTestClassReport();
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
@@ -1,0 +1,174 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.test.clazz;
+
+import com.liferay.jenkins.results.parser.DownstreamBuildReport;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.TestClassReport;
+import com.liferay.jenkins.results.parser.test.clazz.group.BatchTestClassGroup;
+
+import java.io.File;
+
+import org.json.JSONObject;
+
+/**
+ * @author Brittney Nguyen
+ */
+public abstract class BaseAntTargetTestClass extends BaseTestClass {
+
+	@Override
+	public int compareTo(TestClass testClass) {
+		int result = super.compareTo(testClass);
+
+		if (result != 0) {
+			return result;
+		}
+
+		if (testClass instanceof BaseAntTargetTestClass) {
+			BaseAntTargetTestClass otherBaseAntTargetTestClass =
+				(BaseAntTargetTestClass)testClass;
+
+			String otherAntTargetName =
+				otherBaseAntTargetTestClass.getAntTargetName();
+
+			if ((_antTargetName == null) && (otherAntTargetName == null)) {
+				return 0;
+			}
+
+			if (_antTargetName == null) {
+				return -1;
+			}
+
+			if (otherAntTargetName == null) {
+				return 1;
+			}
+
+			return _antTargetName.compareTo(otherAntTargetName);
+		}
+
+		return 0;
+	}
+
+	public String getAntTargetName() {
+		return _antTargetName;
+	}
+
+	public DownstreamBuildReport getCachedDownstreamBuildReport() {
+		if (!isBuildCachingEnabled()) {
+			return null;
+		}
+
+		if (_cachedTestClassReportSearched) {
+			getCachedTestClassReport();
+		}
+
+		return _cachedDownstreamBuildReport;
+	}
+
+	public TestClassReport getCachedTestClassReport() {
+		if (!isBuildCachingEnabled() || _cachedTestClassReportSearched) {
+			return _cachedTestClassReport;
+		}
+
+		BatchTestClassGroup batchTestClassGroup = getBatchTestClassGroup();
+
+		_cachedTestClassReport = batchTestClassGroup.getCachedTestClassReport(
+			getTestClassName());
+
+		if (_cachedTestClassReport != null) {
+			_cachedDownstreamBuildReport =
+				_cachedTestClassReport.getDownstreamBuildReport();
+		}
+
+		_cachedTestClassReportSearched = true;
+
+		return _cachedTestClassReport;
+	}
+
+	@Override
+	public JSONObject getJSONObject() {
+		JSONObject jsonObject = super.getJSONObject();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(_antTargetName)) {
+			jsonObject.put("ant_target_name", _antTargetName);
+		}
+
+		return jsonObject;
+	}
+
+	@Override
+	public String getTestClassName() {
+		String name = getName();
+
+		return name.replaceAll("/", ".");
+	}
+
+	public String getTestrayMainComponentName() {
+		return _testrayMainComponentName;
+	}
+
+	protected BaseAntTargetTestClass(
+		BatchTestClassGroup batchTestClassGroup, File testClassFile) {
+
+		this(batchTestClassGroup, testClassFile, null);
+	}
+
+	protected BaseAntTargetTestClass(
+		BatchTestClassGroup batchTestClassGroup, File testClassFile,
+		String antTargetName) {
+
+		super(batchTestClassGroup, testClassFile);
+
+		_antTargetName = antTargetName;
+
+		addTestClassMethods();
+
+		File testPropertiesBaseDir = getTestPropertiesBaseDir(
+			getTestClassFile());
+
+		if ((testPropertiesBaseDir != null) && testPropertiesBaseDir.exists()) {
+			_testPropertiesFile = new File(
+				testPropertiesBaseDir, "test.properties");
+
+			_testrayMainComponentName = JenkinsResultsParserUtil.getProperty(
+				JenkinsResultsParserUtil.getProperties(_testPropertiesFile),
+				"testray.main.component.name");
+		}
+		else {
+			_testPropertiesFile = null;
+			_testrayMainComponentName = null;
+		}
+	}
+
+	protected BaseAntTargetTestClass(
+		BatchTestClassGroup batchTestClassGroup, JSONObject jsonObject) {
+
+		super(batchTestClassGroup, jsonObject);
+
+		_antTargetName = jsonObject.optString("ant_target_name", null);
+
+		if (jsonObject.has("test_properties_file")) {
+			_testPropertiesFile = new File(
+				jsonObject.getString("test_properties_file"));
+		}
+		else {
+			_testPropertiesFile = null;
+		}
+
+		_testrayMainComponentName = jsonObject.optString(
+			"testray_main_component_name");
+	}
+
+	protected abstract void addTestClassMethods();
+
+	private final String _antTargetName;
+	private DownstreamBuildReport _cachedDownstreamBuildReport;
+	private TestClassReport _cachedTestClassReport;
+	private boolean _cachedTestClassReportSearched;
+	private final File _testPropertiesFile;
+	private final String _testrayMainComponentName;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/RESTBuilderAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/RESTBuilderAntTargetTestClass.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -12,24 +12,24 @@ import java.io.File;
 import org.json.JSONObject;
 
 /**
- * @author Michael Hashimoto
+ * @author Brittney Nguyen
  */
-public class ServiceBuilderAntTargetTestClass extends BaseAntTargetTestClass {
+public class RESTBuilderAntTargetTestClass extends BaseAntTargetTestClass {
 
-	protected ServiceBuilderAntTargetTestClass(
+	protected RESTBuilderAntTargetTestClass(
 		BatchTestClassGroup batchTestClassGroup, File testClassFile) {
 
 		super(batchTestClassGroup, testClassFile);
 	}
 
-	protected ServiceBuilderAntTargetTestClass(
+	protected RESTBuilderAntTargetTestClass(
 		BatchTestClassGroup batchTestClassGroup, File testClassFile,
 		String antTargetName) {
 
 		super(batchTestClassGroup, testClassFile, antTargetName);
 	}
 
-	protected ServiceBuilderAntTargetTestClass(
+	protected RESTBuilderAntTargetTestClass(
 		BatchTestClassGroup batchTestClassGroup, JSONObject jsonObject) {
 
 		super(batchTestClassGroup, jsonObject);
@@ -37,17 +37,7 @@ public class ServiceBuilderAntTargetTestClass extends BaseAntTargetTestClass {
 
 	@Override
 	protected void addTestClassMethods() {
-		BatchTestClassGroup batchTestClassGroup = getBatchTestClassGroup();
-
-		if (batchTestClassGroup.isUnifiedBuilderSupported()) {
-			addTestClassMethod("build-services");
-
-			return;
-		}
-
-		addTestClassMethod("build-service-counter");
-		addTestClassMethod("build-service-portal");
-		addTestClassMethod("build-service-portlets");
+		addTestClassMethod("build-rests");
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
@@ -75,8 +75,13 @@ public class TestClassFactory {
 				batchTestClassGroup, testClassFile, antTargetName);
 		}
 
-		return new ServiceBuilderAntTargetTestClass(
-			batchTestClassGroup, testClassFile, antTargetName);
+		if (Objects.equals(antTargetName, "build-services")) {
+			return new ServiceBuilderAntTargetTestClass(
+				batchTestClassGroup, testClassFile, antTargetName);
+		}
+
+		throw new IllegalArgumentException(
+			"Unsupported ant target name: " + antTargetName);
 	}
 
 	public static TestClass newTestClass(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
@@ -18,6 +18,7 @@ import com.liferay.jenkins.results.parser.test.clazz.group.PluginsBatchTestClass
 import com.liferay.jenkins.results.parser.test.clazz.group.PluginsGulpBatchTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.RESTBuilderModulesBatchTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.SemVerModulesBatchTestClassGroup;
+import com.liferay.jenkins.results.parser.test.clazz.group.ServiceAndRESTBuilderModulesBatchTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.ServiceBuilderModulesBatchTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.TCKJunitBatchTestClassGroup;
 import com.liferay.jenkins.results.parser.test.clazz.group.WorkspacesCompileBatchTestClassGroup;
@@ -28,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.json.JSONObject;
@@ -62,6 +64,19 @@ public class TestClassFactory {
 		Collections.sort(playwrightJUnitTestClasses);
 
 		return playwrightJUnitTestClasses;
+	}
+
+	public static TestClass newAntTargetTestClass(
+		BatchTestClassGroup batchTestClassGroup, File testClassFile,
+		String antTargetName) {
+
+		if (Objects.equals(antTargetName, "build-rests")) {
+			return new RESTBuilderAntTargetTestClass(
+				batchTestClassGroup, testClassFile, antTargetName);
+		}
+
+		return new ServiceBuilderAntTargetTestClass(
+			batchTestClassGroup, testClassFile, antTargetName);
 	}
 
 	public static TestClass newTestClass(
@@ -313,7 +328,51 @@ public class TestClassFactory {
 					batchTestClassGroup, testClassFile);
 			}
 			else if (batchTestClassGroup instanceof
+						ServiceAndRESTBuilderModulesBatchTestClassGroup) {
+
+				String antTargetName = null;
+
+				if (jsonObject != null) {
+					antTargetName = jsonObject.optString(
+						"ant_target_name", null);
+				}
+
+				if (Objects.equals(antTargetName, "build-rests")) {
+					if (jsonObject != null) {
+						return new RESTBuilderAntTargetTestClass(
+							batchTestClassGroup, jsonObject);
+					}
+
+					return new RESTBuilderAntTargetTestClass(
+						batchTestClassGroup, testClassFile, antTargetName);
+				}
+
+				if (jsonObject != null) {
+					return new ServiceBuilderAntTargetTestClass(
+						batchTestClassGroup, jsonObject);
+				}
+
+				return new ServiceBuilderAntTargetTestClass(
+					batchTestClassGroup, testClassFile, "build-services");
+			}
+			else if (batchTestClassGroup instanceof
 						RESTBuilderModulesBatchTestClassGroup) {
+
+				if ((testClassFile == null) && jsonObject.has("file")) {
+					testClassFile = new File(jsonObject.getString("file"));
+				}
+
+				String testClassFileName = testClassFile.getName();
+
+				if (testClassFileName.endsWith(".xml")) {
+					if (jsonObject != null) {
+						return new RESTBuilderAntTargetTestClass(
+							batchTestClassGroup, jsonObject);
+					}
+
+					return new RESTBuilderAntTargetTestClass(
+						batchTestClassGroup, testClassFile);
+				}
 
 				if (jsonObject != null) {
 					return new RESTBuilderModulesTestClass(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -508,6 +508,25 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 		return _testAnalyticsCloud;
 	}
 
+	public boolean isUnifiedBuilderSupported() {
+		JobProperty jobProperty = getJobProperty(
+			"test.batch.unified.builder.supported");
+
+		if (jobProperty == null) {
+			return false;
+		}
+
+		String jobPropertyValue = jobProperty.getValue();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(jobPropertyValue)) {
+			return false;
+		}
+
+		recordJobProperty(jobProperty);
+
+		return Boolean.parseBoolean(jobPropertyValue);
+	}
+
 	protected BatchTestClassGroup(
 		JSONObject jsonObject, PortalTestClassJob portalTestClassJob) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ModulesSegmentTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ModulesSegmentTestClassGroup.java
@@ -6,7 +6,7 @@
 package com.liferay.jenkins.results.parser.test.clazz.group;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
-import com.liferay.jenkins.results.parser.test.clazz.ServiceBuilderAntTargetTestClass;
+import com.liferay.jenkins.results.parser.test.clazz.BaseAntTargetTestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 
@@ -64,7 +64,7 @@ public class ModulesSegmentTestClassGroup extends SegmentTestClassGroup {
 			axisIndex);
 
 		for (TestClass testClass : axisTestClassGroup.getTestClasses()) {
-			if (testClass instanceof ServiceBuilderAntTargetTestClass) {
+			if (testClass instanceof BaseAntTargetTestClass) {
 				continue;
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/RESTBuilderModulesBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/RESTBuilderModulesBatchTestClassGroup.java
@@ -8,6 +8,7 @@ package com.liferay.jenkins.results.parser.test.clazz.group;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
 import com.liferay.jenkins.results.parser.PortalTestClassJob;
+import com.liferay.jenkins.results.parser.test.clazz.TestClassFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,6 +94,17 @@ public class RESTBuilderModulesBatchTestClassGroup
 	protected void setTestClasses() throws IOException {
 		PortalGitWorkingDirectory portalGitWorkingDirectory =
 			getPortalGitWorkingDirectory();
+
+		File portalImplBuildFile = new File(
+			portalGitWorkingDirectory.getWorkingDirectory(),
+			"portal-impl/build.xml");
+
+		if (isUnifiedBuilderSupported()) {
+			addTestClass(
+				TestClassFactory.newTestClass(this, portalImplBuildFile));
+
+			return;
+		}
 
 		File portalModulesBaseDir = new File(
 			portalGitWorkingDirectory.getWorkingDirectory(), "modules");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceAndRESTBuilderModulesBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceAndRESTBuilderModulesBatchTestClassGroup.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.test.clazz.group;
+
+import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
+import com.liferay.jenkins.results.parser.PortalTestClassJob;
+import com.liferay.jenkins.results.parser.test.clazz.TestClassFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.json.JSONObject;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class ServiceAndRESTBuilderModulesBatchTestClassGroup
+	extends ModulesBatchTestClassGroup {
+
+	protected ServiceAndRESTBuilderModulesBatchTestClassGroup(
+		JSONObject jsonObject, PortalTestClassJob portalTestClassJob) {
+
+		super(jsonObject, portalTestClassJob);
+	}
+
+	protected ServiceAndRESTBuilderModulesBatchTestClassGroup(
+		String batchName, PortalTestClassJob portalTestClassJob) {
+
+		super(batchName, portalTestClassJob);
+	}
+
+	@Override
+	protected void setTestClasses() throws IOException {
+		if (!isUnifiedBuilderSupported()) {
+			return;
+		}
+
+		PortalGitWorkingDirectory portalGitWorkingDirectory =
+			getPortalGitWorkingDirectory();
+
+		File portalImplBuildFile = new File(
+			portalGitWorkingDirectory.getWorkingDirectory(),
+			"portal-impl/build.xml");
+
+		addTestClass(
+			TestClassFactory.newAntTargetTestClass(
+				this, portalImplBuildFile, "build-services"));
+		addTestClass(
+			TestClassFactory.newAntTargetTestClass(
+				this, portalImplBuildFile, "build-rests"));
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceAndRESTBuilderModulesBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceAndRESTBuilderModulesBatchTestClassGroup.java
@@ -34,10 +34,6 @@ public class ServiceAndRESTBuilderModulesBatchTestClassGroup
 
 	@Override
 	protected void setTestClasses() throws IOException {
-		if (!isUnifiedBuilderSupported()) {
-			return;
-		}
-
 		PortalGitWorkingDirectory portalGitWorkingDirectory =
 			getPortalGitWorkingDirectory();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroup.java
@@ -99,9 +99,7 @@ public class ServiceBuilderModulesBatchTestClassGroup
 			portalGitWorkingDirectory.getWorkingDirectory(),
 			"portal-impl/build.xml");
 
-		if (JenkinsResultsParserUtil.isUnifiedBuilderSupported(
-				portalGitWorkingDirectory.getUpstreamBranchName())) {
-
+		if (isUnifiedBuilderSupported()) {
 			addTestClass(
 				TestClassFactory.newTestClass(this, portalImplBuildFile));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesSegmentTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesSegmentTestClassGroup.java
@@ -5,9 +5,6 @@
 
 package com.liferay.jenkins.results.parser.test.clazz.group;
 
-import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
-import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
-
 import org.json.JSONObject;
 
 /**
@@ -22,12 +19,8 @@ public class ServiceBuilderModulesSegmentTestClassGroup
 
 		sb.append(super.getTestCasePropertiesContent());
 
-		PortalGitWorkingDirectory portalGitWorkingDirectory =
-			_serviceBuilderModulesBatchTestClassGroup.
-				getPortalGitWorkingDirectory();
-
-		if (JenkinsResultsParserUtil.isUnifiedBuilderSupported(
-				portalGitWorkingDirectory.getUpstreamBranchName())) {
+		if (_serviceBuilderModulesBatchTestClassGroup.
+				isUnifiedBuilderSupported()) {
 
 			return sb.toString();
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/TestClassGroupFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/TestClassGroupFactory.java
@@ -564,6 +564,18 @@ public class TestClassGroupFactory {
 						batchName, portalTestClassJob);
 				}
 			}
+			else if (batchName.startsWith("service-and-rest-builder")) {
+				if (jsonObject != null) {
+					batchTestClassGroup =
+						new ServiceAndRESTBuilderModulesBatchTestClassGroup(
+							jsonObject, portalTestClassJob);
+				}
+				else {
+					batchTestClassGroup =
+						new ServiceAndRESTBuilderModulesBatchTestClassGroup(
+							batchName, portalTestClassJob);
+				}
+			}
 			else if (batchName.startsWith("service-builder")) {
 				if (jsonObject != null) {
 					batchTestClassGroup =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
@@ -260,31 +260,39 @@ public class AntTargetBatchBuildTestrayCaseResult
 	}
 
 	private TestReport _getAntTargetTestReport() {
+		if (_antTargetTestReportSearched) {
+			return _antTargetTestReport;
+		}
+
+		_antTargetTestReportSearched = true;
+
 		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
 
 		if (baseAntTargetTestClass == null) {
-			return null;
+			return _antTargetTestReport;
 		}
 
 		String antTargetName = baseAntTargetTestClass.getAntTargetName();
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(antTargetName)) {
-			return null;
+			return _antTargetTestReport;
 		}
 
 		TestClassReport testClassReport = getTestClassReport();
 
 		if (testClassReport == null) {
-			return null;
+			return _antTargetTestReport;
 		}
 
 		for (TestReport testReport : testClassReport.getTestReports()) {
 			if (Objects.equals(antTargetName, testReport.getTestName())) {
-				return testReport;
+				_antTargetTestReport = testReport;
+
+				break;
 			}
 		}
 
-		return null;
+		return _antTargetTestReport;
 	}
 
 	private String _getTestClassName() {
@@ -295,6 +303,8 @@ public class AntTargetBatchBuildTestrayCaseResult
 		return testClassName.replaceAll("/", ".");
 	}
 
+	private TestReport _antTargetTestReport;
+	private boolean _antTargetTestReportSearched;
 	private TestClassReport _testClassReport;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
@@ -11,7 +11,7 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.TestClassReport;
 import com.liferay.jenkins.results.parser.TestReport;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
-import com.liferay.jenkins.results.parser.test.clazz.ServiceBuilderAntTargetTestClass;
+import com.liferay.jenkins.results.parser.test.clazz.BaseAntTargetTestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
@@ -23,7 +23,7 @@ import java.util.Objects;
  */
 public class AntTargetBatchBuildTestrayCaseResult
 	extends BatchBuildTestrayCaseResult
-		<ServiceBuilderAntTargetTestClass, TestClassMethod> {
+		<BaseAntTargetTestClass, TestClassMethod> {
 
 	public AntTargetBatchBuildTestrayCaseResult(
 		AxisTestClassGroup axisTestClassGroup, TestClass testClass,
@@ -34,11 +34,10 @@ public class AntTargetBatchBuildTestrayCaseResult
 
 	@Override
 	public String getComponentName() {
-		ServiceBuilderAntTargetTestClass serviceBuilderAntTargetTestClass =
-			getTestClass();
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
 
 		String componentName =
-			serviceBuilderAntTargetTestClass.getTestrayMainComponentName();
+			baseAntTargetTestClass.getTestrayMainComponentName();
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(componentName)) {
 			return super.getComponentName();
@@ -49,6 +48,12 @@ public class AntTargetBatchBuildTestrayCaseResult
 
 	@Override
 	public long getDuration() {
+		TestReport testReport = _getAntTargetTestReport();
+
+		if (testReport != null) {
+			return testReport.getDuration();
+		}
+
 		TestClassReport testClassReport = getTestClassReport();
 
 		if (testClassReport == null) {
@@ -60,11 +65,13 @@ public class AntTargetBatchBuildTestrayCaseResult
 
 	@Override
 	public String getErrors() {
+		TestReport antTargetTestReport = _getAntTargetTestReport();
+
 		TestClassReport testClassReport = getTestClassReport();
 
 		BuildReport buildReport = getBuildReport();
 
-		if (testClassReport == null) {
+		if ((antTargetTestReport == null) && (testClassReport == null)) {
 			if (buildReport == null) {
 				return "Unable to run build on CI";
 			}
@@ -88,12 +95,22 @@ public class AntTargetBatchBuildTestrayCaseResult
 
 		StringBuilder sb = new StringBuilder();
 
-		for (TestReport testReport : testClassReport.getTestReports()) {
-			if (testReport.isFailing()) {
-				sb.append(testReport.getTestName());
+		if (antTargetTestReport != null) {
+			if (antTargetTestReport.isFailing()) {
+				sb.append(antTargetTestReport.getTestName());
 				sb.append(": ");
-				sb.append(testReport.getErrorStackTrace());
+				sb.append(antTargetTestReport.getErrorStackTrace());
 				sb.append("\n");
+			}
+		}
+		else {
+			for (TestReport testReport : testClassReport.getTestReports()) {
+				if (testReport.isFailing()) {
+					sb.append(testReport.getTestName());
+					sb.append(": ");
+					sb.append(testReport.getErrorStackTrace());
+					sb.append("\n");
+				}
 			}
 		}
 
@@ -124,16 +141,21 @@ public class AntTargetBatchBuildTestrayCaseResult
 
 	@Override
 	public String getName() {
-		ServiceBuilderAntTargetTestClass serviceBuilderAntTargetTestClass =
-			getTestClass();
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
 
-		if (serviceBuilderAntTargetTestClass == null) {
+		if (baseAntTargetTestClass == null) {
 			return super.getName();
 		}
 
+		String antTargetName = baseAntTargetTestClass.getAntTargetName();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(antTargetName)) {
+			return JenkinsResultsParserUtil.combine(
+				getBatchName(), "[", antTargetName, "]");
+		}
+
 		return JenkinsResultsParserUtil.combine(
-			getBatchName(), "[", serviceBuilderAntTargetTestClass.getName(),
-			"]");
+			getBatchName(), "[", baseAntTargetTestClass.getName(), "]");
 	}
 
 	@Override
@@ -142,6 +164,20 @@ public class AntTargetBatchBuildTestrayCaseResult
 
 		if (buildReport == null) {
 			return Status.UNTESTED;
+		}
+
+		TestReport antTargetTestReport = _getAntTargetTestReport();
+
+		if (antTargetTestReport != null) {
+			if (antTargetTestReport.isFailing()) {
+				return Status.FAILED;
+			}
+
+			if (antTargetTestReport.isSkipped()) {
+				return Status.UNTESTED;
+			}
+
+			return Status.PASSED;
 		}
 
 		TestClassReport testClassReport = getTestClassReport();
@@ -170,12 +206,11 @@ public class AntTargetBatchBuildTestrayCaseResult
 			return _testClassReport;
 		}
 
-		ServiceBuilderAntTargetTestClass serviceBuilderAntTargetTestClass =
-			getTestClass();
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
 
-		if (serviceBuilderAntTargetTestClass.isBuildCachingEnabled()) {
+		if (baseAntTargetTestClass.isBuildCachingEnabled()) {
 			TestClassReport cachedTestClassReport =
-				serviceBuilderAntTargetTestClass.getCachedTestClassReport();
+				baseAntTargetTestClass.getCachedTestClassReport();
 
 			if (cachedTestClassReport != null) {
 				_testClassReport = cachedTestClassReport;
@@ -208,13 +243,11 @@ public class AntTargetBatchBuildTestrayCaseResult
 
 	@Override
 	protected void initBuildReport() {
-		ServiceBuilderAntTargetTestClass serviceBuilderAntTargetTestClass =
-			getTestClass();
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
 
-		if (serviceBuilderAntTargetTestClass.isBuildCachingEnabled()) {
+		if (baseAntTargetTestClass.isBuildCachingEnabled()) {
 			DownstreamBuildReport cachedDownstreamBuildReport =
-				serviceBuilderAntTargetTestClass.
-					getCachedDownstreamBuildReport();
+				baseAntTargetTestClass.getCachedDownstreamBuildReport();
 
 			if (cachedDownstreamBuildReport != null) {
 				setBuildReport(cachedDownstreamBuildReport);
@@ -226,11 +259,38 @@ public class AntTargetBatchBuildTestrayCaseResult
 		super.initBuildReport();
 	}
 
-	private String _getTestClassName() {
-		ServiceBuilderAntTargetTestClass serviceBuilderAntTargetTestClass =
-			getTestClass();
+	private TestReport _getAntTargetTestReport() {
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
 
-		String testClassName = serviceBuilderAntTargetTestClass.getName();
+		if (baseAntTargetTestClass == null) {
+			return null;
+		}
+
+		String antTargetName = baseAntTargetTestClass.getAntTargetName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(antTargetName)) {
+			return null;
+		}
+
+		TestClassReport testClassReport = getTestClassReport();
+
+		if (testClassReport == null) {
+			return null;
+		}
+
+		for (TestReport testReport : testClassReport.getTestReports()) {
+			if (Objects.equals(antTargetName, testReport.getTestName())) {
+				return testReport;
+			}
+		}
+
+		return null;
+	}
+
+	private String _getTestClassName() {
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
+
+		String testClassName = baseAntTargetTestClass.getName();
 
 		return testClassName.replaceAll("/", ".");
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -8,7 +8,7 @@ package com.liferay.jenkins.results.parser.testray;
 import com.liferay.jenkins.results.parser.Build;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
-import com.liferay.jenkins.results.parser.test.clazz.ServiceBuilderAntTargetTestClass;
+import com.liferay.jenkins.results.parser.test.clazz.BaseAntTargetTestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClassMethod;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
@@ -71,7 +71,7 @@ public class TestrayFactory {
 					topLevelBuildReport);
 			}
 			else if (axisTestClassGroup instanceof ModulesAxisTestClassGroup) {
-				if (testClass instanceof ServiceBuilderAntTargetTestClass) {
+				if (testClass instanceof BaseAntTargetTestClass) {
 					return new AntTargetBatchBuildTestrayCaseResult(
 						axisTestClassGroup, testClass, testrayBuild,
 						topLevelBuildReport);

--- a/test.properties
+++ b/test.properties
@@ -2435,6 +2435,8 @@
     test.batch.target.axis.duration[modules-unit]=3600000
     test.batch.target.axis.duration[playwright-*]=1800000
 
+    test.batch.unified.builder.supported[service-builder]=true
+
     test.hotfix.changes[test-portal-hotfix-release]=true
 
     #


### PR DESCRIPTION
[LRCI-7287](https://liferay.atlassian.net/browse/LRCI-7287)

Revises [#4243](https://github.com/pyoo47/liferay-portal/pull/4243) (opened by @brittneyq) with the following follow-up commits:

- [e2af7ab9810c](https://github.com/pyoo47/liferay-portal/commit/e2af7ab9810c06618d9707ab7aaf54e578cea697) LRCI-7287 Always emit test classes for service-and-rest-builder batch
- [98148e930ce2](https://github.com/pyoo47/liferay-portal/commit/98148e930ce214a3f3cc4534ab561be5d96ede5a) LRCI-7287 Fail loudly on unsupported ant target in TestClassFactory
