### PR TITLE
LRCI-7279 Use credential configuration for scancode + LPD-87418 GCloud Translator

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
+++ b/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
@@ -469,6 +469,16 @@ definition {
 
 	@summary = "Default summary"
 	macro setGoogleCloudTranslationServiceKey() {
+		var wifCredentialsFile = "/root/.gcloud/translate.json";
+
+		var wifCredentialsFileExists = FileUtil.exists(${wifCredentialsFile});
+
+		if (${wifCredentialsFileExists} == "true") {
+			var attributes = FileUtil.read(${wifCredentialsFile});
+
+			return ${attributes};
+		}
+
 		var lineSeparater = "\n";
 		var value1 = PropsUtil.get("google.cloud.translation.service.key.type");
 		var value2 = PropsUtil.get("google.cloud.translation.service.key.project.id");

--- a/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
+++ b/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/translator/GoogleCloudTranslator.java
@@ -5,7 +5,7 @@
 
 package com.liferay.translation.translator.google.cloud.internal.translator;
 
-import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.translate.Language;
 import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateOptions;
@@ -151,13 +151,12 @@ public class GoogleCloudTranslator extends BaseTranslator {
 		String serviceAccountPrivateKey =
 			googleCloudTranslatorConfiguration.serviceAccountPrivateKey();
 
-		ServiceAccountCredentials serviceAccountCredentials = null;
+		GoogleCredentials googleCredentials = null;
 
 		try (InputStream inputStream = new ByteArrayInputStream(
 				serviceAccountPrivateKey.getBytes())) {
 
-			serviceAccountCredentials = ServiceAccountCredentials.fromStream(
-				inputStream);
+			googleCredentials = GoogleCredentials.fromStream(inputStream);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
@@ -170,7 +169,7 @@ public class GoogleCloudTranslator extends BaseTranslator {
 		return defaultTranslateFactory.create(
 			TranslateOptions.newBuilder(
 			).setCredentials(
-				serviceAccountCredentials
+				googleCredentials
 			).build());
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -719,10 +719,6 @@ public class CloudBucketUtil {
 			String destination, String source)
 		throws IOException {
 
-		StringBuilder sb = new StringBuilder();
-
-		sb.append("gcloud auth activate-service-account --key-file ");
-
 		String gcpApplicationCredentialFilePath = null;
 
 		if (destination.startsWith(GCP_BUCKET_PATH_JENKINS_CI_DATA) ||
@@ -752,9 +748,15 @@ public class CloudBucketUtil {
 				gcpApplicationCredentialFilePath);
 
 			if (gcpApplicationCredentialFile.exists()) {
-				sb.append(gcpApplicationCredentialFilePath);
+				String credentialFilename = gcpApplicationCredentialFile.getName();
 
-				return sb.toString();
+				String configurationName = credentialFilename.substring(
+					0, credentialFilename.lastIndexOf('.'));
+
+				return StringBundler.concat(
+					"(gcloud config configurations activate ", configurationName,
+					" --quiet || gcloud auth login --cred-file=",
+					gcpApplicationCredentialFilePath, " --quiet)");
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -760,6 +760,9 @@ public class CloudBucketUtil {
 				sb.append(configurationName);
 				sb.append(" --quiet || gcloud auth login --cred-file=");
 				sb.append(gcpApplicationCredentialFilePath);
+				sb.append(" --quiet || gcloud auth activate-service-account");
+				sb.append(" --key-file=");
+				sb.append(gcpApplicationCredentialFilePath);
 				sb.append(" --quiet)");
 
 				return sb.toString();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -748,15 +748,21 @@ public class CloudBucketUtil {
 				gcpApplicationCredentialFilePath);
 
 			if (gcpApplicationCredentialFile.exists()) {
-				String credentialFilename = gcpApplicationCredentialFile.getName();
+				String credentialFileName =
+					gcpApplicationCredentialFile.getName();
 
-				String configurationName = credentialFilename.substring(
-					0, credentialFilename.lastIndexOf('.'));
+				String configurationName = credentialFileName.substring(
+					0, credentialFileName.lastIndexOf('.'));
 
-				return StringBundler.concat(
-					"(gcloud config configurations activate ", configurationName,
-					" --quiet || gcloud auth login --cred-file=",
-					gcpApplicationCredentialFilePath, " --quiet)");
+				StringBuilder sb = new StringBuilder();
+
+				sb.append("(gcloud config configurations activate ");
+				sb.append(configurationName);
+				sb.append(" --quiet || gcloud auth login --cred-file=");
+				sb.append(gcpApplicationCredentialFilePath);
+				sb.append(" --quiet)");
+
+				return sb.toString();
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
@@ -367,11 +367,9 @@ public class ScanCodeCloudBucket {
 
 	private Storage _getStorage() {
 		try {
-			String scancodeCredentialsPath =
+			Storage storage = _getBucketStorage(
 				JenkinsResultsParserUtil.getBuildProperty(
-					"google.application.crendential.file[scancode]");
-
-			Storage storage = _getBucketStorage(scancodeCredentialsPath);
+					"google.application.crendential.file[scancode]"));
 
 			if (storage != null) {
 				return storage;
@@ -380,19 +378,16 @@ public class ScanCodeCloudBucket {
 		catch (Exception exception) {
 		}
 
-		Storage storage = null;
-
 		try {
-			String credentials = JenkinsResultsParserUtil.getBuildProperty(
-				"scancode.credentials.file");
-
-			storage = _getBucketStorage(credentials);
+			return _getBucketStorage(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"scancode.credentials.file"));
 		}
 		catch (Exception exception) {
 			exception.printStackTrace();
 		}
 
-		return storage;
+		return null;
 	}
 
 	private static final Pattern _fileNamePattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser.scancode;
 
 import com.google.api.gax.paging.Page;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -336,19 +337,57 @@ public class ScanCodeCloudBucket {
 		return storage.get(getName());
 	}
 
+	private Storage _getBucketStorage(String credentialsPath) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(credentialsPath)) {
+			return null;
+		}
+
+		File credentialsFile = new File(credentialsPath);
+
+		if (!credentialsFile.exists()) {
+			return null;
+		}
+
+		try {
+			Storage storage = StorageOptions.newBuilder(
+			).setCredentials(
+				GoogleCredentials.fromStream(
+					new FileInputStream(credentialsFile))
+			).build(
+			).getService();
+
+			if (storage.get(getName()) != null) {
+				return storage;
+			}
+		}
+		catch (Exception exception) {
+		}
+
+		return null;
+	}
+
 	private Storage _getStorage() {
+		try {
+			String scancodeCredentialsPath =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"google.application.crendential.file[scancode]");
+
+			Storage storage = _getBucketStorage(scancodeCredentialsPath);
+
+			if (storage != null) {
+				return storage;
+			}
+		}
+		catch (Exception exception) {
+		}
+
 		Storage storage = null;
 
 		try {
 			String credentials = JenkinsResultsParserUtil.getBuildProperty(
 				"scancode.credentials.file");
 
-			storage = StorageOptions.newBuilder(
-			).setCredentials(
-				ServiceAccountCredentials.fromStream(
-					new FileInputStream(credentials))
-			).build(
-			).getService();
+			storage = _getBucketStorage(credentials);
 		}
 		catch (Exception exception) {
 			exception.printStackTrace();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
@@ -7,7 +7,6 @@ package com.liferay.jenkins.results.parser.scancode;
 
 import com.google.api.gax.paging.Page;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;


### PR DESCRIPTION
## Related JIRA tickets

- [LRCI-7279](https://liferay.atlassian.net/browse/LRCI-7279)
- [LPD-87418](https://liferay.atlassian.net/browse/LPD-87418)

## Summary

- LRCI-7279: switch scancode credential storage to prefer credential configuration with a fallback path; add a third backwards-compatible `gcloud auth activate-service-account` fallback in `CloudBucketUtil` so hosts still running the old docker image (with tab-indented service-account-key JSONs) can still authenticate.
- LPD-87418: accept Workload Identity Federation credentials in Google Cloud Translator and prefer `/root/.gcloud/translate.json` in `setGoogleCloudTranslationServiceKey`.

## Commits

- `LRCI-7279` Try to use credential configuration first
- `LRCI-7279` Remove unused ServiceAccountCredentials import
- `LRCI-7279` Fix StringBundler compile error and rename to credentialFileName
- `LRCI-7279` Simplify scancode credential storage fallback
- `LRCI-7279` Add backwards-compatible activate-service-account fallback in GCP authentication chain
- `LPD-87418` Accept Workload Identity Federation credentials in Google Cloud Translator
- `LPD-87418` Prefer /root/.gcloud/translate.json in setGoogleCloudTranslationServiceKey macro

## Test plan

- [ ] Self-review the diff against latest upstream/master.
- [ ] CI run on `test-1-43` validates the three-way auth fallback chain works on hosts still on the old docker image.