### PR TITLE
LRCI-7380 Introduce SHANotReachableException for workspace git setup failures

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1533,10 +1533,8 @@ public abstract class BaseWorkspaceGitRepository
 		if (!gitWorkingDirectory.localSHAExists(sha) ||
 			!gitWorkingDirectory.refContainsSHA(remoteGitRef.getSHA(), sha)) {
 
-			throw new RuntimeException(
-				JenkinsResultsParserUtil.combine(
-					"SHA ", sha, " was not found in branch \"", branchName,
-					"\" on ", remoteGitRef.getRemoteURL()));
+			throw new SHANotReachableException(
+				sha, branchName, remoteGitRef.getRemoteURL());
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SHANotReachableException.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SHANotReachableException.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+/**
+ * @author Peter Yoo
+ */
+public class SHANotReachableException extends RuntimeException {
+
+	public SHANotReachableException(
+		String sha, String branchName, String remoteURL) {
+
+		super(
+			JenkinsResultsParserUtil.combine(
+				"SHA ", sha, " was not found in branch \"", branchName,
+				"\" on ", remoteURL));
+
+		_sha = sha;
+		_branchName = branchName;
+		_remoteURL = remoteURL;
+	}
+
+	public String getBranchName() {
+		return _branchName;
+	}
+
+	public String getRemoteURL() {
+		return _remoteURL;
+	}
+
+	public String getSHA() {
+		return _sha;
+	}
+
+	private final String _branchName;
+	private final String _remoteURL;
+	private final String _sha;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/InvalidGitCommitSHAFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/InvalidGitCommitSHAFailureMessageGenerator.java
@@ -29,6 +29,6 @@ public class InvalidGitCommitSHAFailureMessageGenerator
 	private static final String _TOKEN_SHA = "SHA";
 
 	private static final String _TOKEN_WAS_NOT_FOUND_IN_BRANCH =
-		" was not found in branch '";
+		" was not found in branch \"";
 
 }


### PR DESCRIPTION
- [LRCI-7380](https://liferay.atlassian.net/browse/LRCI-7380)

## Summary

Introduces `SHANotReachableException extends RuntimeException` carrying the SHA, branch name, and remote URL as structured fields, and replaces the single throw site in `BaseWorkspaceGitRepository._validateSHAInRemoteGitRef`. The message string is byte-identical to the previous `RuntimeException` text so any log-based matchers continue to operate against the same console output.

The companion `liferay-jenkins-ee` consumer (PR pyoo47/liferay-jenkins-ee#4806) catches this typed exception in the `prepare-workspace` bsh block and posts a templated PR comment to surface the force-push race condition that LRCI-7380 targets.

This branch also fixes `InvalidGitCommitSHAFailureMessageGenerator` — its matcher token used a single quote that never matched the actual exception text (which uses an escaped double quote). The fix is byte-aligned with both the pre-LRCI-7380 generic `RuntimeException` and the new typed exception, so it benefits historical builds whose console logs are still consulted as well as new builds.

## Commits

- `LRCI-7380 Introduce SHANotReachableException for workspace git setup failures`
- `LRCI-7380 Fix InvalidGitCommitSHAFailureMessageGenerator to match the actual exception text`