### PR TITLE
LRCI-7287 Combine rest-builder and service-builder into a unified batch

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -331,6 +331,35 @@ mariadb.executable=${mariadb.executable}]]></echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="deploy-and-execute-ant-target-builder">
+		<attribute name="ant.target.file" />
+		<attribute name="ant.target.name" />
+		<attribute name="builder.type" />
+		<attribute name="tooling.dir" />
+
+		<sequential>
+			<if>
+				<available file="@{tooling.dir}" />
+				<then>
+					<gradle-execute dir="@{tooling.dir}" task="deploy">
+						<arg value="clean" />
+					</gradle-execute>
+				</then>
+			</if>
+
+			<exec executable="git">
+				<arg value="add" />
+				<arg value="--all" />
+			</exec>
+
+			<execute-ant-target-builder
+				ant.target.file="@{ant.target.file}"
+				ant.target.name="@{ant.target.name}"
+				builder.type="@{builder.type}"
+			/>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="deploy-release-dependency-modules-post-startup">
 		<sequential>
 			<get-release-dependency-modules
@@ -524,35 +553,6 @@ mariadb.executable=${mariadb.executable}]]></echo>
 					</if>
 				</finally>
 			</trycatch>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="deploy-and-execute-ant-target-builder">
-		<attribute name="ant.target.file" />
-		<attribute name="ant.target.name" />
-		<attribute name="builder.type" />
-		<attribute name="tooling.dir" />
-
-		<sequential>
-			<if>
-				<available file="@{tooling.dir}" />
-				<then>
-					<gradle-execute dir="@{tooling.dir}" task="deploy">
-						<arg value="clean" />
-					</gradle-execute>
-				</then>
-			</if>
-
-			<exec executable="git">
-				<arg value="add" />
-				<arg value="--all" />
-			</exec>
-
-			<execute-ant-target-builder
-				ant.target.file="@{ant.target.file}"
-				ant.target.name="@{ant.target.name}"
-				builder.type="@{builder.type}"
-			/>
 		</sequential>
 	</macrodef>
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -401,7 +401,13 @@ mariadb.executable=${mariadb.executable}]]></echo>
 		<attribute name="ant.target.file" />
 
 		<sequential>
-			<trycatch property="ant.target.failure">
+			<local name="builder.type" />
+
+			<condition else="build services" property="builder.type" value="REST builder">
+				<equals arg1="@{ant.target.name}" arg2="build-rests" />
+			</condition>
+
+			<trycatch property="ant.target.failure" reference="ant.target.failure.ref">
 				<try>
 					<beanshell>
 						project.setProperty("ant.target.start.time", String.valueOf(System.currentTimeMillis()));
@@ -449,7 +455,33 @@ mariadb.executable=${mariadb.executable}]]></echo>
 					/>
 				</try>
 				<catch>
+					<var name="ant.target.failure.full.stack" unset="true" />
+
+					<beanshell>
+						<![CDATA[
+							import java.io.PrintWriter;
+							import java.io.StringWriter;
+
+							Object reference = project.getReference("ant.target.failure.ref");
+
+							if (!(reference instanceof Throwable)) {
+								return;
+							}
+
+							Throwable throwable = (Throwable)reference;
+
+							StringWriter stringWriter = new StringWriter();
+							PrintWriter printWriter = new PrintWriter(stringWriter);
+
+							throwable.printStackTrace(printWriter);
+
+							project.setProperty("ant.target.failure.full.stack", stringWriter.toString());
+						]]>
+					</beanshell>
+
 					<record action="stop" name="${project.dir}/execute.ant.target.log" />
+
+					<echo>${ant.target.failure.full.stack}</echo>
 
 					<local name="execute.ant.target.log" />
 
@@ -464,13 +496,13 @@ mariadb.executable=${mariadb.executable}]]></echo>
 
 					<local name="ant.target.failure.stacktrace" />
 
-					<condition else="${ant.target.failure}" property="ant.target.failure.stacktrace" value="${console.log.failure.message}">
+					<condition else="${ant.target.failure.full.stack}" property="ant.target.failure.stacktrace" value="${console.log.failure.message}">
 						<isset property="console.log.failure.message" />
 					</condition>
 
 					<generate-backend-batch-junit-report-ant-target
 						ant.target.failure.count="1"
-						ant.target.failure.message="Detected build services compilation error. Please check the logs for details."
+						ant.target.failure.message="Detected ${builder.type} compilation error. Please check the logs for details."
 						ant.target.failure.stacktrace="${ant.target.failure.stacktrace}"
 						ant.target.file="@{ant.target.file}"
 						ant.target.name="@{ant.target.name}"
@@ -487,7 +519,7 @@ mariadb.executable=${mariadb.executable}]]></echo>
 						<then>
 							<generate-backend-batch-junit-report-ant-target
 								ant.target.failure.count="1"
-								ant.target.failure.message="Detected build services changes. Please check the logs for details. Make sure to commit in all build services results."
+								ant.target.failure.message="Detected ${builder.type} changes. Please check the logs for details. Make sure to commit in all ${builder.type} results."
 								ant.target.failure.stacktrace="${git.diffs}"
 								ant.target.file="@{ant.target.file}"
 								ant.target.name="@{ant.target.name}"

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -396,17 +396,12 @@ mariadb.executable=${mariadb.executable}]]></echo>
 		</sequential>
 	</macrodef>
 
-	<macrodef name="execute-ant-target-build-services">
+	<macrodef name="execute-ant-target-builder">
 		<attribute name="ant.target.name" />
 		<attribute name="ant.target.file" />
+		<attribute name="builder.type" />
 
 		<sequential>
-			<local name="builder.type" />
-
-			<condition else="build services" property="builder.type" value="REST builder">
-				<equals arg1="@{ant.target.name}" arg2="build-rests" />
-			</condition>
-
 			<trycatch property="ant.target.failure" reference="ant.target.failure.ref">
 				<try>
 					<beanshell>
@@ -441,11 +436,11 @@ mariadb.executable=${mariadb.executable}]]></echo>
 
 					<record action="start" name="${project.dir}/execute.ant.target.log" />
 
-					<record-git-diffs-build-services>
+					<record-git-diffs builder.type="@{builder.type}">
 						<action>
 							<ant antfile="${ant.target.file.name}" dir="${ant.target.dir}" target="@{ant.target.name}" />
 						</action>
-					</record-git-diffs-build-services>
+					</record-git-diffs>
 
 					<generate-backend-batch-junit-report-ant-target
 						ant.target.failure.count="0"
@@ -502,7 +497,7 @@ mariadb.executable=${mariadb.executable}]]></echo>
 
 					<generate-backend-batch-junit-report-ant-target
 						ant.target.failure.count="1"
-						ant.target.failure.message="Detected ${builder.type} compilation error. Please check the logs for details."
+						ant.target.failure.message="Detected @{builder.type} compilation error. Please check the logs for details."
 						ant.target.failure.stacktrace="${ant.target.failure.stacktrace}"
 						ant.target.file="@{ant.target.file}"
 						ant.target.name="@{ant.target.name}"
@@ -519,7 +514,7 @@ mariadb.executable=${mariadb.executable}]]></echo>
 						<then>
 							<generate-backend-batch-junit-report-ant-target
 								ant.target.failure.count="1"
-								ant.target.failure.message="Detected ${builder.type} changes. Please check the logs for details. Make sure to commit in all ${builder.type} results."
+								ant.target.failure.message="Detected @{builder.type} changes. Please check the logs for details. Make sure to commit in all @{builder.type} results."
 								ant.target.failure.stacktrace="${git.diffs}"
 								ant.target.file="@{ant.target.file}"
 								ant.target.name="@{ant.target.name}"
@@ -529,6 +524,35 @@ mariadb.executable=${mariadb.executable}]]></echo>
 					</if>
 				</finally>
 			</trycatch>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="deploy-and-execute-ant-target-builder">
+		<attribute name="ant.target.file" />
+		<attribute name="ant.target.name" />
+		<attribute name="builder.type" />
+		<attribute name="tooling.dir" />
+
+		<sequential>
+			<if>
+				<available file="@{tooling.dir}" />
+				<then>
+					<gradle-execute dir="@{tooling.dir}" task="deploy">
+						<arg value="clean" />
+					</gradle-execute>
+				</then>
+			</if>
+
+			<exec executable="git">
+				<arg value="add" />
+				<arg value="--all" />
+			</exec>
+
+			<execute-ant-target-builder
+				ant.target.file="@{ant.target.file}"
+				ant.target.name="@{ant.target.name}"
+				builder.type="@{builder.type}"
+			/>
 		</sequential>
 	</macrodef>
 
@@ -613,13 +637,13 @@ mariadb.executable=${mariadb.executable}]]></echo>
 		<sequential>
 			<execute-gradle-task gradle.task.module.dir="@{gradle.module.dir}" gradle.task.name="@{gradle.task.name}">
 				<action>
-					<record-git-diffs-build-services>
+					<record-git-diffs builder.type="build services">
 						<action>
 							<gradle-execute dir="@{gradle.module.dir}" forcedcacheenabled="false" task="@{gradle.task.name}">
 								<arg value="-Pcom.liferay.portal.tools.service.builder.ignore.local=false" />
 							</gradle-execute>
 						</action>
-					</record-git-diffs-build-services>
+					</record-git-diffs>
 				</action>
 				<action-fail>
 					<if>
@@ -647,14 +671,14 @@ mariadb.executable=${mariadb.executable}]]></echo>
 		<sequential>
 			<execute-gradle-task gradle.task.module.dir="@{gradle.module.dir}" gradle.task.name="@{gradle.task.name}">
 				<action>
-					<record-git-diffs-rest-builder>
+					<record-git-diffs builder.type="REST builder">
 						<action>
 							<gradle-execute dir="@{gradle.module.dir}" forcedcacheenabled="false" task="@{gradle.task.name}">
 								<arg value="-DbuildREST.forceClientVersionDescription=false" />
 								<arg value="-Pcom.liferay.portal.tools.rest.builder.ignore.local=false" />
 							</gradle-execute>
 						</action>
-					</record-git-diffs-rest-builder>
+					</record-git-diffs>
 				</action>
 				<action-fail>
 					<if>
@@ -1592,7 +1616,8 @@ app.server.type=@{app.server.type}]]></echo>
 		</sequential>
 	</macrodef>
 
-	<macrodef name="record-git-diffs-build-services">
+	<macrodef name="record-git-diffs">
+		<attribute name="builder.type" />
 		<element name="action" />
 
 		<sequential>
@@ -1607,64 +1632,41 @@ app.server.type=@{app.server.type}]]></echo>
 			</tstamp>
 
 			<if>
-				<and>
-					<available file="modules/yarn.lock" />
-					<isset property="nodejs.npm.ci.registry" />
-				</and>
+				<equals arg1="@{builder.type}" arg2="build services" />
 				<then>
-					<replace
-						file="modules/yarn.lock"
-						token="${nodejs.npm.ci.registry}"
-						value="https://registry.yarnpkg.com"
-					/>
+					<if>
+						<and>
+							<available file="modules/yarn.lock" />
+							<isset property="nodejs.npm.ci.registry" />
+						</and>
+						<then>
+							<replace
+								file="modules/yarn.lock"
+								token="${nodejs.npm.ci.registry}"
+								value="https://registry.yarnpkg.com"
+							/>
+						</then>
+					</if>
+
+					<exec executable="git" output="${tstamp}.diff">
+						<arg value="diff" />
+						<arg value="--" />
+						<arg value="." />
+						<arg value=":!*/*-portlet-service.jar" />
+						<arg value=":!*/packageinfo" />
+						<arg value=":!*/src/main/resources/service.properties" />
+						<arg value=":!*/src/service.properties" />
+					</exec>
 				</then>
+				<else>
+					<exec executable="git" output="${tstamp}.diff">
+						<arg value="diff" />
+						<arg value="--" />
+						<arg value="." />
+						<arg value=":!*/packageinfo" />
+					</exec>
+				</else>
 			</if>
-
-			<exec executable="git" output="${tstamp}.diff">
-				<arg value="diff" />
-				<arg value="--" />
-				<arg value="." />
-				<arg value=":!*/*-portlet-service.jar" />
-				<arg value=":!*/packageinfo" />
-				<arg value=":!*/src/main/resources/service.properties" />
-				<arg value=":!*/src/service.properties" />
-			</exec>
-
-			<exec executable="git">
-				<arg value="checkout" />
-				<arg value="--" />
-				<arg value="." />
-			</exec>
-
-			<loadfile
-				property="git.diffs"
-				srcfile="${tstamp}.diff"
-			/>
-
-			<delete file="${tstamp}.diff" />
-		</sequential>
-	</macrodef>
-
-	<macrodef name="record-git-diffs-rest-builder">
-		<element name="action" />
-
-		<sequential>
-			<var name="git.diffs" unset="true" />
-
-			<action />
-
-			<local name="tstamp" />
-
-			<tstamp>
-				<format pattern="yyyyMMddkkmmssSSS" property="tstamp" />
-			</tstamp>
-
-			<exec executable="git" output="${tstamp}.diff">
-				<arg value="diff" />
-				<arg value="--" />
-				<arg value="." />
-				<arg value=":!*/packageinfo" />
-			</exec>
 
 			<exec executable="git">
 				<arg value="checkout" />
@@ -10185,21 +10187,12 @@ ${output.content}</echo>
 	<target name="rest-builder">
 		<run-batch-test>
 			<test-action>
-				<if>
-					<available file="modules/util/portal-tools-rest-builder" />
-					<then>
-						<gradle-execute dir="modules/util/portal-tools-rest-builder" task="deploy">
-							<arg value="clean" />
-						</gradle-execute>
-					</then>
-				</if>
-
-				<exec executable="git">
-					<arg value="add" />
-					<arg value="--all" />
-				</exec>
-
-				<execute-ant-target-build-services ant.target.file="portal-impl/build.xml" ant.target.name="build-rests" />
+				<deploy-and-execute-ant-target-builder
+					ant.target.file="portal-impl/build.xml"
+					ant.target.name="build-rests"
+					builder.type="REST builder"
+					tooling.dir="modules/util/portal-tools-rest-builder"
+				/>
 			</test-action>
 
 			<test-set-up>
@@ -10211,37 +10204,19 @@ ${output.content}</echo>
 	<target name="rest-builder-and-service-builder">
 		<run-batch-test>
 			<test-action>
-				<if>
-					<available file="modules/util/portal-tools-service-builder" />
-					<then>
-						<gradle-execute dir="modules/util/portal-tools-service-builder" task="deploy">
-							<arg value="clean" />
-						</gradle-execute>
-					</then>
-				</if>
+				<deploy-and-execute-ant-target-builder
+					ant.target.file="portal-impl/build.xml"
+					ant.target.name="build-services"
+					builder.type="build services"
+					tooling.dir="modules/util/portal-tools-service-builder"
+				/>
 
-				<exec executable="git">
-					<arg value="add" />
-					<arg value="--all" />
-				</exec>
-
-				<execute-ant-target-build-services ant.target.file="portal-impl/build.xml" ant.target.name="build-services" />
-
-				<if>
-					<available file="modules/util/portal-tools-rest-builder" />
-					<then>
-						<gradle-execute dir="modules/util/portal-tools-rest-builder" task="deploy">
-							<arg value="clean" />
-						</gradle-execute>
-					</then>
-				</if>
-
-				<exec executable="git">
-					<arg value="add" />
-					<arg value="--all" />
-				</exec>
-
-				<execute-ant-target-build-services ant.target.file="portal-impl/build.xml" ant.target.name="build-rests" />
+				<deploy-and-execute-ant-target-builder
+					ant.target.file="portal-impl/build.xml"
+					ant.target.name="build-rests"
+					builder.type="REST builder"
+					tooling.dir="modules/util/portal-tools-rest-builder"
+				/>
 			</test-action>
 
 			<test-set-up>
@@ -10351,21 +10326,12 @@ tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/
 	<target name="service-builder">
 		<run-batch-test>
 			<test-action>
-				<if>
-					<available file="modules/util/portal-tools-service-builder" />
-					<then>
-						<gradle-execute dir="modules/util/portal-tools-service-builder" task="deploy">
-							<arg value="clean" />
-						</gradle-execute>
-					</then>
-				</if>
-
-				<exec executable="git">
-					<arg value="add" />
-					<arg value="--all" />
-				</exec>
-
-				<execute-ant-target-build-services ant.target.file="portal-impl/build.xml" ant.target.name="build-services" />
+				<deploy-and-execute-ant-target-builder
+					ant.target.file="portal-impl/build.xml"
+					ant.target.name="build-services"
+					builder.type="build services"
+					tooling.dir="modules/util/portal-tools-service-builder"
+				/>
 			</test-action>
 
 			<test-set-up>

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -10241,6 +10241,48 @@ ${output.content}</echo>
 		</run-batch-test>
 	</target>
 
+	<target name="rest-builder-and-service-builder">
+		<run-batch-test>
+			<test-action>
+				<if>
+					<available file="modules/util/portal-tools-service-builder" />
+					<then>
+						<gradle-execute dir="modules/util/portal-tools-service-builder" task="deploy">
+							<arg value="clean" />
+						</gradle-execute>
+					</then>
+				</if>
+
+				<exec executable="git">
+					<arg value="add" />
+					<arg value="--all" />
+				</exec>
+
+				<execute-ant-target-build-services ant.target.file="portal-impl/build.xml" ant.target.name="build-services" />
+
+				<if>
+					<available file="modules/util/portal-tools-rest-builder" />
+					<then>
+						<gradle-execute dir="modules/util/portal-tools-rest-builder" task="deploy">
+							<arg value="clean" />
+						</gradle-execute>
+					</then>
+				</if>
+
+				<exec executable="git">
+					<arg value="add" />
+					<arg value="--all" />
+				</exec>
+
+				<execute-ant-target-build-services ant.target.file="portal-impl/build.xml" ant.target.name="build-rests" />
+			</test-action>
+
+			<test-set-up>
+				<setup-test-environment />
+			</test-set-up>
+		</run-batch-test>
+	</target>
+
 	<target name="semantic-versioning">
 		<run-batch-test>
 			<test-action>

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -10199,40 +10199,7 @@ ${output.content}</echo>
 					<arg value="--all" />
 				</exec>
 
-				<if>
-					<isset property="modules.test.class.group" />
-					<then>
-						<get-gradle-module-dir-task-names gradle.task.names="${modules.test.class.group}" />
-
-						<for delimiter="|" list="${gradle.module.dir.task.names}" param="gradle.module.dir.task.name" trim="true">
-							<sequential>
-								<local name="gradle.module.dir" />
-								<local name="gradle.task.name" />
-
-								<propertyregex
-									input="@{gradle.module.dir.task.name}"
-									override="true"
-									property="gradle.module.dir"
-									regexp="([^=]+)=([^=]+)"
-									replace="\1"
-								/>
-
-								<propertyregex
-									input="@{gradle.module.dir.task.name}"
-									override="true"
-									property="gradle.task.name"
-									regexp="([^=]+)=([^=]+)"
-									replace="\2"
-								/>
-
-								<execute-gradle-task-rest-builder gradle.module.dir="${gradle.module.dir}" gradle.task.name="${gradle.task.name}" />
-							</sequential>
-						</for>
-					</then>
-					<else>
-						<execute-gradle-task-rest-builder gradle.module.dir="modules" gradle.task.name="buildREST" />
-					</else>
-				</if>
+				<execute-ant-target-build-services ant.target.file="portal-impl/build.xml" ant.target.name="build-rests" />
 			</test-action>
 
 			<test-set-up>

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
@@ -98,6 +98,15 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 			jsonObject.put("ant_target_name", _antTargetName);
 		}
 
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(_testrayMainComponentName)) {
+			jsonObject.put(
+				"testray_main_component_name", _testrayMainComponentName);
+		}
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(_testrayTeamName)) {
+			jsonObject.put("testray_team_name", _testrayTeamName);
+		}
+
 		return jsonObject;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
@@ -98,7 +98,9 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 			jsonObject.put("ant_target_name", _antTargetName);
 		}
 
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(_testrayMainComponentName)) {
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				_testrayMainComponentName)) {
+
 			jsonObject.put(
 				"testray_main_component_name", _testrayMainComponentName);
 		}
@@ -152,10 +154,10 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 				_testPropertiesFile);
 
 			_testrayMainComponentName = JenkinsResultsParserUtil.getProperty(
-				testProperties, "testray.main.component.name", _antTargetName);
+				testProperties, "testray.main.component.name", antTargetName);
 
 			_testrayTeamName = JenkinsResultsParserUtil.getProperty(
-				testProperties, "testray.team.name", _antTargetName);
+				testProperties, "testray.team.name", antTargetName);
 		}
 		else {
 			_testPropertiesFile = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
@@ -12,6 +12,8 @@ import com.liferay.jenkins.results.parser.test.clazz.group.BatchTestClassGroup;
 
 import java.io.File;
 
+import java.util.Properties;
+
 import org.json.JSONObject;
 
 /**
@@ -110,6 +112,10 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 		return _testrayMainComponentName;
 	}
 
+	public String getTestrayTeamName() {
+		return _testrayTeamName;
+	}
+
 	protected BaseAntTargetTestClass(
 		BatchTestClassGroup batchTestClassGroup, File testClassFile) {
 
@@ -133,13 +139,19 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 			_testPropertiesFile = new File(
 				testPropertiesBaseDir, "test.properties");
 
+			Properties testProperties = JenkinsResultsParserUtil.getProperties(
+				_testPropertiesFile);
+
 			_testrayMainComponentName = JenkinsResultsParserUtil.getProperty(
-				JenkinsResultsParserUtil.getProperties(_testPropertiesFile),
-				"testray.main.component.name");
+				testProperties, "testray.main.component.name", _antTargetName);
+
+			_testrayTeamName = JenkinsResultsParserUtil.getProperty(
+				testProperties, "testray.team.name", _antTargetName);
 		}
 		else {
 			_testPropertiesFile = null;
 			_testrayMainComponentName = null;
+			_testrayTeamName = null;
 		}
 	}
 
@@ -160,6 +172,7 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 
 		_testrayMainComponentName = jsonObject.optString(
 			"testray_main_component_name");
+		_testrayTeamName = jsonObject.optString("testray_team_name");
 	}
 
 	protected abstract void addTestClassMethods();
@@ -170,5 +183,6 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 	private boolean _cachedTestClassReportSearched;
 	private final File _testPropertiesFile;
 	private final String _testrayMainComponentName;
+	private final String _testrayTeamName;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/BaseAntTargetTestClass.java
@@ -154,10 +154,11 @@ public abstract class BaseAntTargetTestClass extends BaseTestClass {
 				_testPropertiesFile);
 
 			_testrayMainComponentName = JenkinsResultsParserUtil.getProperty(
-				testProperties, "testray.main.component.name", antTargetName);
+				testProperties, "testray.main.component.name", false,
+				antTargetName);
 
 			_testrayTeamName = JenkinsResultsParserUtil.getProperty(
-				testProperties, "testray.team.name", antTargetName);
+				testProperties, "testray.team.name", false, antTargetName);
 		}
 		else {
 			_testPropertiesFile = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
@@ -47,19 +47,6 @@ public class AntTargetBatchBuildTestrayCaseResult
 	}
 
 	@Override
-	public String getTeamName() {
-		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
-
-		String teamName = baseAntTargetTestClass.getTestrayTeamName();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(teamName)) {
-			return super.getTeamName();
-		}
-
-		return teamName;
-	}
-
-	@Override
 	public long getDuration() {
 		TestReport testReport = _getAntTargetTestReport();
 
@@ -212,6 +199,19 @@ public class AntTargetBatchBuildTestrayCaseResult
 		}
 
 		return Status.PASSED;
+	}
+
+	@Override
+	public String getTeamName() {
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
+
+		String teamName = baseAntTargetTestClass.getTestrayTeamName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(teamName)) {
+			return super.getTeamName();
+		}
+
+		return teamName;
 	}
 
 	public TestClassReport getTestClassReport() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
@@ -47,6 +47,19 @@ public class AntTargetBatchBuildTestrayCaseResult
 	}
 
 	@Override
+	public String getTeamName() {
+		BaseAntTargetTestClass baseAntTargetTestClass = getTestClass();
+
+		String teamName = baseAntTargetTestClass.getTestrayTeamName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(teamName)) {
+			return super.getTeamName();
+		}
+
+		return teamName;
+	}
+
+	@Override
 	public long getDuration() {
 		TestReport testReport = _getAntTargetTestReport();
 

--- a/portal-impl/test.properties
+++ b/portal-impl/test.properties
@@ -33,6 +33,5 @@ test.batch.run.property.query[functional-tomcat-mysql*-jdk*][test-portal-hotfix-
 testray.main.component.name=Portal Services
 testray.main.component.name[build-rests]=Rest Builder
 testray.main.component.name[build-services]=Service Builder
-
 testray.team.name[build-rests]=Headless
 testray.team.name[build-services]=Core Infrastructure

--- a/portal-impl/test.properties
+++ b/portal-impl/test.properties
@@ -31,3 +31,8 @@ test.batch.run.property.query[functional-tomcat-mysql*-jdk*][test-portal-hotfix-
     )
 
 testray.main.component.name=Portal Services
+testray.main.component.name[build-rests]=Rest Builder
+testray.main.component.name[build-services]=Service Builder
+
+testray.team.name[build-rests]=Headless
+testray.team.name[build-services]=Core Infrastructure

--- a/portal-impl/test.properties
+++ b/portal-impl/test.properties
@@ -31,7 +31,7 @@ test.batch.run.property.query[functional-tomcat-mysql*-jdk*][test-portal-hotfix-
     )
 
 testray.main.component.name=Portal Services
-testray.main.component.name[build-rests]=Rest Builder
+testray.main.component.name[build-rests]=REST Builder
 testray.main.component.name[build-services]=Service Builder
 testray.team.name[build-rests]=Headless
 testray.team.name[build-services]=Core Infrastructure

--- a/test.properties
+++ b/test.properties
@@ -6982,7 +6982,6 @@
         **/template/template-web/**
 
     test.batch.axis.max.size[js-unit][stable]=30
-    test.batch.axis.max.size[rest-builder][stable]=10
 
     test.batch.class.names.excludes[modules-integration-postgresql163_*][stable]=\
         **/portal-dao-test/**/*Test.java,\
@@ -7006,8 +7005,7 @@
         playwright-compile,\
         playwright-js-smoke-tomcat101-hypersonic20,\
         playwright-js-tomcat101-postgresql163_stable,\
-        rest-builder,\
-        service-builder,\
+        rest-builder-and-service-builder,\
         unit_stable
 
     workspaces.names[workspaces-compile][stable]=\

--- a/test.properties
+++ b/test.properties
@@ -1444,6 +1444,8 @@
     test.batch.axis.count[playwright-compile]=1
     test.batch.axis.count[playwright-js-smoke*]=1
     test.batch.axis.count[playwright-js-tomcat101*]=1
+    test.batch.axis.count[rest-builder]=1
+    test.batch.axis.count[rest-builder-and-service-builder]=1
     test.batch.axis.count[service-builder]=1
     test.batch.axis.count[tck]=1
     test.batch.axis.max.size[functional-*]=7
@@ -1676,6 +1678,7 @@
         portal-frontend-js-lint,\
         poshi-validation,\
         rest-builder,\
+        rest-builder-and-service-builder,\
         semantic-versioning,\
         service-builder,\
         workspaces-compile,\
@@ -2436,6 +2439,8 @@
     test.batch.target.axis.duration[modules-unit]=3600000
     test.batch.target.axis.duration[playwright-*]=1800000
 
+    test.batch.unified.builder.supported[rest-builder]=true
+    test.batch.unified.builder.supported[rest-builder-and-service-builder]=true
     test.batch.unified.builder.supported[service-builder]=true
 
     test.hotfix.changes[test-portal-hotfix-release]=true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7287

**What is being fixed:** The rest-builder and service-builder batches run as
two separate CI axes even though they share most of their setup and report
against the same area. Collapsing them into a single batch saves an axis of
overhead, but the existing plumbing attributed only one Testray component
and team per batch, so a combined batch would have lumped REST builder
failures under the service-builder component and team. The Ant macrodefs
were also forked between the two flows, with duplicated git-diff recording
and a generic "build services compilation error" message regardless of
which builder actually failed.

**How it is being fixed:** A new `rest-builder-and-service-builder` target
runs both builders back-to-back inside a single `run-batch-test`. The
macrodefs are unified: `record-git-diffs-build-services` and
`record-git-diffs-rest-builder` collapse into one `record-git-diffs` that
branches on a `builder.type` attribute, and `execute-ant-target-build-services`
becomes a generic `execute-ant-target-builder` taking the same attribute so
failure messages name the actual builder and fall back to the full stack
trace when no console message is captured. A new
`deploy-and-execute-ant-target-builder` macrodef wraps the
deploy-then-add-then-execute pattern shared by both targets.

To keep Testray attribution correct for each axis, `BaseAntTargetTestClass`
now reads `testray.main.component.name[<antTargetName>]` and
`testray.team.name[<antTargetName>]` from `test.properties`, falling back
to the plain keys. `AntTargetBatchBuildTestrayCaseResult.getTeamName()` is
overridden to honor the per-target team, and both fields are serialized
into the test class JSON so that `publish-testray-report`, which
rehydrates test classes from cached JSON, preserves the values rather than
dropping back to the batch-glob component. `portal-impl/test.properties`
defines the per-target mappings (`build-rests` -> Rest Builder / Headless,
`build-services` -> Service Builder / Core Infrastructure), and
`test.properties` registers `rest-builder-and-service-builder` as a
unified-builder-supported batch and swaps it in for the separate
`rest-builder` / `service-builder` entries in the stable batch list.