### PR TITLE
LRCI-7396 Restore working tree before format-source-all to avoid slave workspace contamination

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -10413,6 +10413,12 @@ tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/
 					</else>
 				</if>
 
+				<exec executable="git" failonerror="true">
+					<arg value="checkout" />
+					<arg value="--" />
+					<arg value="." />
+				</exec>
+
 				<if>
 					<or>
 						<contains string="${git.diff}" substring="modules${file.separator}util${file.separator}source-formatter" />


### PR DESCRIPTION
- [LRCI-7396](https://liferay.atlassian.net/browse/LRCI-7396)

## Summary

`build-test-batch.xml`'s `source-format-current-branch` target runs `compile`, `install-portal-snapshots`, and a Gradle deploy of `modules/util/source-formatter` before invoking `format-source-all`. Those steps mutate tracked source files — the smoking gun is `portal-kernel/.../ReleaseInfo.java`, where the Ant filter-tokens step substitutes the `@release.info.*@` placeholders with concrete release values. The formatter then scans the post-mutation working tree and reports false-positive violations on files the PR never touched (see [test-portal-source-format #708](https://test-1-43.liferay.com/job/test-portal-source-format/708/)).

This patch reverts tracked-file mutations with `git checkout -- .` between the prep phase and the format-source dispatch. Untracked build outputs and caches are unaffected, so subsequent steps still see the artifacts they need.