### PR TITLE
LRCI-6991 Don't fetch all queue items when the queue item id is known

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
@@ -327,27 +327,27 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 				return null;
 			}
 
-			List<JSONObject> queueItemJSONObjects = new ArrayList<>(
-				jenkinsMaster.getQueueItemJSONObjects());
-
-			String jenkinsJobName = build.getJobName();
-
 			Build.Invocation currentInvocation = build.getCurrentInvocation();
 
 			long currentQueueId = currentInvocation.getQueueId();
 
-			for (JSONObject queueItemJSONObject : queueItemJSONObjects) {
-				if (currentQueueId > 0) {
-					if (Objects.equals(
-							queueItemJSONObject.getLong("id"),
-							currentQueueId)) {
+			if (currentQueueId > 0) {
+				JenkinsMaster.QueueItem queueItem = jenkinsMaster.getQueueItem(
+					currentQueueId);
 
-						return queueItemJSONObject;
-					}
-
-					continue;
+				if (queueItem == null) {
+					return null;
 				}
 
+				return queueItem.getJSONObject();
+			}
+
+			String jenkinsJobName = build.getJobName();
+
+			List<JSONObject> queueItemJSONObjects = new ArrayList<>(
+				jenkinsMaster.getQueueItemJSONObjects());
+
+			for (JSONObject queueItemJSONObject : queueItemJSONObjects) {
 				JSONObject taskJSONObject = queueItemJSONObject.getJSONObject(
 					"task");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -538,6 +538,29 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return queuedBuildURLs;
 	}
 
+	public QueueItem getQueueItem(long queueId) {
+		try {
+			JSONObject queueItemJSONObject =
+				JenkinsResultsParserUtil.toJSONObject(
+					JenkinsResultsParserUtil.combine(
+						getURL(), "/queue/item/", String.valueOf(queueId),
+						"/api/json?tree=actions[parameters[name,value]],",
+						"id,inQueueSince,task[name,url],url,why"),
+					false, 5000);
+
+			if ((queueItemJSONObject == null) ||
+				!queueItemJSONObject.has("id")) {
+
+				return null;
+			}
+
+			return new QueueItem(this, queueItemJSONObject);
+		}
+		catch (IOException ioException) {
+			return null;
+		}
+	}
+
 	public List<JSONObject> getQueueItemJSONObjects() {
 		List<JSONObject> queueItemJSONObjects = new ArrayList<>();
 


### PR DESCRIPTION
- [LRCI-6991](https://liferay.atlassian.net/browse/LRCI-6991)

## Summary

Adds `JenkinsMaster.getQueueItem(long queueId)` that fetches a single queue item via `/queue/item/<id>/api/json`, returning `null` on `IOException` (404 / item left queue) or empty payload. Switches `DefaultBuildUpdater._getQueueItemJSONObject()` to take the single-fetch path when `currentInvocation.getQueueId() > 0`; falls back to the existing full-list + name/parameter matching when the queue id is unknown. The downstream-build invocation now has the queue id, so this avoids downloading every queued item from the master just to find one.