### PR TITLE
LRCI-7397 Detect empty-diff forwards before calling GitHub PR-create API

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -140,7 +140,7 @@ public class CIForwardProcessor {
 								forwardPullRequestException.getMessage());
 						}
 						else {
-							maxRetries = 0;
+							breakOut();
 						}
 
 						throw new RuntimeException(forwardPullRequestException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -132,6 +132,19 @@ public class CIForwardProcessor {
 
 						return pullRequestURL;
 					}
+					catch (PullRequest.ForwardPullRequestException
+								forwardPullRequestException) {
+
+						if (forwardPullRequestException.isRetry()) {
+							System.out.println(
+								forwardPullRequestException.getMessage());
+						}
+						else {
+							maxRetries = 0;
+						}
+
+						throw new RuntimeException(forwardPullRequestException);
+					}
 					catch (Exception exception) {
 						if (exception instanceof RuntimeException) {
 							throw (RuntimeException)exception;
@@ -177,6 +190,16 @@ public class CIForwardProcessor {
 					sb.toString(), gitHubSecondaryRateLimitRuntimeException);
 			}
 			catch (Exception exception) {
+				Throwable throwable = exception.getCause();
+
+				if (throwable instanceof
+						PullRequest.ForwardPullRequestException) {
+
+					_pullRequest.addComment(throwable.getMessage());
+
+					return;
+				}
+
 				exception.printStackTrace();
 
 				StringBuilder sb = new StringBuilder();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -135,11 +135,7 @@ public class CIForwardProcessor {
 					catch (PullRequest.ForwardPullRequestException
 								forwardPullRequestException) {
 
-						if (forwardPullRequestException.isRetryable()) {
-							System.out.println(
-								forwardPullRequestException.getMessage());
-						}
-						else {
+						if (!forwardPullRequestException.isRetryable()) {
 							breakLoop();
 						}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -135,7 +135,7 @@ public class CIForwardProcessor {
 					catch (PullRequest.ForwardPullRequestException
 								forwardPullRequestException) {
 
-						if (forwardPullRequestException.isRetry()) {
+						if (forwardPullRequestException.isRetryable()) {
 							System.out.println(
 								forwardPullRequestException.getMessage());
 						}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -140,7 +140,7 @@ public class CIForwardProcessor {
 								forwardPullRequestException.getMessage());
 						}
 						else {
-							breakOut();
+							breakLoop();
 						}
 
 						throw new RuntimeException(forwardPullRequestException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -1204,18 +1204,18 @@ public class PullRequest {
 	public static class ForwardPullRequestException extends Exception {
 
 		public ForwardPullRequestException(
-			String message, boolean retry, Throwable throwable) {
+			String message, boolean retryable, Throwable throwable) {
 
 			super(message, throwable);
 
-			_retry = retry;
+			_retryable = retryable;
 		}
 
-		public boolean isRetry() {
-			return _retry;
+		public boolean isRetryable() {
+			return _retryable;
 		}
 
-		private final boolean _retry;
+		private final boolean _retryable;
 
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -260,10 +260,26 @@ public class PullRequest {
 			throw new RuntimeException("Unable to push branch to GitHub");
 		}
 
-		int commitCount = gitWorkingDirectory.getCommitCountBetweenBranches(
-			getUpstreamBranchSHA(), forwardLocalGitBranch.getSHA());
+		String compareApiUrl = JenkinsResultsParserUtil.getGitHubApiUrl(
+			getGitRepositoryName(), forwardReceiverUsername,
+			JenkinsResultsParserUtil.combine(
+				"compare/", getUpstreamRemoteGitBranchName(), "...",
+				forwardSenderUsername, ":", forwardBranchName));
 
-		if (commitCount == 0) {
+		int aheadBy = -1;
+
+		try {
+			JSONObject compareJSONObject =
+				JenkinsResultsParserUtil.toJSONObject(compareApiUrl);
+
+			aheadBy = compareJSONObject.getInt("ahead_by");
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"Unable to compare branches: " + ioException.getMessage());
+		}
+
+		if (aheadBy == 0) {
 			StringBuilder sb = new StringBuilder();
 
 			sb.append("`ci:forward` could not forward this pull ");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -230,9 +230,10 @@ public class PullRequest {
 	}
 
 	public String forward(
-		String commentBody, String consoleURL, String forwardReceiverUsername,
-		String forwardBranchName, String forwardSenderUsername,
-		File gitRepositoryDir) {
+			String commentBody, String consoleURL,
+			String forwardReceiverUsername, String forwardBranchName,
+			String forwardSenderUsername, File gitRepositoryDir)
+		throws ForwardPullRequestException {
 
 		if (!isUpdateEnabled()) {
 			return null;
@@ -257,6 +258,25 @@ public class PullRequest {
 
 		if (forwardRemoteGitBranch == null) {
 			throw new RuntimeException("Unable to push branch to GitHub");
+		}
+
+		int commitCount = gitWorkingDirectory.getCommitCountBetweenBranches(
+			getUpstreamBranchSHA(), forwardLocalGitBranch.getSHA());
+
+		if (commitCount == 0) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("`ci:forward` could not forward this pull ");
+			sb.append("request because every commit on this pull request is ");
+			sb.append("already present on `");
+			sb.append(forwardReceiverUsername);
+			sb.append("/");
+			sb.append(getGitRepositoryName());
+			sb.append(":");
+			sb.append(getUpstreamRemoteGitBranchName());
+			sb.append("`.");
+
+			throw new ForwardPullRequestException(sb.toString(), false, null);
 		}
 
 		return gitWorkingDirectory.createPullRequest(
@@ -1178,6 +1198,24 @@ public class PullRequest {
 		}
 
 		private final JSONObject _commentJSONObject;
+
+	}
+
+	public static class ForwardPullRequestException extends Exception {
+
+		public ForwardPullRequestException(
+			String message, boolean retry, Throwable throwable) {
+
+			super(message, throwable);
+
+			_retry = retry;
+		}
+
+		public boolean isRetry() {
+			return _retry;
+		}
+
+		private final boolean _retry;
 
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Retryable.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Retryable.java
@@ -72,7 +72,7 @@ public abstract class Retryable<T> {
 		}
 	}
 
-	protected final void breakOut() {
+	protected final void breakLoop() {
 		maxRetries = 0;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Retryable.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Retryable.java
@@ -72,6 +72,10 @@ public abstract class Retryable<T> {
 		}
 	}
 
+	protected final void breakOut() {
+		maxRetries = 0;
+	}
+
 	protected String getRetryMessage(int retryCount) {
 		return JenkinsResultsParserUtil.combine(
 			"Retry attempt ", String.valueOf(retryCount), " of ",


### PR DESCRIPTION
- [LRCI-7397](https://liferay.atlassian.net/browse/LRCI-7397)

## Summary

When `ci:forward` rebases a PR onto receiver/master and the resulting branch has zero commits ahead (typically because nightly Auto-SF independently picked up the same source-formatter fixes), the GitHub PR-create call returns `HTTP 422 — No commits between <base> and <head>` and the inner `Retryable` storms three retries before failing the build.

`PullRequest.forward(...)` now counts commits ahead of receiver/master after the rebase and throws `ForwardPullRequestException(message, retryable=false, …)` instead of calling `createPullRequest`. `CIForwardProcessor` catches the exception, calls the new `Retryable.breakLoop()` to halt retries, and posts the exception's message to the source PR. Empty-diff forwards finish `SUCCESS` with one explanatory comment instead of an HTTP 422 retry storm.

Validated via [pyoo47/liferay-jenkins-ee#4812](https://github.com/pyoo47/liferay-jenkins-ee/pull/4812) Candidate Jar.