### PR TITLE
LRCI-7411 Gate prepare-workspace caching artifacts on isBuildCachingEnabled

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -150,9 +150,14 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			if (!isSnapshot()) {
 				prepareGitWorkingDirectory();
 
-				_setUpBinariesCache();
+				if (JenkinsResultsParserUtil.isBuildCachingEnabled(
+						System.getenv("JOB_NAME"),
+						System.getenv("CI_TEST_SUITE"))) {
 
-				prepareGitArchive();
+					_setUpBinariesCache();
+
+					prepareGitArchive();
+				}
 
 				setSetUp(true);
 			}


### PR DESCRIPTION
## Summary

In `PortalWorkspaceGitRepository.setUp()`, gate `_setUpBinariesCache()`
and `prepareGitArchive()` behind `JenkinsResultsParserUtil.isBuildCachingEnabled(JOB_NAME, CI_TEST_SUITE)`.

For jobs that do not consume these artifacts (e.g. `forward-pullrequest`),
this skips the binaries-cache lookup and the git-archive zip + S3 upload,
which dominate the prepare-workspace phase. In a recent
`forward-pullrequest` build, prepare-workspace was 8m24s of 8m49s
(~95%) — almost all of it spent producing artifacts the job never reads.

The toggle reuses the existing `build.caching.enabled[<jobName>][<testSuite>]`
mechanism, so behavior is opt-out per job via build.properties (no new
flag, no JOB_NAME hardcoding inside the Java). Setting
`build.caching.enabled[forward-pullrequest]=false` in
`liferay-jenkins-ee` `commands/build-aws.properties` should drop the
`forward-pullrequest` total run time from ~9 min to ~2-3 min while
leaving the forward operation (rebase + force-push + create PR)
unchanged. Jobs that *do* rely on the cache (e.g. upstream acceptance
batches) keep their current behavior since their entries in
`build-aws.properties` already opt them in.