### PR TITLE
LRCI-7412 Fetch remote ref before validating SHA reachability

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1530,6 +1530,8 @@ public abstract class BaseWorkspaceGitRepository
 
 		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
+		gitWorkingDirectory.fetch(remoteGitRef);
+
 		if (!gitWorkingDirectory.localSHAExists(sha) ||
 			!gitWorkingDirectory.refContainsSHA(remoteGitRef.getSHA(), sha)) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7412

**What is being fixed:** Workspace setup in `BaseWorkspaceGitRepository` can fail with a misleading `SHA <X> was not found in branch "Y" on <URL>` error even when the SHA truly is on the branch. The cause is a stale local clone: the worker often bootstraps from an S3 shallow-clone archive that predates the latest push to the target branch, so the freshly-resolved remote tip is never in the local objects database. The validation helper then runs `git merge-base --is-ancestor` against an unfetched tip and reports the resulting non-zero exit as "SHA not on branch." This is the latent product of two recent changes: LRCI-7282's conditional fetch let stale clones stay stale, and LRCI-6626's strict validation turned that into a hard failure. LRCI-7380 already addressed the reverse race (sender SHA orphaned by force-push); this case is the inverse — base tip moves forward, local clone lags.

**How it is being fixed:** `_validateSHAInRemoteGitRef` now calls `gitWorkingDirectory.fetch(remoteGitRef)` before the merge-base check. `GitWorkingDirectory.fetch()` already short-circuits when the ref's SHA is local (see `GitWorkingDirectory.java:706`), so this only triggers a network op in the bug-fix path; the LRCI-7282 steady-state fast path is unaffected. The throw type and message string are unchanged, so the `InvalidGitCommitSHAFailureMessageGenerator` log-pattern matcher introduced under LRCI-7380 keeps matching when the validation legitimately fails. Worth noting on review: this private helper now performs a network fetch as a side effect even though named `_validate...`; in practice the I/O only happens in the bug-fix path because `fetch()` self-elides.

Bench tested by deploying the rebuilt jar to a temp `liferay-jenkins-ee` branch and re-triggering `test-portal-release` — got past the previously-failing setUp step.