### PR TITLE
LRCI-7411 Gate prepare-workspace caching artifacts on isBuildCachingEnabled (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -150,9 +150,14 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			if (!isSnapshot()) {
 				prepareGitWorkingDirectory();
 
-				_setUpBinariesCache();
+				if (JenkinsResultsParserUtil.isBuildCachingEnabled(
+						System.getenv("JOB_NAME"),
+						System.getenv("CI_TEST_SUITE"))) {
 
-				prepareGitArchive();
+					_setUpBinariesCache();
+
+					prepareGitArchive();
+				}
 
 				setSetUp(true);
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -140,20 +140,18 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		System.out.println(toString());
 
 		try {
-			if (JenkinsResultsParserUtil.isBuildCachingEnabled(
-					System.getenv("JOB_NAME"),
-					System.getenv("CI_TEST_SUITE"))) {
+			boolean buildCachingEnabled =
+				JenkinsResultsParserUtil.isBuildCachingEnabled(
+					System.getenv("JOB_NAME"), System.getenv("CI_TEST_SUITE"));
 
+			if (buildCachingEnabled) {
 				checkAvailableGitArchive();
 			}
 
 			if (!isSnapshot()) {
 				prepareGitWorkingDirectory();
 
-				if (JenkinsResultsParserUtil.isBuildCachingEnabled(
-						System.getenv("JOB_NAME"),
-						System.getenv("CI_TEST_SUITE"))) {
-
+				if (buildCachingEnabled) {
 					_setUpBinariesCache();
 
 					prepareGitArchive();


### PR DESCRIPTION
[LRCI-7411](https://liferay.atlassian.net/browse/LRCI-7411)

Revises [#4258](https://github.com/pyoo47/liferay-portal/pull/4258) (opened by @kenjiheigel) with the following follow-up commits:

- [5b0a8ce2b33f](https://github.com/pyoo47/liferay-portal/commit/5b0a8ce2b33f605ec15db6379bcb0c3273a3d330) LRCI-7411 Hoist isBuildCachingEnabled gate into a local boolean
