### PR TITLE
LRCI-7432 Stop wiping recent-batch debit on every JenkinsMaster.update()

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -929,13 +929,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			_assignedLabels.clear();
 			_buildURLs.clear();
 			_jenkinsSlavesMap.clear();
-			_labelBatchSizes.clear();
 
 			return;
 		}
 
 		_assignedLabels.clear();
-		_labelBatchSizes.clear();
 
 		JSONObject computerAPIJSONObject = null;
 
@@ -952,7 +950,6 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			_assignedLabels.clear();
 			_buildURLs.clear();
 			_jenkinsSlavesMap.clear();
-			_labelBatchSizes.clear();
 			_labelExpressionLabels.clear();
 
 			System.out.println("Unable to read " + _masterURL);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7432

**Regression introduced by:** [LRCI-7202](https://liferay.atlassian.net/browse/LRCI-7202) / commit 2e139ee (2026-03-26), which added a `_labelBatchSizes.clear()` call to the successful-update path of `JenkinsMaster.update(boolean)`. The two other clears (in the `!isAvailable()` block and the API-call catch) predate that from [LRCI-5520](https://liferay.atlassian.net/browse/LRCI-5520) and are not the regression cause; this PR removes all three for symmetry, since `_getRecentBatchSizesTotal` self-prunes expired entries on read and the 2-minute TTL covers cleanup. If reviewers prefer a strict regression-only revert, restoring the two failure-path clears is a safe follow-up.

**What is being fixed:** The Jenkins load balancer (`osb-jenkins-web` → `LoadBalancerUtil.getMostAvailableMasterURL`) ranks masters by `availableSlavesCount = idleNodeCount − queueCount − recentBatchSizesTotal`. The `recentBatchSizesTotal` term is a per-master pending-dispatches counter that prevents the picker from overshooting onto the same master during parallel bursts, when Jenkins' own `/queue/api/json` snapshot has not yet caught up with just-dispatched builds. It is supposed to live for 2 minutes (`maxRecentBatchAge` in `JenkinsMaster`) so debits accumulate across an entire burst. In practice, `JenkinsMaster.update(boolean)` was clearing the underlying `_labelBatchSizes` map on every refresh — three places. With `LoadBalancerUtil._updateInterval = 10s` triggering refreshes and `_MAXIMUM_UPDATE_DURATION = 15s` gating them, the pending-dispatch counter was being wiped roughly every 15 seconds. Over a sustained dispatch burst, the debit could only build up for ~15 seconds before resetting to zero, so a master with even a small structural lead in `idleNodeCount` would keep winning every pick within each refresh window. The most recent `test-portal-release` run dispatched 1,226 downstream jobs in 11 minutes; 1,223 went to `test-1-47` even though other masters had capacity.

**How it is being fixed:** Removing the three `_labelBatchSizes.clear()` calls in `JenkinsMaster.update(boolean)` lets the recent-batch debit persist across refreshes the way it was originally designed to. `_getRecentBatchSizesTotal` already self-prunes expired entries inline on every read, so the map maintains itself; nothing else needs to change. With the wipe gone, debits now accumulate over the full 2-minute TTL window, so a master being repeatedly chosen will see its score drop within seconds instead of resetting every 15 s. This restores the proportional distribution the design intended.