### PR TITLE
LRCI-7378 Synthetic setup-yarn repro (do not merge)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -975,6 +975,8 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 	</target>
 
 	<target name="setup-yarn">
+		<fail message="synthetic LRCI-7378 repro" />
+
 		<setup-yarn />
 	</target>
 


### PR DESCRIPTION
## JIRA

- [LRCI-7378](https://liferay.atlassian.net/browse/LRCI-7378)

## Summary

Throwaway PR. Adds a single `<fail message="synthetic LRCI-7378 repro"/>` at the top of `build.xml`'s `setup-yarn` target so the target throws deterministically on every invocation. Two effects on a PR-tester run:

1. The primary `Execute shell` step calls `setup-yarn` and fails immediately — same trigger condition the ticket describes.
2. `stop-current-job` cleanup reaches `PlaywrightBatchTestClassGroup._loadPlaywrightJSONObjects`, which also calls `setup-yarn` and triggers the catch path the ticket fixes.

To validate the fix, run `test-portal-acceptance-pullrequest(master)` against this PR with the candidate jenkins-ee branch override, e.g. `-Djenkins.branch.name=LRCI-7378 -Djenkins.github.userid=pyoo47`. Expect: one clean "Skipping Playwright class-group enumeration because setup-yarn failed" line, no NPE cascade. Re-run without the override (master jar) for the before artifact.

Discard this branch and the candidate-jar PR once BChan publishes the jrp version.