### PR TITLE
LRCI-7152 Fail ci:forward early on merge conflict with the receiver branch

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -731,14 +731,13 @@ public class CIForwardProcessor {
 	}
 
 	private boolean _hasMergeConflict() {
-		GitWorkingDirectory gitWorkingDirectory =
-			GitWorkingDirectoryFactory.newGitWorkingDirectory(
-				_pullRequest.getUpstreamRemoteGitBranchName(),
-				_gitRepositoryDir.getAbsolutePath(),
-				_pullRequest.getGitRepositoryName());
-
 		String upstreamBranchName =
 			_pullRequest.getUpstreamRemoteGitBranchName();
+
+		GitWorkingDirectory gitWorkingDirectory =
+			GitWorkingDirectoryFactory.newGitWorkingDirectory(
+				upstreamBranchName, _gitRepositoryDir.getAbsolutePath(),
+				_pullRequest.getGitRepositoryName());
 
 		String receiverRemoteURL = GitUtil.getUserRemoteURL(
 			_pullRequest.getGitRepositoryName(), _recipientUsername);
@@ -772,7 +771,8 @@ public class CIForwardProcessor {
 
 		LocalGitBranch receiverLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
-				_recipientUsername + "-" + upstreamBranchName + "-precheck",
+				JenkinsResultsParserUtil.combine(
+					_recipientUsername, "-", upstreamBranchName, "-precheck"),
 				true, receiverRemoteGitBranch.getSHA());
 
 		LocalGitBranch senderLocalGitBranch =
@@ -792,6 +792,13 @@ public class CIForwardProcessor {
 			String message = gitWorkingDirectoryRuntimeException.getMessage();
 
 			if ((message != null) && message.contains("Unable to rebase ")) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"Detected merge conflict between ",
+						senderRemoteGitBranch.getUsername(), ":",
+						senderRemoteGitBranch.getName(), " and ",
+						_recipientUsername, ":", upstreamBranchName));
+
 				return true;
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -83,6 +83,12 @@ public class CIForwardProcessor {
 				return;
 			}
 
+			if (_hasMergeConflict()) {
+				_pullRequest.addComment(_getMergeConflictCommentBody());
+
+				return;
+			}
+
 			_pullRequest.addComment(_getPassedCommentBody());
 
 			final String senderUsername;
@@ -522,6 +528,19 @@ public class CIForwardProcessor {
 		return incompleteRequiredCompletedTestSuiteNames;
 	}
 
+	private String _getMergeConflictCommentBody() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("Unable to forward to ");
+		sb.append(_recipientUsername);
+		sb.append(":");
+		sb.append(_pullRequest.getUpstreamRemoteGitBranchName());
+		sb.append(" because the new pull request would contain a merge ");
+		sb.append("conflict.");
+
+		return sb.toString();
+	}
+
 	private List<String> _getOpenForwardedPullRequestUrls() throws IOException {
 		List<String> openForwardedPullRequestUrls = new ArrayList<>();
 
@@ -709,6 +728,75 @@ public class CIForwardProcessor {
 		}
 
 		return sb.toString();
+	}
+
+	private boolean _hasMergeConflict() {
+		GitWorkingDirectory gitWorkingDirectory =
+			GitWorkingDirectoryFactory.newGitWorkingDirectory(
+				_pullRequest.getUpstreamRemoteGitBranchName(),
+				_gitRepositoryDir.getAbsolutePath(),
+				_pullRequest.getGitRepositoryName());
+
+		String upstreamBranchName =
+			_pullRequest.getUpstreamRemoteGitBranchName();
+
+		String receiverRemoteURL = GitUtil.getUserRemoteURL(
+			_pullRequest.getGitRepositoryName(), _recipientUsername);
+
+		RemoteGitBranch senderRemoteGitBranch =
+			_pullRequest.getSenderRemoteGitBranch();
+
+		RemoteGitBranch receiverRemoteGitBranch =
+			gitWorkingDirectory.getRemoteGitBranch(
+				upstreamBranchName, receiverRemoteURL, true);
+
+		GitCommit mergeBaseCommit = receiverRemoteGitBranch.getMergeBaseCommit(
+			senderRemoteGitBranch);
+
+		if (mergeBaseCommit == null) {
+			return false;
+		}
+
+		String senderSHA = _pullRequest.getSenderSHA();
+
+		if (!gitWorkingDirectory.localSHAExists(senderSHA)) {
+			gitWorkingDirectory.fetch(senderRemoteGitBranch);
+		}
+
+		if (!gitWorkingDirectory.localSHAExists(
+				receiverRemoteGitBranch.getSHA())) {
+
+			gitWorkingDirectory.fetch(
+				receiverRemoteGitBranch, mergeBaseCommit.getCommitDate());
+		}
+
+		LocalGitBranch receiverLocalGitBranch =
+			gitWorkingDirectory.createLocalGitBranch(
+				_recipientUsername + "-" + upstreamBranchName + "-precheck",
+				true, receiverRemoteGitBranch.getSHA());
+
+		LocalGitBranch senderLocalGitBranch =
+			gitWorkingDirectory.createLocalGitBranch(
+				_pullRequest.getLocalSenderBranchName() + "-precheck", true,
+				senderSHA);
+
+		try {
+			gitWorkingDirectory.rebase(
+				true, receiverLocalGitBranch, senderLocalGitBranch);
+
+			return false;
+		}
+		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
+					gitWorkingDirectoryRuntimeException) {
+
+			String message = gitWorkingDirectoryRuntimeException.getMessage();
+
+			if ((message != null) && message.contains("Unable to rebase ")) {
+				return true;
+			}
+
+			throw gitWorkingDirectoryRuntimeException;
+		}
 	}
 
 	private boolean _isForwardEligible() throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -19,6 +19,7 @@ import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -696,6 +697,13 @@ public class GitWorkingDirectory {
 		LocalGitBranch localGitBranch, boolean noTags,
 		RemoteGitRef remoteGitRef, int retries) {
 
+		return fetch(localGitBranch, noTags, remoteGitRef, retries, null);
+	}
+
+	public LocalGitBranch fetch(
+		LocalGitBranch localGitBranch, boolean noTags,
+		RemoteGitRef remoteGitRef, int retries, Date shallowSinceDate) {
+
 		if (remoteGitRef == null) {
 			throw new GitWorkingDirectoryIllegalArgumentException(
 				this, "Remote Git reference is null");
@@ -769,6 +777,16 @@ public class GitWorkingDirectory {
 		}
 		else {
 			sb.append("--tags ");
+		}
+
+		if (shallowSinceDate != null) {
+			String shallowSinceDateString =
+				JenkinsResultsParserUtil.toDateString(
+					shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC");
+
+			sb.append("--shallow-since=\"");
+			sb.append(shallowSinceDateString);
+			sb.append("\" ");
 		}
 
 		sb.append(remoteURL);
@@ -889,6 +907,12 @@ public class GitWorkingDirectory {
 
 	public LocalGitBranch fetch(RemoteGitRef remoteGitRef) {
 		return fetch(null, true, remoteGitRef);
+	}
+
+	public LocalGitBranch fetch(
+		RemoteGitRef remoteGitRef, Date shallowSinceDate) {
+
+		return fetch(null, true, remoteGitRef, 3, shallowSinceDate);
 	}
 
 	public LocalGitBranch fetch(RemoteGitRef remoteGitRef, int retries) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitRef.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteGitRef.java
@@ -5,6 +5,10 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.IOException;
+
+import org.json.JSONObject;
+
 /**
  * @author Michael Hashimoto
  */
@@ -22,6 +26,26 @@ public class RemoteGitRef
 		return JenkinsResultsParserUtil.combine(
 			"https://github.com/", getUsername(), "/", getRepositoryName(),
 			"/tree/", getName());
+	}
+
+	public GitCommit getMergeBaseCommit(RemoteGitRef otherRemoteGitRef) {
+		JSONObject compareJSONObject = getCompareJSONObject(otherRemoteGitRef);
+
+		JSONObject mergeBaseCommitJSONObject = compareJSONObject.optJSONObject(
+			"merge_base_commit");
+
+		if (mergeBaseCommitJSONObject == null) {
+			return null;
+		}
+
+		String sha = mergeBaseCommitJSONObject.optString("sha", null);
+
+		if (sha == null) {
+			return null;
+		}
+
+		return GitCommitFactory.newGitHubRemoteGitCommit(
+			getUsername(), getRepositoryName(), sha, mergeBaseCommitJSONObject);
 	}
 
 	public RemoteGitRepository getRemoteGitRepository() {
@@ -68,6 +92,26 @@ public class RemoteGitRef
 		}
 
 		_remoteGitRepository = remoteGitRepository;
+	}
+
+	protected JSONObject getCompareJSONObject(RemoteGitRef otherRemoteGitRef) {
+		if (otherRemoteGitRef == null) {
+			throw new IllegalArgumentException("Other remote Git ref is null");
+		}
+
+		String compareSpec = JenkinsResultsParserUtil.combine(
+			getName(), "...", otherRemoteGitRef.getUsername(), ":",
+			otherRemoteGitRef.getName());
+
+		String url = JenkinsResultsParserUtil.getGitHubApiUrl(
+			getRepositoryName(), getUsername(), "compare/" + compareSpec);
+
+		try {
+			return JenkinsResultsParserUtil.toJSONObject(url);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
 	}
 
 	private final RemoteGitRepository _remoteGitRepository;


### PR DESCRIPTION
- [LRCI-7152](https://liferay.atlassian.net/browse/LRCI-7152)

## Summary

`CIForwardProcessor` precheck before posting "tests passed": GitHub's compare API supplies the merge-base committer date, used as `--shallow-since=` to fetch the receiver branch, then `git rebase` runs locally. On `Unable to rebase`, a single comment names the conflicting refs and short-circuits the forward. Fires under `ci:forward:force` too — a merge conflict is not a test result, and the downstream forward would fail anyway.

Supporting:
- `GitWorkingDirectory.fetch(...)` gains a `Date shallowSinceDate` parameter; existing overloads delegate with `null`.
- `RemoteGitRef.getMergeBaseCommit(RemoteGitRef)` wraps the compare API and returns a `GitCommit` bounding the fetch.

E2E-validated via Candidate Jar against a deliberately-conflicting PR.