### PR TITLE
LRCI-6956 Avoid hard-coding test-1-0 & fix error message (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -2381,6 +2381,10 @@ public abstract class BaseTopLevelBuild
 				"jenkins.remote.url[test-1-0]");
 
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(masterHostname)) {
+				if (!masterHostname.endsWith("/")) {
+					masterHostname += "/";
+				}
+
 				return JenkinsResultsParserUtil.combine(
 					masterHostname,
 					"userContent/reports/ci-system-status/index.html");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -1482,7 +1482,7 @@ public abstract class BaseTopLevelBuild
 			Dom4JUtil.getNewElement(
 				"p", null,
 				Dom4JUtil.getNewAnchorElement(
-					_URL_CI_SYSTEM_STATUS, "CI System Status")),
+					_getCISystemStatusURL(), "CI System Status")),
 			Dom4JUtil.getNewElement(
 				"p", null, "Start Time: ",
 				toJenkinsReportDateString(
@@ -2375,6 +2375,24 @@ public abstract class BaseTopLevelBuild
 		return cachedDownstreamBuilds;
 	}
 
+	private String _getCISystemStatusURL() {
+		try {
+			String masterHostname = JenkinsResultsParserUtil.getBuildProperty(
+				"jenkins.remote.url[test-1-0]");
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(masterHostname)) {
+				return JenkinsResultsParserUtil.combine(
+					masterHostname,
+					"userContent/reports/ci-system-status/index.html");
+			}
+		}
+		catch (IOException ioException) {
+			ioException.printStackTrace();
+		}
+
+		return _URL_CI_SYSTEM_STATUS;
+	}
+
 	private Map<Map<String, String>, Integer> _getSlaveUsageByLabels() {
 		Map<Map<String, String>, Integer> slaveUsages = new HashMap<>();
 
@@ -2474,7 +2492,7 @@ public abstract class BaseTopLevelBuild
 		"https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js";
 
 	private static final String _URL_CI_SYSTEM_STATUS =
-		"http://test-1-0.liferay.com/userContent/reports/ci-system-status" +
+		"https://test-1-0.liferay.com/userContent/reports/ci-system-status" +
 			"/index.html";
 
 	private static final Pattern _downstreamBuildURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
@@ -402,10 +402,17 @@ public abstract class BaseTopLevelBuildReport
 	@Override
 	public URL getTestResultsJSONUserContentURL() {
 		try {
+			String masterHostname = JenkinsResultsParserUtil.getBuildProperty(
+				"jenkins.remote.url[test-1-0]");
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(masterHostname)) {
+				masterHostname = "https://test-1-0.liferay.com/";
+			}
+
 			return new URL(
 				JenkinsResultsParserUtil.combine(
-					"https://test-1-0.liferay.com/userContent/testResults/",
-					getJobName(), "/builds/", String.valueOf(getBuildNumber()),
+					masterHostname, "userContent/testResults/", getJobName(),
+					"/builds/", String.valueOf(getBuildNumber()),
 					"/test.results.json"));
 		}
 		catch (IOException ioException) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
@@ -409,6 +409,10 @@ public abstract class BaseTopLevelBuildReport
 				masterHostname = "https://test-1-0.liferay.com/";
 			}
 
+			if (!masterHostname.endsWith("/")) {
+				masterHostname += "/";
+			}
+
 			return new URL(
 				JenkinsResultsParserUtil.combine(
 					masterHostname, "userContent/testResults/", getJobName(),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/GradleTaskFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/GradleTaskFailureMessageGenerator.java
@@ -104,7 +104,7 @@ public class GradleTaskFailureMessageGenerator
 	private static final String _TOKEN_WHERE = "* Where:";
 
 	private static final Pattern _javaErrorPattern = Pattern.compile(
-		"[^\\n]+.java:\\d+: error:[^\\n]+");
+		"[^\\n]+\\.java:\\d+: error:[^\\n]+");
 	private static final Pattern _taskFailedPattern = Pattern.compile(
 		"\\n(\\s+\\[exec\\] > Task :[^ ]+ FAILED)");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/GradleTaskFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/failure/message/generator/GradleTaskFailureMessageGenerator.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser.failure.message.generator;
 
 import com.liferay.jenkins.results.parser.Dom4JUtil;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 
 import java.io.IOException;
 
@@ -38,32 +39,57 @@ public class GradleTaskFailureMessageGenerator
 
 	@Override
 	public Element getMessageElement(String consoleText) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(consoleText)) {
+			return null;
+		}
+
 		StringBuilder sb = new StringBuilder();
 
-		Matcher matcher = _pattern.matcher(consoleText);
+		int start = consoleText.length();
 
-		if (matcher.find()) {
-			String snippet = matcher.group(1);
+		Matcher javaErrorMatcher = _javaErrorPattern.matcher(consoleText);
 
-			int start = consoleText.lastIndexOf(snippet);
+		if (javaErrorMatcher.find()) {
+			String snippet = javaErrorMatcher.group();
 
+			int snippetStart = consoleText.lastIndexOf(snippet);
+
+			if (snippetStart < start) {
+				start = snippetStart;
+			}
+		}
+
+		Matcher taskFailedMatcher = _taskFailedPattern.matcher(consoleText);
+
+		if (taskFailedMatcher.find()) {
+			String snippet = taskFailedMatcher.group(1);
+
+			int snippetStart = consoleText.lastIndexOf(snippet);
+
+			if (snippetStart < start) {
+				start = snippetStart;
+			}
+		}
+
+		if (start != consoleText.length()) {
 			sb.append(getConsoleTextSnippetByStart(consoleText, start));
 
 			sb.append("\n\n");
 		}
 
 		if (consoleText.contains(_TOKEN_WHAT_WENT_WRONG)) {
-			int start = consoleText.lastIndexOf(_TOKEN_WHAT_WENT_WRONG);
+			int snippetStart = consoleText.lastIndexOf(_TOKEN_WHAT_WENT_WRONG);
 
-			int whereIndex = consoleText.lastIndexOf(_TOKEN_WHERE, start);
+			int whereIndex = consoleText.lastIndexOf(
+				_TOKEN_WHERE, snippetStart);
 
 			if (whereIndex != -1) {
-				start = whereIndex;
+				snippetStart = whereIndex;
 			}
 
-			start = consoleText.lastIndexOf("\n", start);
+			snippetStart = consoleText.lastIndexOf("\n", snippetStart);
 
-			sb.append(getConsoleTextSnippetByStart(consoleText, start));
+			sb.append(getConsoleTextSnippetByStart(consoleText, snippetStart));
 		}
 
 		if (sb.length() == 0) {
@@ -77,7 +103,9 @@ public class GradleTaskFailureMessageGenerator
 
 	private static final String _TOKEN_WHERE = "* Where:";
 
-	private static final Pattern _pattern = Pattern.compile(
+	private static final Pattern _javaErrorPattern = Pattern.compile(
+		"[^\\n]+.java:\\d+: error:[^\\n]+");
+	private static final Pattern _taskFailedPattern = Pattern.compile(
 		"\\n(\\s+\\[exec\\] > Task :[^ ]+ FAILED)");
 
 }


### PR DESCRIPTION
[LRCI-6956](https://liferay.atlassian.net/browse/LRCI-6956)

Revises [#4268](https://github.com/pyoo47/liferay-portal/pull/4268) (opened by @michaelhashimoto) with the following follow-up commits:

- [cfb4655720ac](https://github.com/pyoo47/liferay-portal/commit/cfb4655720ace5143e70cd95ffe21e8d6b9e97c3) LRCI-6956 Ensure trailing slash on jenkins.remote.url[test-1-0] before URL concatenation
- [c7736ce0448c](https://github.com/pyoo47/liferay-portal/commit/c7736ce0448c453afa60caebb75aa13ea57cb471) LRCI-6956 Escape literal dot in _javaErrorPattern
