### PR TITLE
LRCI-7378 Stop amplifying primary failures into misleading PlaywrightBatchTestClassGroup and TestrayImporter NPE cascades

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PlaywrightBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PlaywrightBatchTestClassGroup.java
@@ -5,6 +5,7 @@
 
 package com.liferay.jenkins.results.parser.test.clazz.group;
 
+import com.liferay.jenkins.results.parser.AntException;
 import com.liferay.jenkins.results.parser.AntUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.NotificationUtil;
@@ -685,8 +686,18 @@ public class PlaywrightBatchTestClassGroup extends BatchTestClassGroup {
 					portalGitWorkingDirectory.getWorkingDirectory(),
 					"build.xml", "setup-yarn");
 			}
-			catch (Exception exception) {
-				exception.printStackTrace();
+			catch (AntException antException) {
+				System.out.println(
+					"Skipping Playwright class-group enumeration because " +
+						"setup-yarn failed");
+
+				antException.printStackTrace();
+
+				_playwrightJSONObject = new JSONObject();
+
+				_playwrightJSONObjectsLoaded.set(true);
+
+				return;
 			}
 
 			try {
@@ -716,6 +727,8 @@ public class PlaywrightBatchTestClassGroup extends BatchTestClassGroup {
 				_sendNotification("Unable to parse Playwright JSON object");
 
 				exception.printStackTrace();
+
+				_playwrightJSONObject = new JSONObject();
 			}
 
 			JSONArray errorsJSONArray = _playwrightJSONObject.optJSONArray(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -1193,9 +1193,7 @@ public class TestrayImporter {
 		}
 
 		throw new RuntimeException(
-			JenkinsResultsParserUtil.combine(
-				"Unable to resolve '", basePropertyName,
-				"' Build database has no jobs"));
+			"Unable to get job property " + basePropertyName);
 	}
 
 	private String _getMajorPortalVersion() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -1192,7 +1192,10 @@ public class TestrayImporter {
 			return JobPropertyFactory.newJobProperty(basePropertyName, job);
 		}
 
-		return null;
+		throw new RuntimeException(
+			JenkinsResultsParserUtil.combine(
+				"Unable to resolve '", basePropertyName,
+				"' Build database has no jobs"));
 	}
 
 	private String _getMajorPortalVersion() {


### PR DESCRIPTION
## JIRA

- [LRCI-7378](https://liferay.atlassian.net/browse/LRCI-7378)

## Summary

When a PR-tester run's primary `Execute shell` step fails (e.g. `workspaceGitRepository.setUp()` RuntimeException because the PR head SHA is no longer reachable on the upstream branch), `stop-current-job` cleanup invokes `PlaywrightBatchTestClassGroup._loadPlaywrightJSONObjects` against a half-initialized yarn workspace. `setup-yarn` throws, the previous code swallowed the exception and continued into `_callNPMCommand`, producing a `RuntimeException: Invalid NPM command output:` and a follow-on NPE on a still-null `_playwrightJSONObject`. The exception then propagated through `ParallelExecutor` into the Testray bsh block, where `TestrayImporter._getJobProperty` returned `null` for an empty `BuildDatabase`, generating a third NPE in `getTestrayServer`. Net effect: \~100 000 chars of derivative noise burying the real failure. This change short-circuits cleanly in both files so the primary failure is the first and last failure a log reader sees. Validated end-to-end with a deterministic synthetic-repro PR + candidate jar build on `test-1-41`.