### PR TITLE
LRCI-7434 Allow SanitizeLanguageTopLevelBuild to run without pull request parameters

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
@@ -46,7 +46,14 @@ public class SanitizeLanguageTopLevelBuild
 
 	@Override
 	public String getBranchName() {
-		return getParameterValue("GITHUB_UPSTREAM_BRANCH_NAME");
+		String upstreamBranchName = getParameterValue(
+			"GITHUB_UPSTREAM_BRANCH_NAME");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(upstreamBranchName)) {
+			return "master";
+		}
+
+		return upstreamBranchName;
 	}
 
 	@Override
@@ -79,8 +86,7 @@ public class SanitizeLanguageTopLevelBuild
 	@Override
 	public Workspace getWorkspace() {
 		Workspace workspace = WorkspaceFactory.newWorkspace(
-			"liferay-portal", getParameterValue("GITHUB_UPSTREAM_BRANCH_NAME"),
-			"sanitize-language");
+			"liferay-portal", getBranchName(), "sanitize-language");
 
 		if (workspace instanceof PortalWorkspace) {
 			PortalWorkspace portalWorkspace = (PortalWorkspace)workspace;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SanitizeLanguageTopLevelBuild.java
@@ -16,16 +16,27 @@ public class SanitizeLanguageTopLevelBuild
 
 		super(buildURL, topLevelBuild);
 
-		StringBuilder sb = new StringBuilder();
+		String receiverUsername = getParameterValue("GITHUB_RECEIVER_USERNAME");
+		String pullRequestNumber = getParameterValue(
+			"GITHUB_PULL_REQUEST_NUMBER");
 
-		sb.append("https://github.com/");
-		sb.append(getParameterValue("GITHUB_RECEIVER_USERNAME"));
-		sb.append("/liferay-portal");
+		if (JenkinsResultsParserUtil.isNullOrEmpty(receiverUsername) ||
+			JenkinsResultsParserUtil.isNullOrEmpty(pullRequestNumber) ||
+			pullRequestNumber.equals("0")) {
 
-		sb.append("/pull/");
-		sb.append(getParameterValue("GITHUB_PULL_REQUEST_NUMBER"));
+			_pullRequest = null;
+		}
+		else {
+			StringBuilder sb = new StringBuilder();
 
-		_pullRequest = PullRequestFactory.newPullRequest(sb.toString());
+			sb.append("https://github.com/");
+			sb.append(receiverUsername);
+			sb.append("/liferay-portal");
+			sb.append("/pull/");
+			sb.append(pullRequestNumber);
+
+			_pullRequest = PullRequestFactory.newPullRequest(sb.toString());
+		}
 	}
 
 	@Override
@@ -67,8 +78,6 @@ public class SanitizeLanguageTopLevelBuild
 
 	@Override
 	public Workspace getWorkspace() {
-		PullRequest pullRequest = getPullRequest();
-
 		Workspace workspace = WorkspaceFactory.newWorkspace(
 			"liferay-portal", getParameterValue("GITHUB_UPSTREAM_BRANCH_NAME"),
 			"sanitize-language");
@@ -82,7 +91,9 @@ public class SanitizeLanguageTopLevelBuild
 		WorkspaceGitRepository workspaceGitRepository =
 			workspace.getPrimaryWorkspaceGitRepository();
 
-		workspaceGitRepository.setGitHubURL(pullRequest.getHtmlURL());
+		if (_pullRequest != null) {
+			workspaceGitRepository.setGitHubURL(_pullRequest.getHtmlURL());
+		}
 
 		String senderBranchSHA = _getSenderBranchSHA();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7434

**What is being fixed:** SanitizeLanguageTopLevelBuild crashed when run without pull request parameters (GITHUB_RECEIVER_USERNAME / GITHUB_PULL_REQUEST_NUMBER absent or zero), and also failed when GITHUB_UPSTREAM_BRANCH_NAME was not provided.

**How it is being fixed:** The constructor now guards against missing or zero pull request parameters, setting _pullRequest to null when they are absent and skipping setGitHubURL accordingly. getBranchName falls back to "master" when GITHUB_UPSTREAM_BRANCH_NAME is empty, and getWorkspace uses getBranchName() instead of reading the parameter directly.