### PR TITLE
LRCI-7152 Tighten merge-conflict precheck against shallow-clone false positives

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -801,14 +801,7 @@ public class CIForwardProcessor {
 					expectedMergeBaseSHA)) {
 
 				System.out.println(
-					JenkinsResultsParserUtil.combine(
-						"Skipping merge conflict precheck: local merge ",
-						"base for ", senderRemoteGitBranch.getUsername(), ":",
-						senderRemoteGitBranch.getName(), " and ",
-						_recipientUsername, ":", upstreamBranchName,
-						" does not match GitHub-reported merge base ",
-						expectedMergeBaseSHA,
-						" after deepening the shallow clone."));
+					"WARNING: Unable to identify merge base SHA");
 
 				return false;
 			}
@@ -851,13 +844,8 @@ public class CIForwardProcessor {
 			}
 
 			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"Skipping merge conflict precheck: rebase failed ",
-					"without a content-conflict marker between ",
-					senderRemoteGitBranch.getUsername(), ":",
-					senderRemoteGitBranch.getName(), " and ",
-					_recipientUsername, ":", upstreamBranchName, "\n",
-					String.valueOf(message)));
+				"WARNING: Unable to detect merge conflict marker but rebase " +
+					"failed\n" + String.valueOf(message));
 
 			return false;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -788,11 +788,13 @@ public class CIForwardProcessor {
 				gitWorkingDirectory, senderSHA, receiverSHA,
 				expectedMergeBaseSHA)) {
 
-			Date bufferedDate = new Date(
-				mergeBaseCommitDate.getTime() - _MERGE_BASE_DATE_BUFFER_MILLIS);
+			Date deepenedSinceDate = new Date(
+				mergeBaseCommitDate.getTime() -
+					_BRANCH_DEEPENING_STEP_SIZE_MILLIS);
 
-			gitWorkingDirectory.fetch(receiverRemoteGitBranch, bufferedDate);
-			gitWorkingDirectory.fetch(senderRemoteGitBranch, bufferedDate);
+			gitWorkingDirectory.fetch(
+				receiverRemoteGitBranch, deepenedSinceDate);
+			gitWorkingDirectory.fetch(senderRemoteGitBranch, deepenedSinceDate);
 
 			if (!_localMergeBaseMatches(
 					gitWorkingDirectory, senderSHA, receiverSHA,
@@ -897,7 +899,7 @@ public class CIForwardProcessor {
 		}
 	}
 
-	private static final long _MERGE_BASE_DATE_BUFFER_MILLIS =
+	private static final long _BRANCH_DEEPENING_STEP_SIZE_MILLIS =
 		24L * 60L * 60L * 1000L;
 
 	private static final long _RETRY_PERIOD = 1000L * 60L;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -776,17 +776,47 @@ public class CIForwardProcessor {
 		}
 
 		String senderSHA = _pullRequest.getSenderSHA();
+		String receiverSHA = receiverRemoteGitBranch.getSHA();
+		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
 
 		Date mergeBaseCommitDate = mergeBaseCommit.getCommitDate();
 
 		gitWorkingDirectory.fetch(senderRemoteGitBranch, mergeBaseCommitDate);
 		gitWorkingDirectory.fetch(receiverRemoteGitBranch, mergeBaseCommitDate);
 
+		if (!_localMergeBaseMatches(
+				gitWorkingDirectory, senderSHA, receiverSHA,
+				expectedMergeBaseSHA)) {
+
+			Date bufferedDate = new Date(
+				mergeBaseCommitDate.getTime() - _MERGE_BASE_DATE_BUFFER_MILLIS);
+
+			gitWorkingDirectory.fetch(senderRemoteGitBranch, bufferedDate);
+			gitWorkingDirectory.fetch(receiverRemoteGitBranch, bufferedDate);
+
+			if (!_localMergeBaseMatches(
+					gitWorkingDirectory, senderSHA, receiverSHA,
+					expectedMergeBaseSHA)) {
+
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"Skipping merge conflict precheck: local merge ",
+						"base for ", senderRemoteGitBranch.getUsername(), ":",
+						senderRemoteGitBranch.getName(), " and ",
+						_recipientUsername, ":", upstreamBranchName,
+						" does not match GitHub-reported merge base ",
+						expectedMergeBaseSHA,
+						" after deepening the shallow clone."));
+
+				return false;
+			}
+		}
+
 		LocalGitBranch receiverLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
 				JenkinsResultsParserUtil.combine(
 					_recipientUsername, "-", upstreamBranchName, "-precheck"),
-				true, receiverRemoteGitBranch.getSHA());
+				true, receiverSHA);
 
 		LocalGitBranch senderLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
@@ -804,7 +834,9 @@ public class CIForwardProcessor {
 
 			String message = gitWorkingDirectoryRuntimeException.getMessage();
 
-			if ((message != null) && message.contains("Unable to rebase ")) {
+			if ((message != null) && message.contains("Unable to rebase ") &&
+				message.contains("CONFLICT (")) {
+
 				System.out.println(
 					JenkinsResultsParserUtil.combine(
 						"Detected merge conflict between ",
@@ -816,7 +848,16 @@ public class CIForwardProcessor {
 				return true;
 			}
 
-			throw gitWorkingDirectoryRuntimeException;
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"Skipping merge conflict precheck: rebase failed ",
+					"without a content-conflict marker between ",
+					senderRemoteGitBranch.getUsername(), ":",
+					senderRemoteGitBranch.getName(), " and ",
+					_recipientUsername, ":", upstreamBranchName, "\n",
+					String.valueOf(message)));
+
+			return false;
 		}
 	}
 
@@ -833,6 +874,31 @@ public class CIForwardProcessor {
 
 		return failedRequiredPassingTestSuiteNames.isEmpty();
 	}
+
+	private boolean _localMergeBaseMatches(
+		GitWorkingDirectory gitWorkingDirectory, String senderSHA,
+		String receiverSHA, String expectedMergeBaseSHA) {
+
+		try {
+			String localMergeBaseSHA =
+				gitWorkingDirectory.getMergeBaseCommitSHA(
+					senderSHA, receiverSHA);
+
+			if (localMergeBaseSHA != null) {
+				localMergeBaseSHA = localMergeBaseSHA.trim();
+			}
+
+			return expectedMergeBaseSHA.equals(localMergeBaseSHA);
+		}
+		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
+					gitWorkingDirectoryRuntimeException) {
+
+			return false;
+		}
+	}
+
+	private static final long _MERGE_BASE_DATE_BUFFER_MILLIS =
+		24L * 60L * 60L * 1000L;
 
 	private static final long _RETRY_PERIOD = 1000L * 60L;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -777,16 +777,10 @@ public class CIForwardProcessor {
 
 		String senderSHA = _pullRequest.getSenderSHA();
 
-		if (!gitWorkingDirectory.localSHAExists(senderSHA)) {
-			gitWorkingDirectory.fetch(senderRemoteGitBranch);
-		}
+		Date mergeBaseCommitDate = mergeBaseCommit.getCommitDate();
 
-		if (!gitWorkingDirectory.localSHAExists(
-				receiverRemoteGitBranch.getSHA())) {
-
-			gitWorkingDirectory.fetch(
-				receiverRemoteGitBranch, mergeBaseCommit.getCommitDate());
-		}
+		gitWorkingDirectory.fetch(senderRemoteGitBranch, mergeBaseCommitDate);
+		gitWorkingDirectory.fetch(receiverRemoteGitBranch, mergeBaseCommitDate);
 
 		LocalGitBranch receiverLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
@@ -816,7 +810,8 @@ public class CIForwardProcessor {
 						"Detected merge conflict between ",
 						senderRemoteGitBranch.getUsername(), ":",
 						senderRemoteGitBranch.getName(), " and ",
-						_recipientUsername, ":", upstreamBranchName));
+						_recipientUsername, ":", upstreamBranchName, "\n",
+						message));
 
 				return true;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -775,14 +775,14 @@ public class CIForwardProcessor {
 			return false;
 		}
 
-		String senderSHA = _pullRequest.getSenderSHA();
-		String receiverSHA = receiverRemoteGitBranch.getSHA();
 		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
+		String receiverSHA = receiverRemoteGitBranch.getSHA();
+		String senderSHA = _pullRequest.getSenderSHA();
 
 		Date mergeBaseCommitDate = mergeBaseCommit.getCommitDate();
 
-		gitWorkingDirectory.fetch(senderRemoteGitBranch, mergeBaseCommitDate);
 		gitWorkingDirectory.fetch(receiverRemoteGitBranch, mergeBaseCommitDate);
+		gitWorkingDirectory.fetch(senderRemoteGitBranch, mergeBaseCommitDate);
 
 		if (!_localMergeBaseMatches(
 				gitWorkingDirectory, senderSHA, receiverSHA,
@@ -791,8 +791,8 @@ public class CIForwardProcessor {
 			Date bufferedDate = new Date(
 				mergeBaseCommitDate.getTime() - _MERGE_BASE_DATE_BUFFER_MILLIS);
 
-			gitWorkingDirectory.fetch(senderRemoteGitBranch, bufferedDate);
 			gitWorkingDirectory.fetch(receiverRemoteGitBranch, bufferedDate);
+			gitWorkingDirectory.fetch(senderRemoteGitBranch, bufferedDate);
 
 			if (!_localMergeBaseMatches(
 					gitWorkingDirectory, senderSHA, receiverSHA,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -888,7 +888,7 @@ public class CIForwardProcessor {
 	}
 
 	private static final long _BRANCH_DEEPENING_STEP_SIZE_MILLIS =
-		24L * 60L * 60L * 1000L;
+		1000L * 60L * 60L * 24L;
 
 	private static final long _RETRY_PERIOD = 1000L * 60L;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -711,7 +711,7 @@ public class GitWorkingDirectory {
 
 		String remoteGitRefSHA = remoteGitRef.getSHA();
 
-		if (localSHAExists(remoteGitRefSHA)) {
+		if ((shallowSinceDate == null) && localSHAExists(remoteGitRefSHA)) {
 			System.out.println(
 				remoteGitRefSHA + " already exists in Git repository");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -7431,8 +7431,7 @@ public class JenkinsResultsParserUtil {
 	private static JSONArray _gitDirectoriesJSONArray;
 	private static final Pattern _gitHubAPIURLPattern = Pattern.compile(
 		"https\\:\\/\\/api\\.github\\.com(.*)");
-	private static final DateFormat _gitHubDateFormat = new SimpleDateFormat(
-		"yyyy-MM-dd'T'HH:mm:ss");
+	private static final DateFormat _gitHubDateFormat;
 	private static final Pattern _gitSHAPattern = Pattern.compile(
 		"^([0-9a-fA-F]{6}|[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$");
 	private static JSONArray _gitWorkingDirectoriesJSONArray;
@@ -7500,6 +7499,10 @@ public class JenkinsResultsParserUtil {
 		System.getProperty("user.home"));
 
 	static {
+		_gitHubDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		_gitHubDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
 		try {
 			_initializeRedactTokens();
 


### PR DESCRIPTION
- [LRCI-7152](https://liferay.atlassian.net/browse/LRCI-7152)

## Summary

Follow-up fixes to the `CIForwardProcessor` merge-conflict precheck shipped in #4266. Production runs surfaced spurious conflicts when the slave's shallow boundary fell after the merge-base commit, causing `git rebase` to replay the wrong commit set.

- Always honor `shallowSinceDate` in `GitWorkingDirectory.fetch(...)` instead of skipping the deepen when the SHA is already local.
- Parse GitHub's compare-API committer date as UTC (root-cause fix — the previous local-tz parse shifted `--shallow-since` past the merge base on PT slaves).
- Force-deepen both branches and re-check the local merge-base before rebasing; bail with a `WARNING:` when the deepen step still can't reproduce GitHub's merge base.
- Polish: alphabetize consecutive calls, rename `_MERGE_BASE_DATE_BUFFER_MILLIS` → `_BRANCH_DEEPENING_STEP_SIZE_MILLIS`, simplify warning prose.