### PR TITLE
LRCI-7477 Align ci:forward rebase target with the precheck baseline

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -244,11 +244,19 @@ public class PullRequest {
 				getUpstreamRemoteGitBranchName(),
 				gitRepositoryDir.getAbsolutePath(), getGitRepositoryName());
 
+		String senderSHA = getSenderSHA();
+
+		if (!gitWorkingDirectory.localSHAExists(senderSHA)) {
+			RemoteGitRef senderRemoteGitRef =
+				gitWorkingDirectory.getRemoteGitRef(
+					getSenderBranchName(), getSenderRemoteURL(), true);
+
+			gitWorkingDirectory.fetch(senderRemoteGitRef);
+		}
+
 		LocalGitBranch forwardLocalGitBranch =
-			gitWorkingDirectory.getRebasedLocalGitBranch(
-				forwardBranchName, getSenderBranchName(), getSenderRemoteURL(),
-				getSenderSHA(), getUpstreamRemoteGitBranchName(),
-				getUpstreamBranchSHA());
+			gitWorkingDirectory.createLocalGitBranch(
+				forwardBranchName, true, senderSHA);
 
 		RemoteGitBranch forwardRemoteGitBranch =
 			gitWorkingDirectory.pushToRemoteGitRepository(


### PR DESCRIPTION
## Related issues

- [LRCI-7477](https://liferay.atlassian.net/browse/LRCI-7477)

## Summary

Drops the second rebase from the `ci:forward` flow. The merge-conflict precheck against `brianchandotcom/master` (hardened by LRCI-7152) still runs and gates whether the forward proceeds, but its rebase result is discarded. `PullRequest.forward()` now skips the buggy `getRebasedLocalGitBranch(...)` call — which had been rebasing the sender onto a stale, cached `liferay/master` SHA and tripping over the shallow-clone boundary — and pushes the sender's original HEAD as-is. BChan rebases incoming PRs onto his master anyway (FF-only policy), so the merged result is the same.