### PR TITLE
LRCI-7496 Skip testray case results with the same portal SHA

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCaseResult.java
@@ -139,6 +139,12 @@ public class TestrayCaseResult {
 		return testrayCase.getName();
 	}
 
+	public String getPortalSHA() {
+		TestrayBuild testrayBuild = getTestrayBuild();
+
+		return testrayBuild.getPortalSHA();
+	}
+
 	public int getPriority() {
 		TestrayCase testrayCase = getTestrayCase();
 
@@ -241,6 +247,8 @@ public class TestrayCaseResult {
 						testrayServer, entityJSONObject);
 
 				if (!Objects.equals(
+						testrayCaseResult.getPortalSHA(), getPortalSHA()) &&
+					!Objects.equals(
 						testrayCaseResult.getPullRequestSenderUsername(),
 						getPullRequestSenderUsername())) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7496

## What is being fixed

`TestrayCaseResult#getTestrayCaseResultHistory` builds the history for a case result by filtering only on pull request sender. As a result, reruns at the same portal SHA show up as separate entries in the history, even though they restate the same underlying result.

## How it is being fixed

Add a `getPortalSHA()` accessor on `TestrayCaseResult` and extend the history filter to also exclude case results whose portal SHA matches the current result's portal SHA.

## Why are there no tests?

This change exercises live Testray server responses through `TestrayServer#requestGraphQL`. The fix will be validated by running the change against CI rather than via local unit tests.