### PR TITLE
LRCI-6672 Cache testray attachment and cloud object lookups

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
@@ -199,6 +199,30 @@ public abstract class BaseBuildReport implements BuildReport {
 	}
 
 	@Override
+	public URL getTestrayAttachmentURLBySuffix(String suffix) {
+		if (_testrayAttachmentURLsBySuffix.containsKey(suffix)) {
+			return _testrayAttachmentURLsBySuffix.get(suffix);
+		}
+
+		URL matchedURL = null;
+
+		for (URL testrayAttachmentURL : getTestrayAttachmentURLs()) {
+			String testrayAttachmentURLString = String.valueOf(
+				testrayAttachmentURL);
+
+			if (testrayAttachmentURLString.endsWith(suffix)) {
+				matchedURL = testrayAttachmentURL;
+
+				break;
+			}
+		}
+
+		_testrayAttachmentURLsBySuffix.put(suffix, matchedURL);
+
+		return matchedURL;
+	}
+
+	@Override
 	public List<URL> getTestrayAttachmentURLs() {
 		if (_testrayAttachmentURLs != null) {
 			return _testrayAttachmentURLs;
@@ -285,5 +309,7 @@ public abstract class BaseBuildReport implements BuildReport {
 	private final URL _buildURL;
 	private JenkinsMaster _jenkinsMaster;
 	private List<URL> _testrayAttachmentURLs;
+	private final Map<String, URL> _testrayAttachmentURLsBySuffix =
+		new HashMap<>();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
@@ -200,19 +200,27 @@ public abstract class BaseBuildReport implements BuildReport {
 
 	@Override
 	public List<URL> getTestrayAttachmentURLs() {
+		if (_testrayAttachmentURLs != null) {
+			return _testrayAttachmentURLs;
+		}
+
 		List<URL> testrayAttachmentURLs = new ArrayList<>();
 
 		JSONObject buildReportJSONObject = getBuildReportJSONObject();
 
 		if (buildReportJSONObject == null) {
-			return testrayAttachmentURLs;
+			_testrayAttachmentURLs = testrayAttachmentURLs;
+
+			return _testrayAttachmentURLs;
 		}
 
 		JSONArray testrayAttachmentURLsJSONArray =
 			buildReportJSONObject.optJSONArray("testrayAttachmentURLs");
 
 		if (testrayAttachmentURLsJSONArray == null) {
-			return testrayAttachmentURLs;
+			_testrayAttachmentURLs = testrayAttachmentURLs;
+
+			return _testrayAttachmentURLs;
 		}
 
 		for (int i = 0; i < testrayAttachmentURLsJSONArray.length(); i++) {
@@ -225,7 +233,9 @@ public abstract class BaseBuildReport implements BuildReport {
 			}
 		}
 
-		return testrayAttachmentURLs;
+		_testrayAttachmentURLs = testrayAttachmentURLs;
+
+		return _testrayAttachmentURLs;
 	}
 
 	@Override
@@ -274,5 +284,6 @@ public abstract class BaseBuildReport implements BuildReport {
 
 	private final URL _buildURL;
 	private JenkinsMaster _jenkinsMaster;
+	private List<URL> _testrayAttachmentURLs;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildReport.java
@@ -42,6 +42,8 @@ public interface BuildReport {
 
 	public StopWatchRecordsGroup getStopWatchRecordsGroup();
 
+	public URL getTestrayAttachmentURLBySuffix(String suffix);
+
 	public List<URL> getTestrayAttachmentURLs();
 
 	public boolean isFailing();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BuildTestrayCaseResult.java
@@ -94,39 +94,35 @@ public abstract class BuildTestrayCaseResult extends TestrayCaseResult {
 			return null;
 		}
 
-		for (URL testrayAttachmentURL :
-				buildReport.getTestrayAttachmentURLs()) {
+		URL testrayAttachmentURL = buildReport.getTestrayAttachmentURLBySuffix(
+			key);
 
+		if (testrayAttachmentURL == null) {
+			return null;
+		}
+
+		String cloudObjectPath;
+
+		try {
+			String buildBaseArtifactURL =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"build.base.artifact.url");
 			String testrayAttachmentURLString = String.valueOf(
 				testrayAttachmentURL);
 
-			if (!testrayAttachmentURLString.endsWith(key)) {
-				continue;
-			}
-
-			String cloudObjectPath = null;
-
-			try {
-				String buildBaseArtifactURL =
-					JenkinsResultsParserUtil.getBuildProperty(
-						"build.base.artifact.url");
-
-				cloudObjectPath = testrayAttachmentURLString.replace(
-					buildBaseArtifactURL + "/", "");
-			}
-			catch (IOException ioException) {
-				continue;
-			}
-
-			TestrayAttachment testrayAttachment =
-				new CloudObjectTestrayAttachment(this, name, cloudObjectPath);
-
-			_testrayAttachments.put(key, testrayAttachment);
-
-			return _testrayAttachments.get(key);
+			cloudObjectPath = testrayAttachmentURLString.replace(
+				buildBaseArtifactURL + "/", "");
+		}
+		catch (IOException ioException) {
+			return null;
 		}
 
-		return null;
+		TestrayAttachment testrayAttachment = new CloudObjectTestrayAttachment(
+			this, name, cloudObjectPath);
+
+		_testrayAttachments.put(key, testrayAttachment);
+
+		return testrayAttachment;
 	}
 
 	protected File getTestrayUploadBaseDir() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -183,6 +184,8 @@ public class TestrayCloudBucket {
 			TestrayCloudObject testrayCloudObject =
 				TestrayCloudObjectFactory.newTestrayCloudObject(this, blob);
 
+			_testrayCloudObjectsByKey.put(key, testrayCloudObject);
+
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
 					"Created Cloud Object ", testrayCloudObject.getURLString(),
@@ -216,6 +219,8 @@ public class TestrayCloudBucket {
 
 		TestrayCloudObject testrayCloudObject =
 			TestrayCloudObjectFactory.newTestrayCloudObject(this, blob);
+
+		_testrayCloudObjectsByKey.put(key, testrayCloudObject);
 
 		System.out.println(
 			JenkinsResultsParserUtil.combine(
@@ -251,7 +256,13 @@ public class TestrayCloudBucket {
 	public void deleteTestrayCloudObject(
 		TestrayCloudObject testrayCloudObject) {
 
+		if (testrayCloudObject == null) {
+			return;
+		}
+
 		testrayCloudObject.delete();
+
+		_testrayCloudObjectsByKey.remove(testrayCloudObject.getKey());
 	}
 
 	public void deleteTestrayCloudObjects(
@@ -323,6 +334,13 @@ public class TestrayCloudBucket {
 	}
 
 	public TestrayCloudObject getTestrayCloudObject(String key) {
+		TestrayCloudObject testrayCloudObject = _testrayCloudObjectsByKey.get(
+			key);
+
+		if (testrayCloudObject != null) {
+			return testrayCloudObject;
+		}
+
 		Bucket bucket = _getBucket();
 
 		Blob blob = bucket.get(key);
@@ -331,7 +349,12 @@ public class TestrayCloudBucket {
 			return null;
 		}
 
-		return TestrayCloudObjectFactory.newTestrayCloudObject(this, blob);
+		testrayCloudObject = TestrayCloudObjectFactory.newTestrayCloudObject(
+			this, blob);
+
+		_testrayCloudObjectsByKey.put(key, testrayCloudObject);
+
+		return testrayCloudObject;
 	}
 
 	public List<TestrayCloudObject> getTestrayCloudObjects() {
@@ -405,5 +428,7 @@ public class TestrayCloudBucket {
 		JenkinsResultsParserUtil.getNewThreadPoolExecutor(16, true);
 
 	private final String _name;
+	private final Map<String, TestrayCloudObject> _testrayCloudObjectsByKey =
+		new ConcurrentHashMap<>();
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6672

**What is being fixed:** `recordTestrayCaseResults` in the testray import path performs redundant work on every test case result. `BaseBuildReport.getTestrayAttachmentURLs()` re-parses the build-report JSON array and re-allocates fresh URL objects on each call. `BuildTestrayCaseResult.getTestrayAttachment(buildReport, name, key)` does an O(N) linear scan with `endsWith(key)` per call to find the matching URL, plus a property-file lookup inside the loop. And `CloudObjectTestrayAttachment`'s constructor calls `TestrayCloudBucket.getTestrayCloudObject(key)`, which makes a GCS network round-trip every time. On a 500-case playwright axis with ~15 attachments per case, this adds up to thousands of redundant URL scans and GCS round-trips per axis.

**How it is being fixed:** Three caching layers, axis-scoped or bucket-scoped, all safe across the existing one-thread-per-axis execution model. First, memoize the URL list returned by `getTestrayAttachmentURLs()` on the BuildReport instance — the JSON array doesn't change during recording, so parsing once is enough. Second, add a new `getTestrayAttachmentURLBySuffix(String)` method on `BuildReport` backed by a memoized `Map<String, URL>`; refactor `getTestrayAttachment` to use it, replacing the per-call O(N) scan with an O(1) lookup after the first miss. Third, cache `TestrayCloudObject` results in `TestrayCloudBucket` using a `ConcurrentHashMap` keyed by object key, with cache invalidation on `createTestrayCloudObject` and `deleteTestrayCloudObject` paths. The bucket is a singleton, so axis-level keys (jenkins-console, build-report, etc.) that repeat across all cases in an axis hit the cache after the first call, eliminating the GCS round-trip per attachment.