### PR TITLE
LRCI-7431 Remove setUpPortalProfile method

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
@@ -124,12 +124,6 @@ public class PortalWorkspace extends BaseWorkspace {
 
 		super.setUp();
 
-		Job.BuildProfile buildProfile = getBuildProfile();
-
-		if (buildProfile == Job.BuildProfile.DXP) {
-			portalWorkspaceGitRepository.setUpPortalProfile();
-		}
-
 		portalWorkspaceGitRepository.setUpTCKHome();
 
 		updateOSBAsahModule();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -131,35 +131,6 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			"liferay-portal-ee", getUpstreamBranchName() + "-private");
 	}
 
-	public void setUpPortalProfile() {
-		String upstreamBranchName = getUpstreamBranchName();
-
-		if (upstreamBranchName.startsWith("ee-")) {
-			return;
-		}
-
-		Retryable<Object> setupProfileDXPRetryable = new Retryable<Object>(
-			true, _SETUP_PROFILE_DXP_RETRY_COUNT,
-			_SETUP_PROFILE_DXP_RETRY_DELAY, true) {
-
-			@Override
-			public Object execute() {
-				try {
-					AntUtil.callTarget(
-						getDirectory(), "build.xml", "setup-profile-dxp");
-				}
-				catch (AntException antException) {
-					throw new RuntimeException(antException);
-				}
-
-				return null;
-			}
-
-		};
-
-		setupProfileDXPRetryable.executeWithRetries();
-	}
-
 	public void setUpTCKHome() {
 		Map<String, String> parameters = new HashMap<>();
 
@@ -420,10 +391,6 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 					"test.", System.getenv("HOSTNAME"), ".properties")),
 			_getPortalTestProperties(), true);
 	}
-
-	private static final int _SETUP_PROFILE_DXP_RETRY_COUNT = 2;
-
-	private static final int _SETUP_PROFILE_DXP_RETRY_DELAY = 5;
 
 	private Properties _appServerProperties;
 	private boolean _setUpBinariesCache;


### PR DESCRIPTION
## Summary
- Removes `setUpPortalProfile()` from `PortalWorkspaceGitRepository` and its caller in `PortalWorkspace.setUp()`.
- After LPD-88242 made DXP the default `build.profile` and dropped the Gradle plugin that consumed `build.profile-dxp.properties`, the `setup-profile-dxp` ant target this method invoked no longer does meaningful work on master or `7.x` branches.
- The retry constants used only by the removed method (`_SETUP_PROFILE_DXP_RETRY_COUNT`, `_SETUP_PROFILE_DXP_RETRY_DELAY`) are dropped alongside.

## Notes
On `release-YYYY.qN` branches, portal's `setup-profile-dxp` target still invokes `update-gradle-properties`. This PR removes the Java-side trigger; if any release-branch job depends on that path, a direct `update-gradle-properties` invocation may need to be added back separately.

## Test plan
- [ ] CI smoke test on a `master` upstream-controller job — confirm `setUpPortalProfile` removal does not regress workspace setup.
- [ ] CI smoke test on a `release-YYYY.qN` upstream-controller job — confirm gradle properties still resolve correctly without the explicit ant call.