### PR TITLE
LRCI-7493 Remove WordUtils dependency by inlining capitalize logic

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -32,8 +32,6 @@ import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.WordUtils;
-
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
@@ -228,7 +226,16 @@ public class BatchBuildTestrayCaseResult
 				if (teamComponentName.equals(componentName)) {
 					teamName = teamName.replace("-", " ");
 
-					return WordUtils.capitalize(teamName);
+					StringBuilder sb = new StringBuilder(teamName);
+
+					for (int i = 0; i < sb.length(); i++) {
+						if ((i == 0) || (sb.charAt(i - 1) == ' ')) {
+							sb.setCharAt(
+								i, Character.toUpperCase(sb.charAt(i)));
+						}
+					}
+
+					return sb.toString();
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Removes the `org.apache.commons.lang.WordUtils` import from `BatchBuildTestrayCaseResult.java`
- Replaces the single `WordUtils.capitalize()` call with an inline JDK `StringBuilder` loop — no new dependencies needed
- Verified with `../../../gradlew test jar` → BUILD SUCCESSFUL

## Test plan

- [ ] `../../../gradlew test jar` passes from `modules/test/jenkins-results-parser`