### PR TITLE
LRCI-7493 Remove WordUtils dependency by inlining capitalize logic (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -224,18 +224,8 @@ public class BatchBuildTestrayCaseResult
 
 			for (String teamComponentName : teamComponentNames.split(",")) {
 				if (teamComponentName.equals(componentName)) {
-					teamName = teamName.replace("-", " ");
-
-					StringBuilder sb = new StringBuilder(teamName);
-
-					for (int i = 0; i < sb.length(); i++) {
-						if ((i == 0) || (sb.charAt(i - 1) == ' ')) {
-							sb.setCharAt(
-								i, Character.toUpperCase(sb.charAt(i)));
-						}
-					}
-
-					return sb.toString();
+					return _uppercaseFirstLetterOfEachWord(
+						teamName.replace("-", " "));
 				}
 			}
 		}
@@ -775,6 +765,18 @@ public class BatchBuildTestrayCaseResult
 	private TestrayAttachment _getWarningsTestrayAttachment() {
 		return getTestrayAttachment(
 			getBuildReport(), "Warnings", getAxisName() + "/warnings.html.gz");
+	}
+
+	private String _uppercaseFirstLetterOfEachWord(String string) {
+		StringBuilder sb = new StringBuilder(string);
+
+		for (int i = 0; i < sb.length(); i++) {
+			if ((i == 0) || (sb.charAt(i - 1) == ' ')) {
+				sb.setCharAt(i, Character.toUpperCase(sb.charAt(i)));
+			}
+		}
+
+		return sb.toString();
 	}
 
 	private static final Pattern _dockerLogsURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -32,8 +32,6 @@ import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.text.WordUtils;
-
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
@@ -228,7 +226,16 @@ public class BatchBuildTestrayCaseResult
 				if (teamComponentName.equals(componentName)) {
 					teamName = teamName.replace("-", " ");
 
-					return WordUtils.capitalize(teamName);
+					StringBuilder sb = new StringBuilder(teamName);
+
+					for (int i = 0; i < sb.length(); i++) {
+						if ((i == 0) || (sb.charAt(i - 1) == ' ')) {
+							sb.setCharAt(
+								i, Character.toUpperCase(sb.charAt(i)));
+						}
+					}
+
+					return sb.toString();
 				}
 			}
 		}


### PR DESCRIPTION
[LRCI-7493](https://liferay.atlassian.net/browse/LRCI-7493)

Revises [#4297](https://github.com/pyoo47/liferay-portal/pull/4297) (opened by @CharlotteFrancis) with the following follow-up commits:

- [58a4717ae8ac](https://github.com/pyoo47/liferay-portal/commit/58a4717ae8ac86da0ccb9e4c303941bcdbc8579a) LRCI-7493 Extract capitalize logic to a private helper method
