### PR TITLE
LRCI-7456 Add PullRequest.getMergeableState to jenkins-results-parser

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -591,7 +591,12 @@ public class PullRequest {
 
 			@Override
 			public String execute() {
-				_refreshJSONObject();
+				if (_firstAttempt) {
+					_firstAttempt = false;
+				}
+				else {
+					_refreshJSONObject();
+				}
 
 				String mergeableState = _jsonObject.getString(
 					"mergeable_state");
@@ -602,6 +607,8 @@ public class PullRequest {
 
 				return mergeableState;
 			}
+
+			private boolean _firstAttempt = true;
 
 		};
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -586,6 +586,12 @@ public class PullRequest {
 			getSenderUsername(), "-", getNumber(), "-", getSenderBranchName());
 	}
 
+	public String getMergeableState() {
+		_refreshJSONObject();
+
+		return _jsonObject.getString("mergeable_state");
+	}
+
 	public String getNumber() {
 		return String.valueOf(_number);
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -587,9 +587,25 @@ public class PullRequest {
 	}
 
 	public String getMergeableState() {
-		_refreshJSONObject();
+		Retryable<String> retryable = new Retryable<String>(false, 5, 5, true) {
 
-		return _jsonObject.getString("mergeable_state");
+			@Override
+			public String execute() {
+				_refreshJSONObject();
+
+				String mergeableState = _jsonObject.getString(
+					"mergeable_state");
+
+				if (mergeableState.equals("unknown")) {
+					throw new RuntimeException("mergeable_state is unknown");
+				}
+
+				return mergeableState;
+			}
+
+		};
+
+		return retryable.executeWithRetries();
 	}
 
 	public String getNumber() {


### PR DESCRIPTION
- [LRCI-7456](https://liferay.atlassian.net/browse/LRCI-7456)

## Summary

Adds `PullRequest.getMergeableState()` to jenkins-results-parser. The method wraps the read in `Retryable<String>` (5 retries × 5s, no exception on exhaustion) that throws `RuntimeException` when the payload's `mergeable_state` is `"unknown"`, engaging the retry. The first attempt reads the construction-time cached `_jsonObject`; retries call `_refreshJSONObject()` before re-reading.

Consumer: the `auto-close-merge-conflict-pullrequest` Jenkins job (parent ticket [LRCI-6965](https://liferay.atlassian.net/browse/LRCI-6965)) calls this once per dispatched build to decide whether to post the merge-conflict comment and close the PR.