### PR TITLE
LRCI-7514 Apply caching pattern to remaining attachment URL scans

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
@@ -301,6 +301,12 @@ public abstract class BaseBuildReport implements BuildReport {
 		}
 	}
 
+	protected void clearTestrayAttachmentURLCaches() {
+		_testrayAttachmentURLs = null;
+
+		_testrayAttachmentURLsBySuffix.clear();
+	}
+
 	private static final Pattern _buildURLPattern = Pattern.compile(
 		"(?<jobURL>https?://(?<masterHostname>test-\\d+-\\d+(-aws)?)" +
 			"(\\.liferay\\.com)?/job/(?<jobName>[^/]+))" +

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
@@ -122,19 +122,27 @@ public abstract class BaseDownstreamBuildReport
 
 	@Override
 	public List<TestReport> getTestReports() {
+		if (_testReports != null) {
+			return _testReports;
+		}
+
 		List<TestReport> testReports = new ArrayList<>();
 
 		JSONObject buildReportJSONObject = getBuildReportJSONObject();
 
 		if (buildReportJSONObject == null) {
-			return testReports;
+			_testReports = testReports;
+
+			return _testReports;
 		}
 
 		JSONArray testResultsJSONArray = buildReportJSONObject.optJSONArray(
 			"testResults");
 
 		if (testResultsJSONArray == null) {
-			return testReports;
+			_testReports = testReports;
+
+			return _testReports;
 		}
 
 		for (int i = 0; i < testResultsJSONArray.length(); i++) {
@@ -143,7 +151,9 @@ public abstract class BaseDownstreamBuildReport
 					this, testResultsJSONArray.getJSONObject(i)));
 		}
 
-		return testReports;
+		_testReports = testReports;
+
+		return _testReports;
 	}
 
 	@Override
@@ -206,6 +216,7 @@ public abstract class BaseDownstreamBuildReport
 	private final boolean _buildCached;
 	private final JSONObject _buildReportJSONObject;
 	private Map<String, TestClassReport> _testClassReportsMap;
+	private List<TestReport> _testReports;
 	private final TopLevelBuildReport _topLevelBuildReport;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultTopLevelBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultTopLevelBuildReport.java
@@ -30,6 +30,8 @@ public class DefaultTopLevelBuildReport extends BaseTopLevelBuildReport {
 		}
 
 		_testrayAttachmentURLs.add(testrayAttachmentURL);
+
+		clearTestrayAttachmentURLCaches();
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
@@ -268,22 +268,10 @@ public class PlaywrightBatchBuildTestrayCaseResult
 
 		String traceZipFilePath = matcher.group("traceZipFilePath");
 
-		URL traceZipURL = null;
-
 		BuildReport buildReport = getBuildReport();
 
-		for (URL testrayAttachmentURL :
-				buildReport.getTestrayAttachmentURLs()) {
-
-			String testrayAttachmentURLString = String.valueOf(
-				testrayAttachmentURL);
-
-			if (testrayAttachmentURLString.endsWith(traceZipFilePath)) {
-				traceZipURL = testrayAttachmentURL;
-
-				break;
-			}
-		}
+		URL traceZipURL = buildReport.getTestrayAttachmentURLBySuffix(
+			traceZipFilePath);
 
 		if (traceZipURL == null) {
 			return null;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7514

## What is being fixed

LRCI-6672 introduced suffix-based caching of testray attachment URLs in BuildReport. Three related sites still used the older linear-scan or per-call allocation pattern. PlaywrightBatchBuildTestrayCaseResult.getPlaywrightTraceViewerTestrayAttachment() did its own scan through getTestrayAttachmentURLs() to match the trace zip path. BaseDownstreamBuildReport.getTestReports() re-parsed the build report JSON and reallocated fresh TestReport objects on every call. DefaultTopLevelBuildReport.addTestrayAttachmentURL() left stale entries in BaseBuildReport's URL list cache and per-suffix cache when new URLs were appended, so case results that asked for a top-level attachment after the upload could see a stale null.

## How it is being fixed

The playwright trace viewer lookup now delegates to BuildReport.getTestrayAttachmentURLBySuffix(), reusing the LRCI-6672 cache instead of reimplementing the scan. BaseDownstreamBuildReport.getTestReports() memoizes its result in a _testReports field, mirroring the field-cache pattern LRCI-6672 used for getTestrayAttachmentURLs(). DefaultTopLevelBuildReport.addTestrayAttachmentURL() clears the inherited testray attachment URL caches after appending to the local list, so subsequent lookups re-snapshot rather than returning the pre-mutation view.

## Why are there no tests?

Ran it against stable and results looked good.