### PR TITLE
LRCI-7514 Apply caching pattern to remaining attachment URL scans (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildReport.java
@@ -301,6 +301,12 @@ public abstract class BaseBuildReport implements BuildReport {
 		}
 	}
 
+	protected void clearTestrayAttachmentURLCaches() {
+		_testrayAttachmentURLs = null;
+
+		_testrayAttachmentURLsBySuffix.clear();
+	}
+
 	private static final Pattern _buildURLPattern = Pattern.compile(
 		"(?<jobURL>https?://(?<masterHostname>test-\\d+-\\d+(-aws)?)" +
 			"(\\.liferay\\.com)?/job/(?<jobName>[^/]+))" +

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
@@ -122,19 +122,27 @@ public abstract class BaseDownstreamBuildReport
 
 	@Override
 	public List<TestReport> getTestReports() {
+		if (_testReports != null) {
+			return _testReports;
+		}
+
 		List<TestReport> testReports = new ArrayList<>();
 
 		JSONObject buildReportJSONObject = getBuildReportJSONObject();
 
 		if (buildReportJSONObject == null) {
-			return testReports;
+			_testReports = testReports;
+
+			return _testReports;
 		}
 
 		JSONArray testResultsJSONArray = buildReportJSONObject.optJSONArray(
 			"testResults");
 
 		if (testResultsJSONArray == null) {
-			return testReports;
+			_testReports = testReports;
+
+			return _testReports;
 		}
 
 		for (int i = 0; i < testResultsJSONArray.length(); i++) {
@@ -143,7 +151,9 @@ public abstract class BaseDownstreamBuildReport
 					this, testResultsJSONArray.getJSONObject(i)));
 		}
 
-		return testReports;
+		_testReports = testReports;
+
+		return _testReports;
 	}
 
 	@Override
@@ -206,6 +216,7 @@ public abstract class BaseDownstreamBuildReport
 	private final boolean _buildCached;
 	private final JSONObject _buildReportJSONObject;
 	private Map<String, TestClassReport> _testClassReportsMap;
+	private List<TestReport> _testReports;
 	private final TopLevelBuildReport _topLevelBuildReport;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
@@ -81,6 +81,8 @@ public abstract class BaseTopLevelBuildReport
 		jsonArray.put(String.valueOf(testrayAttachmentURL));
 
 		buildReportJSONObject.put("testrayAttachmentURLs", jsonArray);
+
+		clearTestrayAttachmentURLCaches();
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultTopLevelBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultTopLevelBuildReport.java
@@ -30,6 +30,8 @@ public class DefaultTopLevelBuildReport extends BaseTopLevelBuildReport {
 		}
 
 		_testrayAttachmentURLs.add(testrayAttachmentURL);
+
+		clearTestrayAttachmentURLCaches();
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
@@ -268,22 +268,10 @@ public class PlaywrightBatchBuildTestrayCaseResult
 
 		String traceZipFilePath = matcher.group("traceZipFilePath");
 
-		URL traceZipURL = null;
-
 		BuildReport buildReport = getBuildReport();
 
-		for (URL testrayAttachmentURL :
-				buildReport.getTestrayAttachmentURLs()) {
-
-			String testrayAttachmentURLString = String.valueOf(
-				testrayAttachmentURL);
-
-			if (testrayAttachmentURLString.endsWith(traceZipFilePath)) {
-				traceZipURL = testrayAttachmentURL;
-
-				break;
-			}
-		}
+		URL traceZipURL = buildReport.getTestrayAttachmentURLBySuffix(
+			traceZipFilePath);
 
 		if (traceZipURL == null) {
 			return null;


### PR DESCRIPTION
[LRCI-7514](https://liferay.atlassian.net/browse/LRCI-7514)

Revises [#4300](https://github.com/pyoo47/liferay-portal/pull/4300) (opened by @brittneyq) with the following follow-up commits:

- [97d8cc5a55f8](https://github.com/pyoo47/liferay-portal/commit/97d8cc5a55f8bdd1c6af5687b3d46e4a248e13fe) LRCI-7514 Invalidate testray attachment URL caches in BaseTopLevelBuildReport
