### PR TITLE
LRCI-7262 Modify mirrors-get task so it will never try mirrors when not running in CI

### DIFF
--- a/modules/sdk/ant-mirrors-get/build.gradle
+++ b/modules/sdk/ant-mirrors-get/build.gradle
@@ -9,10 +9,15 @@ clean {
 
 dependencies {
 	compileOnly group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
+	testImplementation group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
 }
 
 liferay {
 	deployDir = file("../../../lib/development")
+}
+
+test {
+	jvmArgs "--add-opens", "java.base/java.util=ALL-UNNAMED"
 }
 
 updateFileVersions {

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -1278,7 +1278,9 @@ public class MirrorsGetTask extends Task {
 	private boolean _skipChecksum;
 	private String _src;
 	private boolean _ssl;
-	private boolean _tryLocalNetwork = true;
+	private boolean _tryLocalNetwork =
+		(System.getenv("JENKINS_URL") != null) ||
+		(System.getenv("MASTER_NETWORK_NAME") != null);
 	private String _userAgent;
 	private String _username;
 	private boolean _verbose;

--- a/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
+++ b/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ant.mirrors.get;
+
+import java.lang.reflect.Field;
+
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Charlotte Wong
+ */
+public class MirrorsGetTaskTest {
+
+	@Before
+	public void setUp() {
+		_originalJenkinsURL = System.getenv("JENKINS_URL");
+		_originalMasterNetworkName = System.getenv("MASTER_NETWORK_NAME");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_restoreEnv("JENKINS_URL", _originalJenkinsURL);
+		_restoreEnv("MASTER_NETWORK_NAME", _originalMasterNetworkName);
+	}
+
+	@Test
+	public void testTryLocalNetworkFalseWhenNoCIEnvVarsSet() throws Exception {
+		_removeEnv("JENKINS_URL");
+		_removeEnv("MASTER_NETWORK_NAME");
+
+		Assert.assertFalse(_getTryLocalNetwork(new MirrorsGetTask()));
+	}
+
+	@Test
+	public void testTryLocalNetworkTrueWhenJenkinsURLSet() throws Exception {
+		_removeEnv("MASTER_NETWORK_NAME");
+		_setEnv("JENKINS_URL", "http://test-1-41.liferay.com");
+
+		Assert.assertTrue(_getTryLocalNetwork(new MirrorsGetTask()));
+	}
+
+	@Test
+	public void testTryLocalNetworkTrueWhenMasterNetworkNameSet()
+		throws Exception {
+
+		_removeEnv("JENKINS_URL");
+		_setEnv("MASTER_NETWORK_NAME", "test-network");
+
+		Assert.assertTrue(_getTryLocalNetwork(new MirrorsGetTask()));
+	}
+
+	private boolean _getTryLocalNetwork(MirrorsGetTask task) throws Exception {
+		Field field = MirrorsGetTask.class.getDeclaredField("_tryLocalNetwork");
+
+		field.setAccessible(true);
+
+		return (boolean)field.get(task);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, String> _getWritableEnv() throws Exception {
+		Map<String, String> env = System.getenv();
+
+		Field field = env.getClass().getDeclaredField("m");
+
+		field.setAccessible(true);
+
+		return (Map<String, String>)field.get(env);
+	}
+
+	private void _removeEnv(String name) throws Exception {
+		_getWritableEnv().remove(name);
+	}
+
+	private void _restoreEnv(String name, String value) throws Exception {
+		if (value == null) {
+			_removeEnv(name);
+		}
+		else {
+			_setEnv(name, value);
+		}
+	}
+
+	private void _setEnv(String name, String value) throws Exception {
+		_getWritableEnv().put(name, value);
+	}
+
+	private String _originalJenkinsURL;
+	private String _originalMasterNetworkName;
+
+}

--- a/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
+++ b/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
@@ -1,13 +1,20 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.ant.mirrors.get;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
 import java.lang.reflect.Field;
 
+import java.nio.file.Files;
+
 import java.util.Map;
+
+import org.apache.tools.ant.Project;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -32,11 +39,102 @@ public class MirrorsGetTaskTest {
 	}
 
 	@Test
+	public void testMirrorConnectionAttemptedWhenJenkinsURLSet()
+		throws Exception {
+
+		_removeEnv("MASTER_NETWORK_NAME");
+		_setEnv("JENKINS_URL", "http://test-1-41.liferay.com");
+
+		Project antProject = new Project();
+
+		antProject.setProperty("mirrors.hostname", "mirrors.lax.liferay.com");
+
+		MirrorsGetTask task = new MirrorsGetTask();
+
+		task.setProject(antProject);
+		task.setTaskName("mirrors-get");
+		task.setVerbose(true);
+		task.setSrc(
+			"https://repository.liferay.com/nexus/content/groups/public" +
+				"/nonexistent-lrci-7262-test/file.jar");
+		task.setDest(
+			Files.createTempDirectory(
+				"mirrors-get-test"
+			).toFile());
+
+		ByteArrayOutputStream capturedByteArrayOutputStream =
+			new ByteArrayOutputStream();
+		PrintStream originalOut = System.out;
+
+		System.setOut(new PrintStream(capturedByteArrayOutputStream));
+
+		try {
+			task.execute();
+		}
+		catch (Exception exception) {
+		}
+		finally {
+			System.setOut(originalOut);
+		}
+
+		String output = capturedByteArrayOutputStream.toString();
+
+		Assert.assertTrue(
+			"Mirror URL was not attempted with JENKINS_URL set — output: " +
+				output,
+			output.contains("mirrors.lax.liferay.com"));
+	}
+
+	@Test
+	public void testNoMirrorConnectionsAttemptedOutsideCI() throws Exception {
+		_removeEnv("JENKINS_URL");
+		_removeEnv("MASTER_NETWORK_NAME");
+
+		Project antProject = new Project();
+
+		antProject.setProperty("mirrors.hostname", "mirrors.lax.liferay.com");
+
+		MirrorsGetTask task = new MirrorsGetTask();
+
+		task.setProject(antProject);
+		task.setTaskName("mirrors-get");
+		task.setVerbose(true);
+		task.setSrc(
+			"https://repository.liferay.com/nexus/content/groups/public" +
+				"/nonexistent-lrci-7262-test/file.jar");
+		task.setDest(
+			Files.createTempDirectory(
+				"mirrors-get-test"
+			).toFile());
+
+		ByteArrayOutputStream capturedByteArrayOutputStream =
+			new ByteArrayOutputStream();
+		PrintStream originalOut = System.out;
+
+		System.setOut(new PrintStream(capturedByteArrayOutputStream));
+
+		try {
+			task.execute();
+		}
+		catch (Exception exception) {
+		}
+		finally {
+			System.setOut(originalOut);
+		}
+
+		String output = capturedByteArrayOutputStream.toString();
+
+		Assert.assertFalse(
+			"Mirror URL was attempted outside CI — output: " + output,
+			output.contains("mirrors.lax.liferay.com"));
+	}
+
+	@Test
 	public void testTryLocalNetworkFalseWhenNoCIEnvVarsSet() throws Exception {
 		_removeEnv("JENKINS_URL");
 		_removeEnv("MASTER_NETWORK_NAME");
 
-		Assert.assertFalse(_getTryLocalNetwork(new MirrorsGetTask()));
+		Assert.assertFalse(_isTryLocalNetwork(new MirrorsGetTask()));
 	}
 
 	@Test
@@ -44,7 +142,7 @@ public class MirrorsGetTaskTest {
 		_removeEnv("MASTER_NETWORK_NAME");
 		_setEnv("JENKINS_URL", "http://test-1-41.liferay.com");
 
-		Assert.assertTrue(_getTryLocalNetwork(new MirrorsGetTask()));
+		Assert.assertTrue(_isTryLocalNetwork(new MirrorsGetTask()));
 	}
 
 	@Test
@@ -54,26 +152,29 @@ public class MirrorsGetTaskTest {
 		_removeEnv("JENKINS_URL");
 		_setEnv("MASTER_NETWORK_NAME", "test-network");
 
-		Assert.assertTrue(_getTryLocalNetwork(new MirrorsGetTask()));
-	}
-
-	private boolean _getTryLocalNetwork(MirrorsGetTask task) throws Exception {
-		Field field = MirrorsGetTask.class.getDeclaredField("_tryLocalNetwork");
-
-		field.setAccessible(true);
-
-		return (boolean)field.get(task);
+		Assert.assertTrue(_isTryLocalNetwork(new MirrorsGetTask()));
 	}
 
 	@SuppressWarnings("unchecked")
 	private Map<String, String> _getWritableEnv() throws Exception {
 		Map<String, String> env = System.getenv();
 
-		Field field = env.getClass().getDeclaredField("m");
+		Field field = env.getClass(
+		).getDeclaredField(
+			"m"
+		);
 
 		field.setAccessible(true);
 
 		return (Map<String, String>)field.get(env);
+	}
+
+	private boolean _isTryLocalNetwork(MirrorsGetTask task) throws Exception {
+		Field field = MirrorsGetTask.class.getDeclaredField("_tryLocalNetwork");
+
+		field.setAccessible(true);
+
+		return (boolean)field.get(task);
 	}
 
 	private void _removeEnv(String name) throws Exception {

--- a/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
+++ b/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
@@ -108,7 +108,9 @@ public class FileUtil {
 
 		boolean tryLocalNetwork = false;
 
-		if (System.getenv("JENKINS_HOME") != null) {
+		if ((System.getenv("JENKINS_URL") != null) ||
+			(System.getenv("MASTER_NETWORK_NAME") != null)) {
+
 			tryLocalNetwork = true;
 		}
 


### PR DESCRIPTION
## Summary

- Changed `MirrorsGetTask._tryLocalNetwork` default from `true` to `false` unless `JENKINS_URL` or `MASTER_NETWORK_NAME` is set, so mirrors are never attempted outside CI
- Updated `FileUtil` to use the same env vars (`JENKINS_URL` / `MASTER_NETWORK_NAME`) instead of the old `JENKINS_HOME` check
- Added unit tests for `MirrorsGetTask` covering all three cases: no CI env vars → false, `JENKINS_URL` set → true, `MASTER_NETWORK_NAME` set → true

## Test plan

- [x] `gradlew test` passes in `modules/sdk/ant-mirrors-get` (3 new tests all green)
- [x] Verify a local Gradle build no longer attempts mirror connections
- [ ] Verify CI builds (with `JENKINS_URL` set) still use mirrors as expected