### PR TITLE
LRCI-7579 Send ScanCode Slack notification when first pipeline fails

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/AnalyzeDockerImageScanCodePipeline.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/AnalyzeDockerImageScanCodePipeline.java
@@ -31,6 +31,12 @@ public class AnalyzeDockerImageScanCodePipeline extends BaseScanCodePipeline {
 
 		waitForScan(_pipelineName);
 
+		if (hasFailedScan()) {
+			sendSlackNotification(getCloudBucketURL());
+
+			return;
+		}
+
 		addAdditionalPipeline("match_to_matchcode");
 
 		waitForScan("match_to_matchcode");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/BaseScanCodePipeline.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/BaseScanCodePipeline.java
@@ -319,6 +319,16 @@ public abstract class BaseScanCodePipeline implements ScanCodePipeline {
 		return _simpleDateFormat;
 	}
 
+	public boolean hasFailedScan() {
+		for (String projectStatus : _projectStatuses) {
+			if (!projectStatus.equals("success")) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public void invokeScan(JSONObject jsonObject)
 		throws IOException, TimeoutException {
 
@@ -366,7 +376,10 @@ public abstract class BaseScanCodePipeline implements ScanCodePipeline {
 
 		String subject = "ScanCode pipeline is complete";
 
-		if (_hasErrors()) {
+		if (hasFailedScan()) {
+			subject = "ScanCode pipeline has failed :red-circle:";
+		}
+		else if (_hasErrors()) {
 			subject = ":red-alert: Release blocker :red-alert:";
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/InspectPackagesScanCodePipeline.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/InspectPackagesScanCodePipeline.java
@@ -25,6 +25,12 @@ public class InspectPackagesScanCodePipeline extends BaseScanCodePipeline {
 
 		waitForScan(_pipelineName);
 
+		if (hasFailedScan()) {
+			sendSlackNotification(getCloudBucketURL());
+
+			return;
+		}
+
 		addAdditionalPipeline("populate_purldb");
 
 		waitForScan("populate_purldb");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7579

**What is being fixed:** The `inspect_packages` and `analyze_docker_image` ScanCode pipelines always triggered their second pipeline (`populate_purldb` and `match_to_matchcode` respectively) even when the first pipeline failed, and the Slack notification only fired at the very end. A first-pipeline failure was therefore reported late, after needlessly running the second pipeline.

**How it is being fixed:** A `hasFailedScan()` method was added to `BaseScanCodePipeline` that inspects the recorded run statuses. Both pipeline classes now check it immediately after the first `waitForScan`; on failure they send the ScanCode Slack notification right away and return without adding the second pipeline. The notification subject now reflects the outcome, reading "ScanCode pipeline has failed :red-circle:" instead of "ScanCode pipeline is complete".