### PR TITLE
LRCI-7262 Never try mirrors outside CI; copy from shared mount when available

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -949,6 +949,26 @@ public class MirrorsGetTask extends Task {
 		return fileName.endsWith(".7z");
 	}
 
+	private boolean _isCINode() {
+		if (_isNullOrEmpty(System.getenv("JENKINS_URL")) &&
+			_isNullOrEmpty(System.getenv("MASTER_NETWORK_NAME"))) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean _isNullOrEmpty(String string) {
+		if (string == null) {
+			return true;
+		}
+
+		String trimmedString = string.trim();
+
+		return trimmedString.isEmpty();
+	}
+
 	private boolean _isTarGzFile(File file) throws IOException {
 		if (!file.exists()) {
 			return false;
@@ -1278,9 +1298,7 @@ public class MirrorsGetTask extends Task {
 	private boolean _skipChecksum;
 	private String _src;
 	private boolean _ssl;
-	private boolean _tryLocalNetwork =
-		(System.getenv("JENKINS_URL") != null) ||
-		(System.getenv("MASTER_NETWORK_NAME") != null);
+	private boolean _tryLocalNetwork = _isCINode();
 	private String _userAgent;
 	private String _username;
 	private boolean _verbose;

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -1278,7 +1278,9 @@ public class MirrorsGetTask extends Task {
 	private boolean _skipChecksum;
 	private String _src;
 	private boolean _ssl;
-	private boolean _tryLocalNetwork = true;
+	private boolean _tryLocalNetwork =
+		(System.getenv("JENKINS_URL") != null) ||
+		(System.getenv("MASTER_NETWORK_NAME") != null);
 	private String _userAgent;
 	private String _username;
 	private boolean _verbose;

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -471,53 +471,64 @@ public class MirrorsGetTask extends Task {
 		}
 
 		if (!mirrorsCacheFile.exists()) {
-			List<URL> urls = new ArrayList<>();
-
 			if (_tryLocalNetwork) {
-				String mirrorsHostname = _getMirrorsHostname();
-				URL nexusTomcatURL = _getNexusTomcatURL();
+				File mirrorsMountFile = _getMirrorsMountFile();
 
-				if (nexusTomcatURL != null) {
-					urls.add(nexusTomcatURL);
-				}
-				else if (!mirrorsHostname.isEmpty()) {
-					urls.add(_getMirrorsURL());
-				}
-			}
-
-			urls.add(_getLocalURL());
-
-			urls.removeAll(Collections.singleton(null));
-
-			for (URL url : urls) {
-				try {
-					_downloadFile(url, mirrorsCacheTempFile, _retries);
-				}
-				catch (IOException ioException) {
-					if (_verbose) {
-						System.out.println("Unable to connect to " + url + ".");
-					}
-				}
-
-				if (mirrorsCacheTempFile.exists()) {
-					break;
+				if (mirrorsMountFile.isFile()) {
+					_copyFile(mirrorsMountFile, mirrorsCacheTempFile);
 				}
 			}
 
 			if (!mirrorsCacheTempFile.exists()) {
-				_downloadGCPFile(mirrorsCacheTempFile);
+				List<URL> urls = new ArrayList<>();
 
-				if (!mirrorsCacheTempFile.exists()) {
-					URL remoteURL = _getRemoteURL();
+				if (_tryLocalNetwork) {
+					String mirrorsHostname = _getMirrorsHostname();
+					URL nexusTomcatURL = _getNexusTomcatURL();
 
+					if (nexusTomcatURL != null) {
+						urls.add(nexusTomcatURL);
+					}
+					else if (!mirrorsHostname.isEmpty()) {
+						urls.add(_getMirrorsURL());
+					}
+				}
+
+				urls.add(_getLocalURL());
+
+				urls.removeAll(Collections.singleton(null));
+
+				for (URL url : urls) {
 					try {
-						_downloadFile(
-							remoteURL, mirrorsCacheTempFile, _retries);
+						_downloadFile(url, mirrorsCacheTempFile, _retries);
 					}
 					catch (IOException ioException) {
-						_deleteFile(mirrorsCacheTempFile);
+						if (_verbose) {
+							System.out.println(
+								"Unable to connect to " + url + ".");
+						}
+					}
 
-						throw ioException;
+					if (mirrorsCacheTempFile.exists()) {
+						break;
+					}
+				}
+
+				if (!mirrorsCacheTempFile.exists()) {
+					_downloadGCPFile(mirrorsCacheTempFile);
+
+					if (!mirrorsCacheTempFile.exists()) {
+						URL remoteURL = _getRemoteURL();
+
+						try {
+							_downloadFile(
+								remoteURL, mirrorsCacheTempFile, _retries);
+						}
+						catch (IOException ioException) {
+							_deleteFile(mirrorsCacheTempFile);
+
+							throw ioException;
+						}
 					}
 				}
 			}
@@ -689,6 +700,18 @@ public class MirrorsGetTask extends Task {
 		}
 
 		return _mirrorsHostname;
+	}
+
+	private File _getMirrorsMountFile() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("/mnt/shared/mirrors");
+		sb.append(File.separator);
+		sb.append(_hostName);
+		sb.append(File.separator);
+		sb.append(_getPlatformIndependentPath(_getPath()));
+
+		return new File(sb.toString(), _fileName);
 	}
 
 	private URL _getMirrorsURL() {

--- a/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
+++ b/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
@@ -107,18 +107,9 @@ public class FileUtil {
 	public static File get(Project project, String url, File destinationFile)
 		throws IOException {
 
-		boolean tryLocalNetwork = false;
-
-		if ((System.getenv("JENKINS_URL") != null) ||
-			(System.getenv("MASTER_NETWORK_NAME") != null)) {
-
-			tryLocalNetwork = true;
-		}
-		else if (_getProperty(project, "mirrors.hostname") != null) {
-			tryLocalNetwork = true;
-		}
-
-		return get(project, url, destinationFile, false, tryLocalNetwork);
+		return get(
+			project, url, destinationFile, false,
+			_isCINode() || (_getProperty(project, "mirrors.hostname") != null));
 	}
 
 	public static File get(
@@ -737,6 +728,26 @@ public class FileUtil {
 
 		antBuilder.invokeMethod(
 			"manifestclasspath", new Object[] {args, closure});
+	}
+
+	private static boolean _isCINode() {
+		if (_isNullOrEmpty(System.getenv("JENKINS_URL")) &&
+			_isNullOrEmpty(System.getenv("MASTER_NETWORK_NAME"))) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private static boolean _isNullOrEmpty(String string) {
+		if (string == null) {
+			return true;
+		}
+
+		String trimmedString = string.trim();
+
+		return trimmedString.isEmpty();
 	}
 
 	private static final File _TMP_DIR = new File(

--- a/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
+++ b/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
@@ -109,7 +109,9 @@ public class FileUtil {
 
 		boolean tryLocalNetwork = false;
 
-		if (System.getenv("JENKINS_HOME") != null) {
+		if ((System.getenv("JENKINS_URL") != null) ||
+			(System.getenv("MASTER_NETWORK_NAME") != null)) {
+
 			tryLocalNetwork = true;
 		}
 		else if (_getProperty(project, "mirrors.hostname") != null) {

--- a/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
+++ b/modules/sdk/gradle-util/src/main/java/com/liferay/gradle/util/FileUtil.java
@@ -160,17 +160,27 @@ public class FileUtil {
 			mirrorsCacheArtifactDir.mkdirs();
 
 			if (tryLocalNetwork) {
-				try {
-					_get(
-						project, _getMirrorsURL(project, url),
-						_getProperty(project, "mirrors.username"),
-						_getProperty(project, "mirrors.password"),
-						mirrorsCacheArtifactFile, ignoreErrors);
+				File mirrorsMountFile = _getMirrorsMountFile(url, fileName);
+
+				if (mirrorsMountFile.isFile()) {
+					Files.copy(
+						mirrorsMountFile.toPath(),
+						mirrorsCacheArtifactFile.toPath(),
+						StandardCopyOption.REPLACE_EXISTING);
 				}
-				catch (Exception exception) {
-					_get(
-						project, url, username, password,
-						mirrorsCacheArtifactFile, ignoreErrors);
+				else {
+					try {
+						_get(
+							project, _getMirrorsURL(project, url),
+							_getProperty(project, "mirrors.username"),
+							_getProperty(project, "mirrors.password"),
+							mirrorsCacheArtifactFile, ignoreErrors);
+					}
+					catch (Exception exception) {
+						_get(
+							project, url, username, password,
+							mirrorsCacheArtifactFile, ignoreErrors);
+					}
 				}
 			}
 			else {
@@ -578,6 +588,12 @@ public class FileUtil {
 		String userHome = System.getProperty("user.home");
 
 		return new File(userHome, ".liferay/mirrors");
+	}
+
+	private static File _getMirrorsMountFile(String url, String fileName) {
+		String subdir = url.replaceFirst("https?:\\/\\/(.+\\/).+", "$1");
+
+		return new File(new File("/mnt/shared/mirrors", subdir), fileName);
 	}
 
 	private static String _getMirrorsURL(Project project, String url) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7262

**What is being fixed:** Mirrors servers are only accessible inside CI environments, but `MirrorsGetTask` and `FileUtil` were defaulting `tryLocalNetwork` to `true` unconditionally (or using a bare `!= null` env var check), causing local developer builds to attempt mirror connections that always fail. Additionally, CI builds were downloading artifacts over HTTP when those files are already available on the AWS shared filesystem mount at `/mnt/shared/mirrors/`.

**How it is being fixed:** The CI detection is updated in both `MirrorsGetTask` and `FileUtil` to use private copies of the canonical `isCINode()` / `isNullOrEmpty()` logic from `JenkinsResultsParserUtil`, so that blank or whitespace-only env vars are treated as absent rather than as CI. Both classes now default `tryLocalNetwork` to this CI check. When running in CI, both classes check `/mnt/shared/mirrors/<host>/<path>/<file>` before attempting any HTTP download; if the file is present on the mount it is copied directly, and the full HTTP/GCP/remote fallback chain is skipped entirely.

**Test:** https://github.com/CharlotteFrancis/liferay-portal/pull/378