### PR TITLE
LRCI-7472 Update google-cloud-storage to 2.48.0

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	api group: "com.amazonaws", name: "aws-java-sdk-ec2", version: "1.12.719"
 	api group: "com.amazonaws", name: "aws-java-sdk-rds", version: "1.12.719"
 	api group: "com.atlassian.jira", name: "jira-rest-java-client-app", version: "5.2.4"
-	api group: "com.google.cloud", name: "google-cloud-storage", version: "1.113.16"
+	api group: "com.google.cloud", name: "google-cloud-storage", version: "2.48.0"
 	api group: "com.google.guava", name: "guava", version: "32.0.1-jre"
 	api group: "com.liferay", name: "com.liferay.poshi.core", version: "1.0.159"
 	api group: "com.liferay", name: "org.apache.activemq.client", version: "5.16.7.JAKARTA-LIFERAY-PATCHED-1"


### PR DESCRIPTION
## Summary

Update `google-cloud-storage` dependency to version 2.48.0.

## Tests

- CI: https://test-1-41.liferay.com/job/test-portal-acceptance-pullrequest(master)/2466/
- liferay-jenkins-ee: https://github.com/CharlotteFrancis/liferay-jenkins-ee/pull/62