### PR TITLE
[DEV-ONLY] LRCI-7485 ci:forward conflict test

### DIFF
--- a/modules/.releng/apps/accessibility/accessibility-menu-web/artifact.properties
+++ b/modules/.releng/apps/accessibility/accessibility-menu-web/artifact.properties
@@ -1,4 +1,4 @@
-artifact.git.id=7d6c67eceda23ff7c05ca4365aa6036ee09e072b
+artifact.git.id=0123456789abcdef0123456789abcdef01234567
 artifact.jspc.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.accessibility.menu.web/1.0.42/com.liferay.accessibility.menu.web-1.0.42-jspc.jar
 artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.accessibility.menu.web/1.0.42/com.liferay.accessibility.menu.web-1.0.42-sources.jar
 artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.accessibility.menu.web/1.0.42/com.liferay.accessibility.menu.web-1.0.42.jar


### PR DESCRIPTION
- [LRCI-7485](https://liferay.atlassian.net/browse/LRCI-7485)

## Summary

Throwaway PR to exercise ci:forward merge-conflict detection with the candidate jar. The single commit sets `cloud/helm/default/Chart.yaml` to `version: 0.6.99`, which merges cleanly into liferay/liferay-portal:master but conflicts with brianchandotcom/liferay-portal:master (which set the same line to 0.6.1). Not for merge.