### PR TITLE
LRCI-7485 Self-heal shallow-clone gaps via branch-source deepening

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -10,12 +10,8 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 
-import java.time.Duration;
-import java.time.Instant;
-
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -900,51 +896,6 @@ public abstract class BaseWorkspaceGitRepository
 		String senderBranchSHA = getSenderBranchSHA();
 
 		if (!gitWorkingDirectory.localSHAExists(senderBranchSHA)) {
-			if (JenkinsResultsParserUtil.isCloudCINode()) {
-				try {
-					GitHubRemoteGitCommit gitHubRemoteGitCommit =
-						GitCommitFactory.newGitHubRemoteGitCommit(
-							getSenderBranchUsername(),
-							gitWorkingDirectory.getGitRepositoryName(),
-							senderBranchSHA);
-
-					Date commitDate = gitHubRemoteGitCommit.getCommitDate();
-
-					Instant commitInstant = commitDate.toInstant();
-
-					Instant oneMonthAgo = Instant.now(
-					).minus(
-						Duration.ofDays(30)
-					);
-
-					if (commitInstant.isBefore(oneMonthAgo) &&
-						_isPullRequest()) {
-
-						PullRequest pullRequest =
-							PullRequestFactory.newPullRequest(getGitHubURL());
-
-						if (pullRequest != null) {
-							String message =
-								"User's commit " + senderBranchSHA +
-									" is more than 1 month old. Rebase and " +
-										"retest your changes.";
-
-							pullRequest.addComment(message);
-
-							throw new RuntimeException(
-								"Sender's commit is more than 1 month old");
-						}
-					}
-				}
-				catch (Exception exception) {
-					exception.printStackTrace();
-
-					throw new RuntimeException(
-						"Sender's commit is more than 1 month old or there " +
-							"was an error retrieving commit information");
-				}
-			}
-
 			gitWorkingDirectory.fetch(_getSenderRemoteGitRef());
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1438,10 +1438,10 @@ public abstract class BaseWorkspaceGitRepository
 
 		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
-		gitWorkingDirectory.fetch(remoteGitRef);
+		LocalGitBranch localGitBranch = gitWorkingDirectory.fetch(remoteGitRef);
 
-		if (!gitWorkingDirectory.localSHAExists(sha) ||
-			!gitWorkingDirectory.refContainsSHA(remoteGitRef.getSHA(), sha)) {
+		if ((localGitBranch == null) ||
+			!gitWorkingDirectory.refContainsSHA(localGitBranch, sha)) {
 
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -800,9 +800,7 @@ public class CIForwardProcessor {
 
 			String message = gitWorkingDirectoryRuntimeException.getMessage();
 
-			if ((message != null) && message.contains("Unable to rebase ") &&
-				message.contains("CONFLICT (")) {
-
+			if ((message != null) && message.contains("Unable to rebase ")) {
 				System.out.println(
 					JenkinsResultsParserUtil.combine(
 						"Detected merge conflict between ",
@@ -815,8 +813,8 @@ public class CIForwardProcessor {
 			}
 
 			System.out.println(
-				"WARNING: Unable to detect merge conflict marker but rebase " +
-					"failed\n" + String.valueOf(message));
+				"WARNING: Unable to determine merge conflict status\n" +
+					String.valueOf(message));
 
 			return false;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -776,47 +776,41 @@ public class CIForwardProcessor {
 		}
 
 		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
-		String receiverSHA = receiverRemoteGitBranch.getSHA();
-		String senderSHA = _pullRequest.getSenderSHA();
 
-		Date mergeBaseCommitDate = mergeBaseCommit.getCommitDate();
-
-		gitWorkingDirectory.fetch(receiverRemoteGitBranch, mergeBaseCommitDate);
-		gitWorkingDirectory.fetch(senderRemoteGitBranch, mergeBaseCommitDate);
-
-		if (!_localMergeBaseMatches(
-				gitWorkingDirectory, senderSHA, receiverSHA,
-				expectedMergeBaseSHA)) {
-
-			Date deepenedSinceDate = new Date(
-				mergeBaseCommitDate.getTime() -
-					_BRANCH_DEEPENING_STEP_SIZE_MILLIS);
-
-			gitWorkingDirectory.fetch(
-				receiverRemoteGitBranch, deepenedSinceDate);
-			gitWorkingDirectory.fetch(senderRemoteGitBranch, deepenedSinceDate);
-
-			if (!_localMergeBaseMatches(
-					gitWorkingDirectory, senderSHA, receiverSHA,
-					expectedMergeBaseSHA)) {
-
-				System.out.println(
-					"WARNING: Unable to identify merge base SHA");
-
-				return false;
-			}
-		}
+		gitWorkingDirectory.fetch(receiverRemoteGitBranch);
+		gitWorkingDirectory.fetch(senderRemoteGitBranch);
 
 		LocalGitBranch receiverLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
 				JenkinsResultsParserUtil.combine(
 					_recipientUsername, "-", upstreamBranchName, "-precheck"),
-				true, receiverSHA);
+				true, receiverRemoteGitBranch.getSHA(),
+				receiverRemoteGitBranch);
 
 		LocalGitBranch senderLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
 				_pullRequest.getLocalSenderBranchName() + "-precheck", true,
-				senderSHA);
+				_pullRequest.getSenderSHA(), senderRemoteGitBranch);
+
+		String localMergeBaseSHA = null;
+
+		try {
+			localMergeBaseSHA = gitWorkingDirectory.getMergeBaseCommitSHA(
+				receiverLocalGitBranch, senderLocalGitBranch);
+		}
+		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
+					gitWorkingDirectoryRuntimeException) {
+
+			gitWorkingDirectoryRuntimeException.printStackTrace();
+		}
+
+		if ((localMergeBaseSHA == null) ||
+			!expectedMergeBaseSHA.equals(localMergeBaseSHA.trim())) {
+
+			System.out.println("WARNING: Unable to identify merge base SHA");
+
+			return false;
+		}
 
 		try {
 			gitWorkingDirectory.rebase(
@@ -864,31 +858,6 @@ public class CIForwardProcessor {
 
 		return failedRequiredPassingTestSuiteNames.isEmpty();
 	}
-
-	private boolean _localMergeBaseMatches(
-		GitWorkingDirectory gitWorkingDirectory, String senderSHA,
-		String receiverSHA, String expectedMergeBaseSHA) {
-
-		try {
-			String localMergeBaseSHA =
-				gitWorkingDirectory.getMergeBaseCommitSHA(
-					senderSHA, receiverSHA);
-
-			if (localMergeBaseSHA != null) {
-				localMergeBaseSHA = localMergeBaseSHA.trim();
-			}
-
-			return expectedMergeBaseSHA.equals(localMergeBaseSHA);
-		}
-		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
-					gitWorkingDirectoryRuntimeException) {
-
-			return false;
-		}
-	}
-
-	private static final long _BRANCH_DEEPENING_STEP_SIZE_MILLIS =
-		1000L * 60L * 60L * 24L;
 
 	private static final long _RETRY_PERIOD = 1000L * 60L;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -768,14 +768,11 @@ public class CIForwardProcessor {
 			gitWorkingDirectory.getRemoteGitBranch(
 				upstreamBranchName, receiverRemoteURL, true);
 
-		GitCommit mergeBaseCommit = receiverRemoteGitBranch.getMergeBaseCommit(
-			senderRemoteGitBranch);
+		if (receiverRemoteGitBranch.getMergeBaseCommit(senderRemoteGitBranch) ==
+				null) {
 
-		if (mergeBaseCommit == null) {
 			return false;
 		}
-
-		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
 
 		gitWorkingDirectory.fetch(receiverRemoteGitBranch);
 		gitWorkingDirectory.fetch(senderRemoteGitBranch);
@@ -791,26 +788,6 @@ public class CIForwardProcessor {
 			gitWorkingDirectory.createLocalGitBranch(
 				_pullRequest.getLocalSenderBranchName() + "-precheck", true,
 				_pullRequest.getSenderSHA(), senderRemoteGitBranch);
-
-		String localMergeBaseSHA = null;
-
-		try {
-			localMergeBaseSHA = gitWorkingDirectory.getMergeBaseCommitSHA(
-				receiverLocalGitBranch, senderLocalGitBranch);
-		}
-		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
-					gitWorkingDirectoryRuntimeException) {
-
-			gitWorkingDirectoryRuntimeException.printStackTrace();
-		}
-
-		if ((localMergeBaseSHA == null) ||
-			!expectedMergeBaseSHA.equals(localMergeBaseSHA.trim())) {
-
-			System.out.println("WARNING: Unable to identify merge base SHA");
-
-			return false;
-		}
 
 		try {
 			gitWorkingDirectory.rebase(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
@@ -16,6 +16,14 @@ public class GitBranchFactory {
 		return new LocalGitBranch(localGitRepository, name, sha);
 	}
 
+	public static LocalGitBranch newLocalGitBranch(
+		LocalGitRepository localGitRepository, String name, String sha,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
+		return new LocalGitBranch(
+			localGitRepository, name, sha, sourceRemoteGitBranch);
+	}
+
 	public static RemoteGitRef newRemoteGitRef(
 		RemoteGitRepository remoteGitRepository, String name, String sha,
 		String type) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2733,6 +2733,29 @@ public class GitWorkingDirectory {
 		}
 	}
 
+	public boolean refContainsSHA(LocalGitBranch localGitBranch, String sha) {
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			if (refContainsSHA(localGitBranch.getName(), sha)) {
+				return true;
+			}
+
+			boolean deepened = false;
+
+			if (deepenAttempt < _DEEPEN_MAX_ATTEMPTS) {
+				Date shallowSinceDate = new Date(
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
+
+				deepened = deepenLocalGitBranch(
+					localGitBranch, shallowSinceDate);
+			}
+
+			if (!deepened) {
+				return false;
+			}
+		}
+	}
+
 	public boolean refContainsSHA(String ref, String sha) {
 		GitUtil.ExecutionResult executionResult = executeBashCommands(
 			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY, 1000 * 60 * 2,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -499,6 +499,27 @@ public class GitWorkingDirectory {
 		return retryable.executeWithRetries();
 	}
 
+	public boolean deepenLocalGitBranch(
+		LocalGitBranch localGitBranch, Date shallowSinceDate) {
+
+		RemoteGitBranch sourceRemoteGitBranch =
+			localGitBranch.getSourceRemoteGitBranch();
+
+		if (sourceRemoteGitBranch == null) {
+			return false;
+		}
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Deepening ", localGitBranch.getName(), " to ",
+				JenkinsResultsParserUtil.toDateString(
+					shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC")));
+
+		fetch(sourceRemoteGitBranch, shallowSinceDate);
+
+		return true;
+	}
+
 	public void deleteLocalGitBranch(LocalGitBranch localGitBranch) {
 		if (localGitBranch == null) {
 			return;
@@ -1635,45 +1656,28 @@ public class GitWorkingDirectory {
 				return executionResult.getStandardOut();
 			}
 
-			boolean canDeepen = false;
+			boolean deepened = false;
 
-			for (LocalGitBranch localGitBranch : localGitBranches) {
-				if (localGitBranch.getSourceRemoteGitBranch() != null) {
-					canDeepen = true;
+			if (deepenAttempt < _DEEPEN_MAX_ATTEMPTS) {
+				Date shallowSinceDate = new Date(
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
 
-					break;
+				for (LocalGitBranch localGitBranch : localGitBranches) {
+					if (deepenLocalGitBranch(
+							localGitBranch, shallowSinceDate)) {
+
+						deepened = true;
+					}
 				}
 			}
 
-			if (!canDeepen ||
-				(deepenAttempt >= _MERGE_BASE_DEEPEN_MAX_ATTEMPTS)) {
-
+			if (!deepened) {
 				throw new GitWorkingDirectoryRuntimeException(
 					this,
 					JenkinsResultsParserUtil.combine(
 						"Unable to get merge base commit SHA\n",
 						executionResult.getStandardError()));
-			}
-
-			Date shallowSinceDate = new Date(
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					(_MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
-
-			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"WARNING: No merge base found within the local shallow ",
-					"horizon. Deepening to ",
-					JenkinsResultsParserUtil.toDateString(
-						shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC"),
-					" and retrying."));
-
-			for (LocalGitBranch localGitBranch : localGitBranches) {
-				RemoteGitBranch sourceRemoteGitBranch =
-					localGitBranch.getSourceRemoteGitBranch();
-
-				if (sourceRemoteGitBranch != null) {
-					fetch(sourceRemoteGitBranch, shallowSinceDate);
-				}
 			}
 		}
 	}
@@ -1948,9 +1952,6 @@ public class GitWorkingDirectory {
 			LocalGitBranch rebasedLocalGitBranch = createLocalGitBranch(
 				rebasedLocalGitBranchName, true, senderSHA,
 				senderRemoteGitBranch);
-
-			getMergeBaseCommitSHA(
-				upstreamLocalGitBranch, rebasedLocalGitBranch);
 
 			rebasedLocalGitBranch = rebase(
 				true, upstreamLocalGitBranch, rebasedLocalGitBranch);
@@ -2660,32 +2661,45 @@ public class GitWorkingDirectory {
 			return localGitBranch;
 		}
 
-		checkoutLocalGitBranch(baseLocalGitBranch);
-
-		reset("--hard " + baseLocalGitBranch.getSHA());
-
 		String rebaseCommand = JenkinsResultsParserUtil.combine(
 			"git rebase ", baseLocalGitBranch.getName(), " ",
 			localGitBranch.getName());
 
-		GitUtil.ExecutionResult executionResult = executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			1000 * 60 * 10, rebaseCommand);
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			checkoutLocalGitBranch(baseLocalGitBranch);
 
-		if (executionResult.getExitValue() != 0) {
+			reset("--hard " + baseLocalGitBranch.getSHA());
+
+			GitUtil.ExecutionResult executionResult = executeBashCommands(
+				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+				1000 * 60 * 10, rebaseCommand);
+
+			if (executionResult.getExitValue() == 0) {
+				return getCurrentLocalGitBranch();
+			}
+
 			if (abortOnFail) {
 				rebaseAbort();
 			}
 
-			throw new GitWorkingDirectoryRuntimeException(
-				this,
-				JenkinsResultsParserUtil.combine(
-					"Unable to rebase ", localGitBranch.getName(), " to ",
-					baseLocalGitBranch.getName(), "\n",
-					executionResult.getStandardError()));
-		}
+			long deepenStepSizeMillis =
+				_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt;
 
-		return getCurrentLocalGitBranch();
+			Date shallowSinceDate = new Date(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					deepenStepSizeMillis);
+
+			if (!abortOnFail || (deepenAttempt >= _DEEPEN_MAX_ATTEMPTS) ||
+				!deepenLocalGitBranch(baseLocalGitBranch, shallowSinceDate)) {
+
+				throw new GitWorkingDirectoryRuntimeException(
+					this,
+					JenkinsResultsParserUtil.combine(
+						"Unable to rebase ", localGitBranch.getName(), " to ",
+						baseLocalGitBranch.getName(), "\n",
+						executionResult.getStandardError()));
+			}
+		}
 	}
 
 	public void rebaseAbort() {
@@ -3614,14 +3628,14 @@ public class GitWorkingDirectory {
 
 	private static final int _BRANCHES_DELETE_BATCH_SIZE = 5;
 
+	private static final int _DEEPEN_MAX_ATTEMPTS = 5;
+
+	private static final long _DEEPEN_STEP_SIZE_MILLIS =
+		1000L * 60L * 60L * 24L * 30L;
+
 	private static final String _GIT_COMMIT_LOG_SEPARATOR = "\u0000";
 
 	private static final String _GIT_COMMIT_LOG_SEPARATOR_FORMAT = "%x00";
-
-	private static final int _MERGE_BASE_DEEPEN_MAX_ATTEMPTS = 5;
-
-	private static final long _MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS =
-		1000L * 60L * 60L * 24L * 30L;
 
 	private static final Pattern _badRefPattern = Pattern.compile(
 		"fatal: bad object (?<badRef>.+/HEAD)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1555,10 +1555,6 @@ public class GitWorkingDirectory {
 			return getUpstreamLocalGitBranch();
 		}
 
-		if (!localGitBranchExists(branchName)) {
-			return null;
-		}
-
 		return _getLocalGitBranch(branchName, required);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -795,13 +795,15 @@ public class GitWorkingDirectory {
 				fetch(null, noTags, gitHubDevRemoteGitBranch);
 
 				if (localSHAExists(remoteGitRefSHA)) {
-					if (localGitBranch != null) {
+					if (localGitBranch == null) {
 						return createLocalGitBranch(
-							localGitBranch.getName(), true, remoteGitRefSHA,
+							remoteGitRef.getName(), true, remoteGitRefSHA,
 							sourceRemoteGitBranch);
 					}
 
-					return null;
+					return createLocalGitBranch(
+						localGitBranch.getName(), true, remoteGitRefSHA,
+						sourceRemoteGitBranch);
 				}
 			}
 		}
@@ -929,7 +931,13 @@ public class GitWorkingDirectory {
 			}
 		}
 
-		if (localSHAExists(remoteGitRefSHA) && (localGitBranch != null)) {
+		if (localSHAExists(remoteGitRefSHA)) {
+			if (localGitBranch == null) {
+				return createLocalGitBranch(
+					remoteGitRef.getName(), true, remoteGitRefSHA,
+					sourceRemoteGitBranch);
+			}
+
 			return createLocalGitBranch(
 				localGitBranch.getName(), true, remoteGitRefSHA,
 				sourceRemoteGitBranch);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1747,16 +1747,11 @@ public class GitWorkingDirectory {
 			return "";
 		}
 
-		executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			GitUtil.MILLIS_TIMEOUT,
-			JenkinsResultsParserUtil.combine(
-				"git fetch ", upstreamGitRemote.getName(), " master"));
+		RemoteGitBranch upstreamMasterRemoteGitBranch = getRemoteGitBranch(
+			"master", upstreamGitRemote, true);
 
 		return getMergeBaseCommitSHA(
-			getCurrentBranchName(),
-			JenkinsResultsParserUtil.combine(
-				upstreamGitRemote.getName(), "/master"));
+			getCurrentLocalGitBranch(), fetch(upstreamMasterRemoteGitBranch));
 	}
 
 	public List<File> getModifiedDirsList(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1572,10 +1572,17 @@ public class GitWorkingDirectory {
 
 		if (branchName != null) {
 			try {
+				RemoteGitBranch upstreamRemoteGitBranch = null;
+
+				if (branchName.equals(upstreamBranchName)) {
+					upstreamRemoteGitBranch = getUpstreamRemoteGitBranch();
+				}
+
 				return Arrays.asList(
 					GitBranchFactory.newLocalGitBranch(
 						localGitRepository, branchName,
-						getLocalGitBranchSHA(branchName)));
+						getLocalGitBranchSHA(branchName),
+						upstreamRemoteGitBranch));
 			}
 			catch (Exception exception) {
 				if (!branchName.equals(upstreamBranchName)) {
@@ -1601,10 +1608,17 @@ public class GitWorkingDirectory {
 				continue;
 			}
 
+			RemoteGitBranch remoteGitBranch = null;
+
+			if (localGitBranchName.equals(upstreamBranchName)) {
+				remoteGitBranch = getUpstreamRemoteGitBranch();
+			}
+
 			localGitBranches.add(
 				GitBranchFactory.newLocalGitBranch(
 					localGitRepository, localGitBranchName,
-					localGitBranchesShaMap.get(localGitBranchName)));
+					localGitBranchesShaMap.get(localGitBranchName),
+					remoteGitBranch));
 		}
 
 		return localGitBranches;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -442,6 +442,18 @@ public class GitWorkingDirectory {
 		return createLocalGitBranchRetryable.executeWithRetries();
 	}
 
+	public LocalGitBranch createLocalGitBranch(
+		String localGitBranchName, boolean force, String startPoint,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
+		LocalGitBranch localGitBranch = createLocalGitBranch(
+			localGitBranchName, force, startPoint);
+
+		return GitBranchFactory.newLocalGitBranch(
+			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
+			localGitBranch.getSHA(), sourceRemoteGitBranch);
+	}
+
 	public String createPullRequest(
 		final String body, final String pullRequestBranchName,
 		final String receiverUserName, final String senderUserName,
@@ -711,6 +723,12 @@ public class GitWorkingDirectory {
 
 		String remoteGitRefSHA = remoteGitRef.getSHA();
 
+		RemoteGitBranch sourceRemoteGitBranch = null;
+
+		if (remoteGitRef instanceof RemoteGitBranch) {
+			sourceRemoteGitBranch = (RemoteGitBranch)remoteGitRef;
+		}
+
 		if ((shallowSinceDate == null) && localSHAExists(remoteGitRefSHA)) {
 			System.out.println(
 				remoteGitRefSHA + " already exists in Git repository");
@@ -723,11 +741,13 @@ public class GitWorkingDirectory {
 
 			if (localGitBranch == null) {
 				return createLocalGitBranch(
-					remoteGitRef.getName(), true, remoteGitRefSHA);
+					remoteGitRef.getName(), true, remoteGitRefSHA,
+					sourceRemoteGitBranch);
 			}
 
 			return createLocalGitBranch(
-				localGitBranch.getName(), true, remoteGitRefSHA);
+				localGitBranch.getName(), true, remoteGitRefSHA,
+				sourceRemoteGitBranch);
 		}
 
 		StringBuilder gitBranchesSHAReportStringBuilder = new StringBuilder();
@@ -760,7 +780,8 @@ public class GitWorkingDirectory {
 				if (localSHAExists(remoteGitRefSHA)) {
 					if (localGitBranch != null) {
 						return createLocalGitBranch(
-							localGitBranch.getName(), true, remoteGitRefSHA);
+							localGitBranch.getName(), true, remoteGitRefSHA,
+							sourceRemoteGitBranch);
 					}
 
 					return null;
@@ -893,7 +914,8 @@ public class GitWorkingDirectory {
 
 		if (localSHAExists(remoteGitRefSHA) && (localGitBranch != null)) {
 			return createLocalGitBranch(
-				localGitBranch.getName(), true, remoteGitRefSHA);
+				localGitBranch.getName(), true, remoteGitRefSHA,
+				sourceRemoteGitBranch);
 		}
 
 		return null;
@@ -1606,19 +1628,58 @@ public class GitWorkingDirectory {
 			sb.append(localGitBranch.getName());
 		}
 
-		GitUtil.ExecutionResult executionResult = executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			GitUtil.MILLIS_TIMEOUT, sb.toString());
+		String command = sb.toString();
 
-		if (executionResult.getExitValue() != 0) {
-			throw new GitWorkingDirectoryRuntimeException(
-				this,
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			GitUtil.ExecutionResult executionResult = executeBashCommands(
+				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+				GitUtil.MILLIS_TIMEOUT, command);
+
+			if (executionResult.getExitValue() == 0) {
+				return executionResult.getStandardOut();
+			}
+
+			boolean canDeepen = false;
+
+			for (LocalGitBranch localGitBranch : localGitBranches) {
+				if (localGitBranch.getSourceRemoteGitBranch() != null) {
+					canDeepen = true;
+
+					break;
+				}
+			}
+
+			if (!canDeepen ||
+				(deepenAttempt >= _MERGE_BASE_DEEPEN_MAX_ATTEMPTS)) {
+
+				throw new GitWorkingDirectoryRuntimeException(
+					this,
+					JenkinsResultsParserUtil.combine(
+						"Unable to get merge base commit SHA\n",
+						executionResult.getStandardError()));
+			}
+
+			Date shallowSinceDate = new Date(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(_MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
+
+			System.out.println(
 				JenkinsResultsParserUtil.combine(
-					"Unable to get merge base commit SHA\n",
-					executionResult.getStandardError()));
-		}
+					"WARNING: No merge base found within the local shallow ",
+					"horizon. Deepening to ",
+					JenkinsResultsParserUtil.toDateString(
+						shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC"),
+					" and retrying."));
 
-		return executionResult.getStandardOut();
+			for (LocalGitBranch localGitBranch : localGitBranches) {
+				RemoteGitBranch sourceRemoteGitBranch =
+					localGitBranch.getSourceRemoteGitBranch();
+
+				if (sourceRemoteGitBranch != null) {
+					fetch(sourceRemoteGitBranch, shallowSinceDate);
+				}
+			}
+		}
 	}
 
 	public String getMergeBaseCommitSHA(String... refNames) {
@@ -1863,14 +1924,14 @@ public class GitWorkingDirectory {
 				checkoutLocalGitBranch(tempLocalGitBranch);
 			}
 
+			RemoteGitBranch senderRemoteGitBranch = getRemoteGitBranch(
+				senderBranchName, senderRemoteURL, true);
+
 			if (localSHAExists(senderSHA)) {
 				createLocalGitBranch(senderBranchName, true, senderSHA);
 			}
 			else {
-				RemoteGitRef senderRemoteGitRef = getRemoteGitRef(
-					senderBranchName, senderRemoteURL, true);
-
-				fetch(senderRemoteGitRef);
+				fetch(senderRemoteGitBranch);
 			}
 
 			RemoteGitBranch upstreamRemoteGitBranch = getRemoteGitBranch(
@@ -1880,21 +1941,20 @@ public class GitWorkingDirectory {
 				upstreamBranchSHA = upstreamRemoteGitBranch.getSHA();
 			}
 
-			LocalGitBranch upstreamLocalGitBranch;
-
-			if (localSHAExists(upstreamBranchSHA)) {
-				upstreamLocalGitBranch = createLocalGitBranch(
-					upstreamBranchName, true, upstreamBranchSHA);
-			}
-			else {
+			if (!localSHAExists(upstreamBranchSHA)) {
 				fetch(upstreamRemoteGitBranch);
-
-				upstreamLocalGitBranch = createLocalGitBranch(
-					upstreamRemoteGitBranch.getName(), true, upstreamBranchSHA);
 			}
+
+			LocalGitBranch upstreamLocalGitBranch = createLocalGitBranch(
+				upstreamBranchName, true, upstreamBranchSHA,
+				upstreamRemoteGitBranch);
 
 			LocalGitBranch rebasedLocalGitBranch = createLocalGitBranch(
-				rebasedLocalGitBranchName, true, senderSHA);
+				rebasedLocalGitBranchName, true, senderSHA,
+				senderRemoteGitBranch);
+
+			getMergeBaseCommitSHA(
+				upstreamLocalGitBranch, rebasedLocalGitBranch);
 
 			rebasedLocalGitBranch = rebase(
 				true, upstreamLocalGitBranch, rebasedLocalGitBranch);
@@ -3551,6 +3611,11 @@ public class GitWorkingDirectory {
 	private static final String _GIT_COMMIT_LOG_SEPARATOR = "\u0000";
 
 	private static final String _GIT_COMMIT_LOG_SEPARATOR_FORMAT = "%x00";
+
+	private static final int _MERGE_BASE_DEEPEN_MAX_ATTEMPTS = 5;
+
+	private static final long _MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS =
+		1000L * 60L * 60L * 24L * 30L;
 
 	private static final Pattern _badRefPattern = Pattern.compile(
 		"fatal: bad object (?<badRef>.+/HEAD)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2674,45 +2674,33 @@ public class GitWorkingDirectory {
 			return localGitBranch;
 		}
 
-		String rebaseCommand = JenkinsResultsParserUtil.combine(
-			"git rebase ", baseLocalGitBranch.getName(), " ",
-			localGitBranch.getName());
+		getMergeBaseCommitSHA(baseLocalGitBranch, localGitBranch);
 
-		for (int deepenAttempt = 0;; deepenAttempt++) {
-			checkoutLocalGitBranch(baseLocalGitBranch);
+		checkoutLocalGitBranch(baseLocalGitBranch);
 
-			reset("--hard " + baseLocalGitBranch.getSHA());
+		reset("--hard " + baseLocalGitBranch.getSHA());
 
-			GitUtil.ExecutionResult executionResult = executeBashCommands(
-				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-				1000 * 60 * 10, rebaseCommand);
+		GitUtil.ExecutionResult executionResult = executeBashCommands(
+			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+			1000 * 60 * 10,
+			JenkinsResultsParserUtil.combine(
+				"git rebase ", baseLocalGitBranch.getName(), " ",
+				localGitBranch.getName()));
 
-			if (executionResult.getExitValue() == 0) {
-				return getCurrentLocalGitBranch();
-			}
-
-			if (abortOnFail) {
-				rebaseAbort();
-			}
-
-			long deepenStepSizeMillis =
-				_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt;
-
-			Date shallowSinceDate = new Date(
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					deepenStepSizeMillis);
-
-			if (!abortOnFail || (deepenAttempt >= _DEEPEN_MAX_ATTEMPTS) ||
-				!deepenLocalGitBranch(baseLocalGitBranch, shallowSinceDate)) {
-
-				throw new GitWorkingDirectoryRuntimeException(
-					this,
-					JenkinsResultsParserUtil.combine(
-						"Unable to rebase ", localGitBranch.getName(), " to ",
-						baseLocalGitBranch.getName(), "\n",
-						executionResult.getStandardError()));
-			}
+		if (executionResult.getExitValue() == 0) {
+			return getCurrentLocalGitBranch();
 		}
+
+		if (abortOnFail) {
+			rebaseAbort();
+		}
+
+		throw new GitWorkingDirectoryRuntimeException(
+			this,
+			JenkinsResultsParserUtil.combine(
+				"Unable to rebase ", localGitBranch.getName(), " to ",
+				baseLocalGitBranch.getName(), "\n",
+				executionResult.getStandardError()));
 	}
 
 	public void rebaseAbort() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -425,8 +425,15 @@ public class GitWorkingDirectory {
 	}
 
 	public LocalGitBranch createLocalGitBranch(
+		String localGitBranchName, boolean force, String startPoint) {
+
+		return createLocalGitBranch(
+			localGitBranchName, force, startPoint, null);
+	}
+
+	public LocalGitBranch createLocalGitBranch(
 		final String localGitBranchName, final boolean force,
-		final String startPoint) {
+		final String startPoint, final RemoteGitBranch sourceRemoteGitBranch) {
 
 		Retryable<LocalGitBranch> createLocalGitBranchRetryable =
 			new Retryable<LocalGitBranch>(true, 3, 0, true) {
@@ -434,24 +441,13 @@ public class GitWorkingDirectory {
 				@Override
 				public LocalGitBranch execute() {
 					return _createLocalGitBranch(
-						localGitBranchName, force, startPoint);
+						localGitBranchName, force, startPoint,
+						sourceRemoteGitBranch);
 				}
 
 			};
 
 		return createLocalGitBranchRetryable.executeWithRetries();
-	}
-
-	public LocalGitBranch createLocalGitBranch(
-		String localGitBranchName, boolean force, String startPoint,
-		RemoteGitBranch sourceRemoteGitBranch) {
-
-		LocalGitBranch localGitBranch = createLocalGitBranch(
-			localGitBranchName, force, startPoint);
-
-		return GitBranchFactory.newLocalGitBranch(
-			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
-			localGitBranch.getSHA(), sourceRemoteGitBranch);
 	}
 
 	public String createPullRequest(
@@ -3192,7 +3188,8 @@ public class GitWorkingDirectory {
 	}
 
 	private LocalGitBranch _createLocalGitBranch(
-		String localGitBranchName, boolean force, String startPoint) {
+		String localGitBranchName, boolean force, String startPoint,
+		RemoteGitBranch sourceRemoteGitBranch) {
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(localGitBranchName)) {
 			throw new GitWorkingDirectoryRuntimeException(
@@ -3260,7 +3257,16 @@ public class GitWorkingDirectory {
 				"Created local branch ", localGitBranchName, " at ",
 				startPoint));
 
-		return getLocalGitBranch(localGitBranchName, true);
+		LocalGitBranch localGitBranch = getLocalGitBranch(
+			localGitBranchName, true);
+
+		if (sourceRemoteGitBranch == null) {
+			return localGitBranch;
+		}
+
+		return GitBranchFactory.newLocalGitBranch(
+			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
+			localGitBranch.getSHA(), sourceRemoteGitBranch);
 	}
 
 	private boolean _deleteLocalGitBranches(String... branchNames) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
@@ -7,6 +7,8 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.util.List;
+
 /**
  * @author Michael Hashimoto
  */
@@ -26,6 +28,24 @@ public class LocalGitBranch extends BaseGitRef {
 
 	public LocalGitRepository getLocalGitRepository() {
 		return _localGitRepository;
+	}
+
+	public RemoteGitBranch getSourceRemoteGitBranch() {
+		if (_sourceRemoteGitBranch == null) {
+			return null;
+		}
+
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		List<String> branchNamesContainingSHA =
+			gitWorkingDirectory.getBranchNamesContainingSHA(
+				_sourceRemoteGitBranch.getSHA());
+
+		if (!branchNamesContainingSHA.contains(getName())) {
+			return null;
+		}
+
+		return _sourceRemoteGitBranch;
 	}
 
 	public String getUpstreamBranchName() {
@@ -53,6 +73,13 @@ public class LocalGitBranch extends BaseGitRef {
 	protected LocalGitBranch(
 		LocalGitRepository localGitRepository, String name, String sha) {
 
+		this(localGitRepository, name, sha, null);
+	}
+
+	protected LocalGitBranch(
+		LocalGitRepository localGitRepository, String name, String sha,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
 		super(name, sha);
 
 		if (localGitRepository == null) {
@@ -60,8 +87,11 @@ public class LocalGitBranch extends BaseGitRef {
 		}
 
 		_localGitRepository = localGitRepository;
+
+		_sourceRemoteGitBranch = sourceRemoteGitBranch;
 	}
 
 	private final LocalGitRepository _localGitRepository;
+	private final RemoteGitBranch _sourceRemoteGitBranch;
 
 }


### PR DESCRIPTION
- [LRCI-7485](https://liferay.atlassian.net/browse/LRCI-7485)
- [LRCI-7487](https://liferay.atlassian.net/browse/LRCI-7487)
- [LRCI-7488](https://liferay.atlassian.net/browse/LRCI-7488)

## What is being fixed

Liferay CI Jenkins masters use shallow clones. History-walking operations (merge-base, rebase, SHA containment) silently fail when the needed commit lies beyond the local horizon; the old code gave up after a single one-step widening or rejected month-old PRs outright.

## How it is being fixed

LocalGitBranch now carries its source RemoteGitBranch, so any local-history operation can lazily deepen through that source and retry. fetch reliably returns a stamped branch; getMergeBaseCommitSHA, refContainsSHA, and rebase deepen-and-retry on miss. rebase guarantees merge-base depth once up front rather than per attempt, and the conflict probe treats any failed rebase as a conflict.

## Why are there no tests?

New jrp test classes are deferred pending the CI-class testing revamp tracked by epic [LRCI-6664](https://liferay.atlassian.net/browse/LRCI-6664); validation runs through the sandbox Candidate Jar / ci:forward path.