### PR TITLE
LRCI-7485 Address post-merge review feedback in GitWorkingDirectory

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2722,8 +2722,10 @@ public class GitWorkingDirectory {
 	}
 
 	public boolean refContainsSHA(LocalGitBranch localGitBranch, String sha) {
+		String name = localGitBranch.getName();
+
 		for (int deepenAttempt = 0;; deepenAttempt++) {
-			if (refContainsSHA(localGitBranch.getName(), sha)) {
+			if (refContainsSHA(name, sha)) {
 				return true;
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1612,17 +1612,17 @@ public class GitWorkingDirectory {
 				continue;
 			}
 
-			RemoteGitBranch remoteGitBranch = null;
+			RemoteGitBranch upstreamRemoteGitBranch = null;
 
 			if (localGitBranchName.equals(upstreamBranchName)) {
-				remoteGitBranch = getUpstreamRemoteGitBranch();
+				upstreamRemoteGitBranch = getUpstreamRemoteGitBranch();
 			}
 
 			localGitBranches.add(
 				GitBranchFactory.newLocalGitBranch(
 					localGitRepository, localGitBranchName,
 					localGitBranchesShaMap.get(localGitBranchName),
-					remoteGitBranch));
+					upstreamRemoteGitBranch));
 		}
 
 		return localGitBranches;


### PR DESCRIPTION
- [LRCI-7485](https://liferay.atlassian.net/browse/LRCI-7485)

## Summary

Two readability cleanups in GitWorkingDirectory from post-merge code review of the shallow-clone self-heal work, no behavior change:

- refContainsSHA(LocalGitBranch, String): hoist the loop-invariant localGitBranch.getName() into a local before the deepen loop so it is computed once.
- getLocalGitBranches: rename the loop-local RemoteGitBranch from remoteGitBranch to upstreamRemoteGitBranch, matching the sibling block and the getUpstreamRemoteGitBranch() source.