### PR TITLE
LRCI-6956 Derive top level build URL from the build description

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser.testray;
 
 import com.liferay.jenkins.results.parser.BuildReportFactory;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.MultiPattern;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
 
 import java.io.IOException;
@@ -438,18 +439,48 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	}
 
 	public URL getTopLevelBuildURL() {
-		Matcher matcher = _getTestrayAttachmentURLMatcher();
+		String topLevelMasterHostname = null;
+		String topLevelJobName = null;
+		String topLevelBuildNumber = null;
 
-		if (matcher == null) {
+		String description = getDescription();
+
+		Matcher descriptionMatcher = null;
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(description)) {
+			descriptionMatcher = _descriptionPattern.matches(description);
+		}
+
+		if (descriptionMatcher != null) {
+			topLevelMasterHostname = descriptionMatcher.group(
+				"topLevelMasterHostname");
+			topLevelJobName = descriptionMatcher.group("topLevelJobName");
+			topLevelBuildNumber = descriptionMatcher.group(
+				"topLevelBuildNumber");
+		}
+		else {
+			Matcher testrayAttachmentURLMatcher =
+				_getTestrayAttachmentURLMatcher();
+
+			if (testrayAttachmentURLMatcher != null) {
+				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
+					"topLevelMasterHostname");
+				topLevelJobName = testrayAttachmentURLMatcher.group(
+					"topLevelJobName");
+				topLevelBuildNumber = testrayAttachmentURLMatcher.group(
+					"topLevelBuildNumber");
+			}
+		}
+
+		if (topLevelMasterHostname == null) {
 			return null;
 		}
 
 		try {
 			return new URL(
 				JenkinsResultsParserUtil.combine(
-					"https://", matcher.group("topLevelMasterHostname"),
-					".liferay.com/job/", matcher.group("topLevelJobName"), "/",
-					matcher.group("topLevelBuildNumber"), "/"));
+					"https://", topLevelMasterHostname, ".liferay.com/job/",
+					topLevelJobName, "/", topLevelBuildNumber, "/"));
 		}
 		catch (MalformedURLException malformedURLException) {
 			throw new RuntimeException(malformedURLException);
@@ -617,6 +648,16 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		return null;
 	}
 
+	private static final MultiPattern _descriptionPattern = new MultiPattern(
+		JenkinsResultsParserUtil.combine(
+			".*<a href=\"https://(?<topLevelMasterHostname>test-\\d+-\\d+)",
+			"\\.liferay\\.com/userContent/jobs/(?<topLevelJobName>[^/]+)/",
+			"builds/(?<topLevelBuildNumber>\\d+)/jenkins-report\\.html\">",
+			"Jenkins Report</a>.*"),
+		JenkinsResultsParserUtil.combine(
+			".*<a href=\".+/testray-results/\\d{4}-\\d{2}/",
+			"(?<topLevelMasterHostname>test-\\d+-\\d+)/",
+			"(?<topLevelJobName>[^/]+)/(?<topLevelBuildNumber>[^/]+)/.+"));
 	private static final Pattern _portalBranchPattern = Pattern.compile(
 		"Portal Branch: (?<portalBranch>[^;]+);");
 	private static final Pattern _testrayAttachmentURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -657,7 +657,8 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 		JenkinsResultsParserUtil.combine(
 			".*<a href=\".+/testray-results/\\d{4}-\\d{2}/",
 			"(?<topLevelMasterHostname>test-\\d+-\\d+)/",
-			"(?<topLevelJobName>[^/]+)/(?<topLevelBuildNumber>[^/]+)/.+"));
+			"(?<topLevelJobName>[^/]+)/(?<topLevelBuildNumber>\\d+)/",
+			"[^\"]+\">Jenkins Report</a>.*"));
 	private static final Pattern _portalBranchPattern = Pattern.compile(
 		"Portal Branch: (?<portalBranch>[^;]+);");
 	private static final Pattern _testrayAttachmentURLPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayBuild.java
@@ -439,10 +439,6 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 	}
 
 	public URL getTopLevelBuildURL() {
-		String topLevelMasterHostname = null;
-		String topLevelJobName = null;
-		String topLevelBuildNumber = null;
-
 		String description = getDescription();
 
 		Matcher descriptionMatcher = null;
@@ -451,24 +447,28 @@ public class TestrayBuild implements Comparable<TestrayBuild> {
 			descriptionMatcher = _descriptionPattern.matches(description);
 		}
 
+		String topLevelBuildNumber = null;
+		String topLevelJobName = null;
+		String topLevelMasterHostname = null;
+
 		if (descriptionMatcher != null) {
-			topLevelMasterHostname = descriptionMatcher.group(
-				"topLevelMasterHostname");
-			topLevelJobName = descriptionMatcher.group("topLevelJobName");
 			topLevelBuildNumber = descriptionMatcher.group(
 				"topLevelBuildNumber");
+			topLevelJobName = descriptionMatcher.group("topLevelJobName");
+			topLevelMasterHostname = descriptionMatcher.group(
+				"topLevelMasterHostname");
 		}
 		else {
 			Matcher testrayAttachmentURLMatcher =
 				_getTestrayAttachmentURLMatcher();
 
 			if (testrayAttachmentURLMatcher != null) {
-				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
-					"topLevelMasterHostname");
-				topLevelJobName = testrayAttachmentURLMatcher.group(
-					"topLevelJobName");
 				topLevelBuildNumber = testrayAttachmentURLMatcher.group(
 					"topLevelBuildNumber");
+				topLevelJobName = testrayAttachmentURLMatcher.group(
+					"topLevelJobName");
+				topLevelMasterHostname = testrayAttachmentURLMatcher.group(
+					"topLevelMasterHostname");
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -43,6 +43,8 @@ import com.liferay.jenkins.results.parser.test.clazz.group.PlaywrightAxisTestCla
 import java.io.File;
 import java.io.IOException;
 
+import java.net.URL;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -386,7 +388,19 @@ public class TestrayImporter {
 		}
 
 		sb.append("<a href=\"");
-		sb.append(_topLevelBuildReport.getJenkinsReportURL());
+
+		URL jenkinsReportTestrayAttachmentURL =
+			_topLevelBuildReport.getTestrayAttachmentURLBySuffix(
+				"jenkins-report.html.gz");
+
+		if (jenkinsReportTestrayAttachmentURL != null) {
+			sb.append(jenkinsReportTestrayAttachmentURL);
+			sb.append("?authuser=0");
+		}
+		else {
+			sb.append(_topLevelBuildReport.getJenkinsReportURL());
+		}
+
 		sb.append("\">Jenkins Report</a>");
 		sb.append("; ");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6956

## What Is Being Fixed

The top-level build URL for a Testray build was resolved only from a Testray attachment URL pattern. When the attachment URL was absent or in a different form, the URL could not be determined, and the build description — which carries the "Jenkins Report" link — was not consulted.

## How It Is Being Fixed

TestrayBuild now first parses the build description for the top-level master hostname, job name, and build number, using a MultiPattern anchored to the "Jenkins Report" link (covering both the userContent and testray-results URL forms), and falls back to the existing Testray attachment URL matcher only when the description does not match. TestrayImporter, in turn, links the "Jenkins Report" anchor to the jenkins-report.html.gz Testray attachment (with ?authuser=0) when one exists, falling back to the plain Jenkins report URL otherwise.

## Why Are There No Tests?

jenkins-results-parser is build/CI tooling exercised by the CI pipeline itself. The network-backed Testray parser methods touched here have no unit-test harness, and the behavior is validated by the actual Testray import run in CI.

## PR Check

**pr-check: PASS** — tested on `172fa7f87472cc38b9506315ba1ec58cb99980b9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS¹ |
| Java Unit Tests | PASS² |

¹ The structural assertions (`ModulesStructureTest`, `LibraryReferenceTest`, `ConfigurationEnvBuilderTest`) pass. Two failures are pre-existing baseline drift in this checkout, unrelated to the diff: `Log4jConfigUtilTest` trips the portal-kernel `CodeCoverageAssertor` coverage gate (all 11 test cases pass), and `SampleSQLBuilderTest` cannot resolve `com.liferay.util.taglib:30.0.0-SNAPSHOT` (an unbuilt version bump in the checkout).
² No counterpart unit test exists for the changed classes; compilation is verified by Per-Module Deploy and Integration Test Compile.

<!-- pr-check {"result": "success", "sha": "172fa7f87472cc38b9506315ba1ec58cb99980b9"} -->
