### PR TITLE
LRCI-7532 De-lambda LoadBalancerUtil for the ee-6.2.x webhook compiler

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -33,12 +33,18 @@ public class LoadBalancerUtil {
 		String blacklistString, String masterPrefix, Properties properties,
 		boolean verbose) {
 
-		List<JenkinsMaster> allJenkinsMasters =
-			_jenkinsMastersMap.computeIfAbsent(
+		List<JenkinsMaster> allJenkinsMasters = _jenkinsMastersMap.get(
+			masterPrefix);
+
+		if (allJenkinsMasters == null) {
+			_jenkinsMastersMap.putIfAbsent(
 				masterPrefix,
-				key -> JenkinsResultsParserUtil.getJenkinsMasters(
+				JenkinsResultsParserUtil.getJenkinsMasters(
 					properties, JenkinsMaster.getSlaveRAMMinimumDefault(),
-					JenkinsMaster.getSlavesPerHostDefault(), key));
+					JenkinsMaster.getSlavesPerHostDefault(), masterPrefix));
+
+			allJenkinsMasters = _jenkinsMastersMap.get(masterPrefix);
+		}
 
 		List<String> blacklist = _getBlacklist(
 			properties, blacklistString, verbose);
@@ -92,13 +98,16 @@ public class LoadBalancerUtil {
 			return null;
 		}
 
-		AtomicInteger counter = _roundRobinCounters.computeIfAbsent(
-			masterPrefix,
-			key -> {
-				Random random = new Random();
+		AtomicInteger counter = _roundRobinCounters.get(masterPrefix);
 
-				return new AtomicInteger(random.nextInt());
-			});
+		if (counter == null) {
+			Random random = new Random();
+
+			_roundRobinCounters.putIfAbsent(
+				masterPrefix, new AtomicInteger(random.nextInt()));
+
+			counter = _roundRobinCounters.get(masterPrefix);
+		}
 
 		int index = Math.floorMod(
 			counter.getAndIncrement(), availableJenkinsMasters.size());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7532

## What Is Being Fixed

The LRCI-7532 round-robin work (published in jenkins-results-parser 1.0.1829) introduced two `computeIfAbsent(..., key -> ...)` lambdas into `LoadBalancerUtil`. Lambdas compile to `invokedynamic` constant-pool entries, which the `liferay-plugins-ee` ee-6.2.x plugins SDK compiler (ECJ 3.7.2, pre-Java-8) cannot parse. Compiling `osb-github-web` (the GitHub webhook) against 1.0.1829 fails with `The import com.liferay.jenkins.results.parser.LoadBalancerUtil cannot be resolved`, leaving the webhook stuck on 1.0.1774.

## How It Is Being Fixed

The two lambdas are replaced with the classic `get` / `putIfAbsent` / re-`get` idiom on the same `ConcurrentHashMap` fields, preserving the atomic one-counter-per-prefix guarantee of the round-robin seeding while producing no `invokedynamic` bytecode. The rebuilt class was verified to contain zero `invokedynamic`/`BootstrapMethods` entries, an isolated ECJ 3.7.2 + JDK 7 compile of a `LoadBalancerUtil` consumer now succeeds, and a full `ant deploy` of `osb-github-web` against the rebuilt jar compiles all nine sources and builds the war. The webhook can move off 1.0.1774 once the next jar version is published with this change.

## Why Are There No Tests?

`LoadBalancerUtil` has no existing unit tests — it reads live build properties and Jenkins master state. The change is a behavior-preserving refactor verified by bytecode inspection (zero `invokedynamic`), an ECJ 3.7.2 compile reproduction, and a successful `osb-github-web` `ant deploy` against the rebuilt jar.

## PR Check

**pr-check: PASS** — tested on `2337794e82744dacf3bfd0e401a90de7c02d08ff`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS¹ |
| Java Unit Tests | PASS² |

¹ `Log4jConfigUtilTest` fails its code-coverage assertion identically on the clean merge-base (`89b6cd1`) — pre-existing upstream failure, not attributable to this branch. All other smoke classes pass.
² 74 run; 11 failures exactly equal to the clean-master baseline (environment-dependent Git/RelevantRule tests) — zero new failures.

<!-- pr-check {"result": "success", "sha": "2337794e82744dacf3bfd0e401a90de7c02d08ff"} -->