### PR TITLE
LRCI-7625 Remove unused methods from jenkins-results-parser

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -502,10 +502,6 @@ public abstract class BaseTopLevelBuild
 		return testSuiteName;
 	}
 
-	public TimelineData getTimelineData() {
-		return new TimelineData(500, this);
-	}
-
 	@Override
 	public TopLevelBuildReport getTopLevelBuildReport() {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(getBuildURL())) {
@@ -1631,7 +1627,7 @@ public abstract class BaseTopLevelBuild
 		scriptElement.addAttribute("src", _URL_CHART_JS);
 		scriptElement.addText("");
 
-		TimelineData timelineData = getTimelineData();
+		TimelineData timelineData = new TimelineData(500, this);
 
 		Element chartJSScriptElement = getJenkinsReportChartJsScriptElement(
 			Arrays.toString(timelineData.getIndexData()),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Dom4JUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Dom4JUtil.java
@@ -21,13 +21,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.dom4j.Attribute;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.dom4j.Node;
-import org.dom4j.Text;
 import org.dom4j.XPath;
 import org.dom4j.io.DOMReader;
 import org.dom4j.io.OutputFormat;
@@ -255,7 +253,7 @@ public class Dom4JUtil {
 
 		elements.add(targetElementIndex + 1, newElement);
 
-		setElements(parentElement, elements);
+		_setElements(parentElement, elements);
 	}
 
 	public static void insertElementBefore(
@@ -282,7 +280,7 @@ public class Dom4JUtil {
 
 		elements.add(targetElementIndex, newElement);
 
-		setElements(parentElement, elements);
+		_setElements(parentElement, elements);
 	}
 
 	public static Document parse(String xml) throws DocumentException {
@@ -339,54 +337,6 @@ public class Dom4JUtil {
 
 				throw new RuntimeException(exception2);
 			}
-		}
-	}
-
-	public static void replace(
-		Element element, boolean cascade, String replacementText,
-		String targetText) {
-
-		for (Attribute attribute : element.attributes()) {
-			String text = attribute.getValue();
-
-			attribute.setValue(text.replace(targetText, replacementText));
-		}
-
-		Iterator<? extends Node> nodeIterator = element.nodeIterator();
-
-		while (nodeIterator.hasNext()) {
-			Node node = nodeIterator.next();
-
-			if (node instanceof Text) {
-				Text textNode = (Text)node;
-
-				String text = textNode.getText();
-
-				if (text.contains(targetText)) {
-					text = text.replace(targetText, replacementText);
-
-					textNode.setText(text);
-				}
-			}
-			else if ((node instanceof Element) && cascade) {
-				replace((Element)node, cascade, replacementText, targetText);
-			}
-		}
-	}
-
-	public static void setElements(
-		Element parentElement, List<Element> elements) {
-
-		if (parentElement == null) {
-			throw new IllegalArgumentException("Parent is null");
-		}
-
-		for (Element element : parentElement.elements()) {
-			parentElement.remove(element);
-		}
-
-		for (Element element : elements) {
-			parentElement.add(element);
 		}
 	}
 
@@ -489,6 +439,22 @@ public class Dom4JUtil {
 		sb.append(path);
 
 		return JenkinsResultsParserUtil.toJSONObject(sb.toString());
+	}
+
+	private static void _setElements(
+		Element parentElement, List<Element> elements) {
+
+		if (parentElement == null) {
+			throw new IllegalArgumentException("Parent is null");
+		}
+
+		for (Element element : parentElement.elements()) {
+			parentElement.remove(element);
+		}
+
+		for (Element element : elements) {
+			parentElement.add(element);
+		}
 	}
 
 	private static String _entities;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JIRAUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JIRAUtil.java
@@ -8,11 +8,7 @@ package com.liferay.jenkins.results.parser;
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.JiraRestClientFactory;
-import com.atlassian.jira.rest.client.api.RestClientException;
-import com.atlassian.jira.rest.client.api.domain.Comment;
 import com.atlassian.jira.rest.client.api.domain.Issue;
-import com.atlassian.jira.rest.client.api.domain.Transition;
-import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 
 import io.atlassian.util.concurrent.Promise;
@@ -24,40 +20,11 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 
 /**
  * @author Charlotte Wong
  */
 public class JIRAUtil {
-
-	public static void executeTransition(
-		String comment, Issue issue, Transition transition) {
-
-		if (_issueRestClient == null) {
-			return;
-		}
-
-		TransitionInput transitionInput = new TransitionInput(
-			transition.getId(), Comment.valueOf(comment));
-
-		try {
-			Promise<Void> promise = _issueRestClient.transition(
-				issue, transitionInput);
-
-			promise.get();
-
-			_uncacheIssue(issue.getKey());
-		}
-		catch (ExecutionException | InterruptedException | RestClientException
-					exception) {
-
-			System.err.println(
-				"Unable to execute transition " + transition.getName());
-
-			exception.printStackTrace();
-		}
-	}
 
 	public static Issue getIssue(String issueKey) {
 		if (_issueRestClient == null) {
@@ -92,24 +59,6 @@ public class JIRAUtil {
 		}
 	}
 
-	public static Transition getTransition(Issue issue, String transitionName) {
-		Map<String, Transition> transitionMap = getTransitions(issue);
-
-		if (transitionMap == null) {
-			return null;
-		}
-
-		return transitionMap.get(transitionName);
-	}
-
-	public static Map<String, Transition> getTransitions(Issue issue) {
-		if (!_transitionsMap.containsKey(issue.getKey())) {
-			_initTransitions(issue);
-		}
-
-		return _transitionsMap.get(issue.getKey());
-	}
-
 	private static IssueRestClient _initIssueRestClient() {
 		try {
 			Properties buildProperties = null;
@@ -142,36 +91,14 @@ public class JIRAUtil {
 		}
 	}
 
-	private static void _initTransitions(Issue issue) {
-		if (_issueRestClient == null) {
-			return;
-		}
-
-		Map<String, Transition> transitions = new ConcurrentHashMap<>();
-
-		Promise<Iterable<Transition>> promise = _issueRestClient.getTransitions(
-			issue);
-
-		Iterable<Transition> iterable = promise.claim();
-
-		for (Transition transition : iterable) {
-			transitions.put(transition.getName(), transition);
-		}
-
-		_transitionsMap.put(issue.getKey(), transitions);
-	}
-
 	private static void _uncacheIssue(String issueKey) {
 		_cachedIssues.remove(issueKey);
-		_transitionsMap.remove(issueKey);
 	}
 
 	private static final Map<String, CachedIssue> _cachedIssues =
 		new ConcurrentHashMap<>();
 	private static final IssueRestClient _issueRestClient =
 		_initIssueRestClient();
-	private static final Map<String, Map<String, Transition>> _transitionsMap =
-		new ConcurrentHashMap<>();
 
 	private static class CachedIssue {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConsoleTextLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConsoleTextLoader.java
@@ -114,18 +114,6 @@ public class JenkinsConsoleTextLoader {
 		return consoleText;
 	}
 
-	public int getLineCount() {
-		String consoleLog = getConsoleText();
-
-		String[] consoleLogLines = consoleLog.split("\n");
-
-		return consoleLogLines.length;
-	}
-
-	public boolean hasMoreData() {
-		return hasMoreData;
-	}
-
 	public void moveCacheFileToArchiveFile(File archiveFile) {
 		if ((archiveFile == null) ||
 			JenkinsResultsParserUtil.isNullOrEmpty(getConsoleText())) {
@@ -178,7 +166,6 @@ public class JenkinsConsoleTextLoader {
 	protected String buildURL;
 	protected boolean bypassConsoleLogSizeLimit;
 	protected String consoleLogFileKey;
-	protected boolean hasMoreData = true;
 	protected long serverLogSize;
 	protected boolean truncated;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -278,29 +278,6 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return new ArrayList<>(_buildURLs);
 	}
 
-	public List<DefaultBuild> getDefaultBuilds() {
-		List<String> buildURLs = getBuildURLs();
-
-		List<DefaultBuild> oldDefaultBuilds = new ArrayList<>();
-
-		for (DefaultBuild defaultBuild : _defaultBuilds) {
-			if (!buildURLs.contains(defaultBuild.getBuildURL())) {
-				oldDefaultBuilds.add(defaultBuild);
-			}
-			else {
-				buildURLs.remove(defaultBuild.getBuildURL());
-			}
-		}
-
-		_defaultBuilds.removeAll(oldDefaultBuilds);
-
-		for (String buildURL : buildURLs) {
-			_defaultBuilds.add(BuildFactory.newDefaultBuild(buildURL));
-		}
-
-		return _defaultBuilds;
-	}
-
 	public Map<String, String> getGlobalEnvironmentVariables() {
 		if (_globalEnvironmentVariables != null) {
 			return _globalEnvironmentVariables;
@@ -1637,7 +1614,6 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		new HashMap<>();
 	private final Map<String, Long> _buildsUpdateTimes = new HashMap<>();
 	private final List<String> _buildURLs = new CopyOnWriteArrayList<>();
-	private final List<DefaultBuild> _defaultBuilds = new ArrayList<>();
 	private Map<String, String> _globalEnvironmentVariables;
 	private boolean _idle;
 	private JenkinsCohort _jenkinsCohort;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -191,22 +191,6 @@ public class JenkinsResultsParserUtil {
 		}
 	}
 
-	public static void cancelQueuedItem(
-		long itemID, JenkinsMaster jenkinsMaster) {
-
-		StringBuilder sb = new StringBuilder();
-
-		sb.append("def queue = Jenkins.instance.queue;\n");
-
-		sb.append("def items = queue.items.findAll{it.getId() == ");
-		sb.append(itemID);
-		sb.append("};\n");
-
-		sb.append("queue.cancel(items[0]);");
-
-		executeJenkinsScript(jenkinsMaster.getName(), sb.toString());
-	}
-
 	public static void clearCache() {
 		File cacheDirectory = new File(
 			System.getProperty("java.io.tmpdir"), "jenkins-cached-files");
@@ -2047,24 +2031,6 @@ public class JenkinsResultsParserUtil {
 		return targetGitDirectoryName;
 	}
 
-	public static String getGitHubAPIRateLimitStatusMessage() {
-		try {
-			JSONObject jsonObject = toJSONObject(
-				"https://api.github.com/rate_limit");
-
-			jsonObject = jsonObject.getJSONObject("rate");
-
-			return _getGitHubAPIRateLimitStatusMessage(
-				jsonObject.getInt("limit"), jsonObject.getInt("remaining"),
-				jsonObject.getLong("reset"));
-		}
-		catch (Exception exception) {
-			System.out.println("Unable to get GitHub API rate limit");
-		}
-
-		return "";
-	}
-
 	public static String getGitHubApiSearchUrl(List<String> filters) {
 		return combine(
 			"https://api.github.com/search/issues?q=", join("+", filters));
@@ -2195,35 +2161,6 @@ public class JenkinsResultsParserUtil {
 		return globs.toArray(new String[0]);
 	}
 
-	public static String getHeadersString(URLConnection urlConnection) {
-		Map<String, List<String>> headersMap = urlConnection.getHeaderFields();
-
-		StringBuilder sb = new StringBuilder();
-
-		for (Map.Entry<String, List<String>> entry : headersMap.entrySet()) {
-			sb.append(entry.getKey());
-			sb.append(": ");
-
-			sb.append(join(", ", entry.getValue()));
-			sb.append("\n");
-		}
-
-		sb.append("\n");
-
-		return sb.toString();
-	}
-
-	public static String getHostIPAddress() {
-		try {
-			InetAddress inetAddress = InetAddress.getLocalHost();
-
-			return inetAddress.getHostAddress();
-		}
-		catch (UnknownHostException unknownHostException) {
-			return "127.0.0.1";
-		}
-	}
-
 	public static String getHostName(String defaultHostName) {
 		try {
 			InetAddress inetAddress = InetAddress.getLocalHost();
@@ -2311,53 +2248,6 @@ public class JenkinsResultsParserUtil {
 		}
 
 		return includedFiles;
-	}
-
-	public static List<URL> getIncludedResourceURLs(
-			String[] resourceIncludesRelativeGlobs, File rootDir)
-		throws IOException {
-
-		final List<PathMatcher> pathMatchers = toPathMatchers(
-			getCanonicalPath(rootDir) + File.separator,
-			resourceIncludesRelativeGlobs);
-
-		Path rootDirPath = rootDir.toPath();
-
-		if (!Files.exists(rootDirPath)) {
-			System.out.println(
-				combine(
-					"Directory ", rootDirPath.toString(), " does not exist."));
-
-			return Collections.emptyList();
-		}
-
-		final List<URL> includedResourceURLs = new ArrayList<>();
-
-		Files.walkFileTree(
-			rootDirPath,
-			new SimpleFileVisitor<Path>() {
-
-				@Override
-				public FileVisitResult visitFile(
-						Path filePath, BasicFileAttributes basicFileAttributes)
-					throws IOException {
-
-					for (PathMatcher pathMatcher : pathMatchers) {
-						if (pathMatcher.matches(filePath)) {
-							URI uri = filePath.toUri();
-
-							includedResourceURLs.add(uri.toURL());
-
-							break;
-						}
-					}
-
-					return FileVisitResult.CONTINUE;
-				}
-
-			});
-
-		return includedResourceURLs;
 	}
 
 	public static float getJavaVersionNumber() {
@@ -3228,37 +3118,6 @@ public class JenkinsResultsParserUtil {
 		return getRandomString(gitHubDevNodeHostnames);
 	}
 
-	public static List<String> getRandomList(List<String> list, int size) {
-		if (list.size() < size) {
-			throw new IllegalStateException(
-				"Size must not exceed the size of the list");
-		}
-
-		if (size == list.size()) {
-			return list;
-		}
-
-		List<String> randomList = new ArrayList<>(size);
-
-		for (int i = 0; i < size; i++) {
-			String item = null;
-
-			while (true) {
-				item = getRandomString(list);
-
-				if (randomList.contains(item)) {
-					continue;
-				}
-
-				randomList.add(item);
-
-				break;
-			}
-		}
-
-		return randomList;
-	}
-
 	public static <T> T getRandomListItem(List<T> list) {
 		return list.get(getRandomValue(0, list.size() - 1));
 	}
@@ -3487,21 +3346,6 @@ public class JenkinsResultsParserUtil {
 
 			return readInputStream(resourceInputStream);
 		}
-	}
-
-	public static String getResponseHeaders(URLConnection urlConnection) {
-		StringBuilder sb = new StringBuilder();
-
-		Map<String, List<String>> map = urlConnection.getHeaderFields();
-
-		for (Map.Entry<String, List<String>> entry : map.entrySet()) {
-			sb.append(entry.getKey());
-			sb.append(":");
-			sb.append(join(",", entry.getValue()));
-			sb.append("\n");
-		}
-
-		return sb.toString();
 	}
 
 	public static String getSHA(File file) {
@@ -4389,111 +4233,6 @@ public class JenkinsResultsParserUtil {
 		executeJenkinsScript(masterHostname, sb.toString());
 	}
 
-	public static int lastIndexOfRegex(String string, String regex) {
-		Pattern pattern = Pattern.compile(regex);
-
-		Matcher matcher = pattern.matcher(string);
-
-		int lastIndex = -1;
-
-		while (matcher.find()) {
-			lastIndex = matcher.start();
-		}
-
-		return lastIndex;
-	}
-
-	public static void loadBalanceQueuedBuilds(
-			String jobName, JenkinsMaster jenkinsMaster)
-		throws IOException {
-
-		List<JenkinsMaster> availableJenkinsMasters = new ArrayList<>();
-
-		JenkinsCohort jenkinsCohort = jenkinsMaster.getJenkinsCohort();
-
-		for (JenkinsMaster availableJenkinsMaster :
-				jenkinsCohort.getJenkinsMasters()) {
-
-			if (!availableJenkinsMaster.isAvailable() ||
-				availableJenkinsMaster.isBlackListed()) {
-
-				continue;
-			}
-
-			availableJenkinsMasters.add(availableJenkinsMaster);
-		}
-
-		JSONObject jsonObject = toJSONObject(
-			combine(
-				"https://", jenkinsMaster.getName(),
-				".liferay.com/queue/api/json"));
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		for (int i = 0; i < itemsJSONArray.length(); i++) {
-			JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
-
-			JSONObject taskJSONObject = itemJSONObject.getJSONObject("task");
-
-			String name = taskJSONObject.getString("name");
-
-			if (!name.equals(jobName)) {
-				continue;
-			}
-
-			JSONArray actionsJSONArray = itemJSONObject.optJSONArray("actions");
-
-			StringBuilder sb = new StringBuilder();
-
-			JenkinsMaster availableJenkinsMaster = getRandomListItem(
-				availableJenkinsMasters);
-
-			sb.append("http://");
-			sb.append(availableJenkinsMaster.getName());
-			sb.append("/job/");
-			sb.append(jobName);
-			sb.append("/buildWithParameters?");
-			sb.append("token=raen3Aib");
-
-			for (int j = 0; j < actionsJSONArray.length(); j++) {
-				JSONObject actionJSONObject = actionsJSONArray.getJSONObject(j);
-
-				if (!Objects.equals(
-						actionJSONObject.optString("_class"),
-						"hudson.model.ParametersAction")) {
-
-					continue;
-				}
-
-				JSONArray parametersJSONArray = actionJSONObject.optJSONArray(
-					"parameters");
-
-				for (int k = 0; k < parametersJSONArray.length(); k++) {
-					JSONObject parameterJSONObject =
-						parametersJSONArray.getJSONObject(k);
-
-					String paramName = parameterJSONObject.getString("name");
-					String paramValue = parameterJSONObject.getString("value");
-
-					if (isNullOrEmpty(paramName) || isNullOrEmpty(paramValue)) {
-						continue;
-					}
-
-					sb.append("&");
-					sb.append(paramName);
-					sb.append("=");
-					sb.append(paramValue);
-				}
-			}
-
-			System.out.println(sb);
-
-			toString(sb.toString());
-
-			cancelQueuedItem(itemJSONObject.getLong("id"), jenkinsMaster);
-		}
-	}
-
 	public static void move(File sourceFile, File targetFile)
 		throws IOException {
 
@@ -4533,66 +4272,6 @@ public class JenkinsResultsParserUtil {
 		}
 
 		return Lists.partition(list, partitionSize);
-	}
-
-	public static void printTable(String[][] table) {
-		if (table.length == 0) {
-			return;
-		}
-
-		int[] maxColumnWidth = new int[table[0].length];
-
-		for (String[] row : table) {
-			for (int columnNumber = 0; columnNumber < row.length;
-				 columnNumber++) {
-
-				String item = row[columnNumber];
-
-				if (maxColumnWidth[columnNumber] <= item.length()) {
-					maxColumnWidth[columnNumber] = item.length();
-				}
-			}
-		}
-
-		StringBuilder rowsStringBuilder = new StringBuilder();
-
-		for (String[] row : table) {
-			for (int columnNumber = 0; columnNumber < row.length;
-				 columnNumber++) {
-
-				String cellText = row[columnNumber];
-
-				rowsStringBuilder.append(
-					String.format(
-						combine(
-							"| %-",
-							String.valueOf(maxColumnWidth[columnNumber]), "s "),
-						cellText));
-			}
-
-			rowsStringBuilder.append("|\n");
-		}
-
-		int rowTotalSize = rowsStringBuilder.indexOf("\n");
-
-		StringBuilder tableStringBuilder = new StringBuilder();
-
-		for (int columnNumber = 0; columnNumber < rowTotalSize;
-			 columnNumber++) {
-
-			tableStringBuilder.append("-");
-		}
-
-		tableStringBuilder.append("\n");
-		tableStringBuilder.append(rowsStringBuilder);
-
-		for (int columnNumber = 0; columnNumber < rowTotalSize;
-			 columnNumber++) {
-
-			tableStringBuilder.append("-");
-		}
-
-		System.out.println(tableStringBuilder.toString());
 	}
 
 	public static void pullDockerImageDependencies(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MultiPattern.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MultiPattern.java
@@ -35,14 +35,6 @@ public class MultiPattern {
 		return null;
 	}
 
-	public int getSize() {
-		return _patterns.size();
-	}
-
-	public int indexOf(Pattern pattern) {
-		return _patterns.indexOf(pattern);
-	}
-
 	public Matcher matches(String input) {
 		for (Pattern pattern : _patterns) {
 			Matcher matcher = pattern.matcher(input);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ParallelExecutor.java
@@ -94,10 +94,6 @@ public class ParallelExecutor<T> {
 		return true;
 	}
 
-	public void shutdownNow() {
-		_executorService.shutdownNow();
-	}
-
 	public synchronized void start() {
 		_taskRunnable = new TaskRunnable<>(_callables, this);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/GitHubWebhookPayloadProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/GitHubWebhookPayloadProcessor.java
@@ -403,14 +403,6 @@ public class GitHubWebhookPayloadProcessor {
 		}
 	}
 
-	public void removeTestPullRequestQueryString(String queryString) {
-		_testPullRequestQueryStrings.remove(queryString);
-	}
-
-	public void removeTestPullRequestURL(String url) {
-		_testPullRequestURLs.remove(url);
-	}
-
 	protected void commentMergeSubrepoPullRequest(PullRequest pullRequest) {
 		try {
 			String currentSHA = "";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/PushEventPayload.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/github/webhook/PushEventPayload.java
@@ -38,10 +38,6 @@ public class PushEventPayload extends Payload {
 		return get("after");
 	}
 
-	public String getBeforeSHA() {
-		return get("before");
-	}
-
 	public GitHubRemoteGitCommit getHeadGitHubRemoteGitCommit() {
 		if (headGitHubRemoteGitCommit == null) {
 			headGitHubRemoteGitCommit =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildArchiverUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildArchiverUtil.java
@@ -31,35 +31,6 @@ import org.json.JSONObject;
  */
 public class BuildArchiverUtil {
 
-	public static void archive(
-		String startDateString, String endDateString, String outputDirPath) {
-
-		try {
-			String groovyScript = JenkinsResultsParserUtil.readInputStream(
-				JenkinsResultsParserUtil.class.getResourceAsStream(
-					"dependencies/get-build-data.groovy"));
-
-			groovyScript = groovyScript.replaceFirst(
-				"new Date\\(\\)",
-				"Date.parse(\"yyyyMMdd hh:mm:ss\", \"" + endDateString +
-					" 00:00:00\")");
-			groovyScript = groovyScript.replaceFirst(
-				"startDate\\.format\\(\"yyyyMMdd\"\\) \\+ \"",
-				"\"" + startDateString);
-
-			System.out.println(groovyScript);
-
-			_recordGroovyScriptResponses(
-				JenkinsResultsParserUtil.getJenkinsMasters(
-					_buildProperties, 12, 2, "test-1"),
-				groovyScript, new File(outputDirPath));
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(
-				"Unable to get get-build-data.groovy", ioException);
-		}
-	}
-
 	public static void archiveOneDay(String startDateString) {
 		String outputDirPath = null;
 
@@ -100,7 +71,7 @@ public class BuildArchiverUtil {
 		String endDateString = localDateTime.format(
 			DateTimeFormatter.ofPattern("yyyyMMdd"));
 
-		archive(
+		_archive(
 			startDateString, endDateString,
 			outputDirPath + "/" + startDateString + "/");
 	}
@@ -119,6 +90,35 @@ public class BuildArchiverUtil {
 		}
 
 		return true;
+	}
+
+	private static void _archive(
+		String startDateString, String endDateString, String outputDirPath) {
+
+		try {
+			String groovyScript = JenkinsResultsParserUtil.readInputStream(
+				JenkinsResultsParserUtil.class.getResourceAsStream(
+					"dependencies/get-build-data.groovy"));
+
+			groovyScript = groovyScript.replaceFirst(
+				"new Date\\(\\)",
+				"Date.parse(\"yyyyMMdd hh:mm:ss\", \"" + endDateString +
+					" 00:00:00\")");
+			groovyScript = groovyScript.replaceFirst(
+				"startDate\\.format\\(\"yyyyMMdd\"\\) \\+ \"",
+				"\"" + startDateString);
+
+			System.out.println(groovyScript);
+
+			_recordGroovyScriptResponses(
+				JenkinsResultsParserUtil.getJenkinsMasters(
+					_buildProperties, 12, 2, "test-1"),
+				groovyScript, new File(outputDirPath));
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to get get-build-data.groovy", ioException);
+		}
 	}
 
 	private static Boolean _call(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryProcessor.java
@@ -12,7 +12,6 @@ import java.io.File;
 import java.io.IOException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -51,12 +50,6 @@ public class BuildHistoryProcessor {
 		return _mergeBuildHistories(new ArrayList<>(buildHistories), name);
 	}
 
-	public static BuildHistory mergeBuildHistories(
-		String name, BuildHistory... buildHistories) {
-
-		return _mergeBuildHistories(Arrays.asList(buildHistories), name);
-	}
-
 	public static Collection<BuildHistory> newAggregateJobHistories(
 		long duration, long startTime) {
 
@@ -71,27 +64,6 @@ public class BuildHistoryProcessor {
 					_addToBuildHistoriesMap(
 						buildJSONObjects, buildHistories, duration,
 						new GroupByCategory(), startTime);
-				}
-
-			};
-
-		return _getBuildHistories(biConsumer, duration, null, null, startTime);
-	}
-
-	public static Collection<BuildHistory> newDefaultJobHistories(
-		long duration, long startTime) {
-
-		BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>> biConsumer =
-			new BiConsumer<Set<BuildJSONObject>, Map<String, BuildHistory>>() {
-
-				@Override
-				public void accept(
-					Set<BuildJSONObject> buildJSONObjects,
-					Map<String, BuildHistory> buildHistories) {
-
-					_addToBuildHistoriesMap(
-						buildJSONObjects, buildHistories, duration,
-						new GroupByJobName(), startTime);
 				}
 
 			};


### PR DESCRIPTION
## Summary

- Remove unused public methods from 10 `jenkins-results-parser` classes
- Demote 2 package-private methods to private where they had no external callers
- Cascade removal of orphaned private fields and imports

12 files changed, +49 / -570. Classes: `BaseTopLevelBuild`, `Dom4JUtil`, `JIRAUtil`, `JenkinsConsoleTextLoader`, `JenkinsMaster`, `JenkinsResultsParserUtil`, `MultiPattern`, `ParallelExecutor`, `GitHubWebhookPayloadProcessor`, `PushEventPayload`, `BuildArchiverUtil`, `BuildHistoryProcessor`.

## Verification

All callers verified across Java, BeanShell, Ant XML (liferay-jenkins-ee + portal root), and bash scripts before removal.

pr-check results:
- Source format: **PASS** — no changes required
- `gradlew jar`: **BUILD SUCCESSFUL**
- Unit tests: **66/74 passing** — the 8 failures are pre-existing environment artifacts in `RelevantRuleEngineTest`/`RelevantTestSuiteTest` (`getPortalDir()` searches for a directory named exactly `liferay-portal` and fails in any worktree with a different name). None of the failing tests touch the 12 changed classes.

## Note

Replaces #4332, which was accidentally based against upstream master (~149 commits ahead of this fork), causing a polluted diff. This PR is based directly on pyoo47/master.