### PR TITLE
LRCI-7648 Split JUnit test class cache to fix ClassCastException

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/TestClassFactory.java
@@ -43,6 +43,8 @@ public class TestClassFactory {
 		List<JUnitTestClass> jUnitTestClasses = new ArrayList<>(
 			_jUnitTestClasses.values());
 
+		jUnitTestClasses.addAll(_modulesJUnitTestClasses.values());
+
 		Collections.sort(jUnitTestClasses);
 
 		return jUnitTestClasses;
@@ -221,6 +223,32 @@ public class TestClassFactory {
 				return new JSUnitModulesTestClass(
 					batchTestClassGroup, testClassFile);
 			}
+			else if (batchTestClassGroup instanceof
+						ModulesJUnitBatchTestClassGroup) {
+
+				File canonicalFile = _getCanonicalFile(
+					testClassFile, jsonObject);
+
+				if (_modulesJUnitTestClasses.containsKey(canonicalFile)) {
+					return _modulesJUnitTestClasses.get(canonicalFile);
+				}
+
+				ModulesJUnitTestClass modulesJUnitTestClass = null;
+
+				if (jsonObject != null) {
+					modulesJUnitTestClass = new ModulesJUnitTestClass(
+						batchTestClassGroup, jsonObject);
+				}
+				else {
+					modulesJUnitTestClass = new ModulesJUnitTestClass(
+						batchTestClassGroup, testClassFile);
+				}
+
+				_modulesJUnitTestClasses.put(
+					canonicalFile, modulesJUnitTestClass);
+
+				return _modulesJUnitTestClasses.get(canonicalFile);
+			}
 			else if (batchTestClassGroup instanceof JUnitBatchTestClassGroup) {
 				File canonicalFile = _getCanonicalFile(
 					testClassFile, jsonObject);
@@ -232,28 +260,12 @@ public class TestClassFactory {
 				JUnitTestClass jUnitTestClass = null;
 
 				if (jsonObject != null) {
-					if (batchTestClassGroup instanceof
-							ModulesJUnitBatchTestClassGroup) {
-
-						jUnitTestClass = new ModulesJUnitTestClass(
-							batchTestClassGroup, jsonObject);
-					}
-					else {
-						jUnitTestClass = new JUnitTestClass(
-							batchTestClassGroup, jsonObject);
-					}
+					jUnitTestClass = new JUnitTestClass(
+						batchTestClassGroup, jsonObject);
 				}
 				else {
-					if (batchTestClassGroup instanceof
-							ModulesJUnitBatchTestClassGroup) {
-
-						jUnitTestClass = new ModulesJUnitTestClass(
-							batchTestClassGroup, testClassFile);
-					}
-					else {
-						jUnitTestClass = new JUnitTestClass(
-							batchTestClassGroup, testClassFile);
-					}
+					jUnitTestClass = new JUnitTestClass(
+						batchTestClassGroup, testClassFile);
 				}
 
 				_jUnitTestClasses.put(canonicalFile, jUnitTestClass);
@@ -468,6 +480,8 @@ public class TestClassFactory {
 
 	private static final Map<File, JUnitTestClass> _jUnitTestClasses =
 		new ConcurrentHashMap<>();
+	private static final Map<File, ModulesJUnitTestClass>
+		_modulesJUnitTestClasses = new ConcurrentHashMap<>();
 	private static final Map<File, NPMTestClass> _npmTestClasses =
 		new ConcurrentHashMap<>();
 	private static final Map<File, PlaywrightJUnitTestClass>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7648

## What Is Being Fixed

test-portal-release aborts before any tests run with
`java.lang.ClassCastException: JUnitTestClass cannot be cast to
ModulesJUnitTestClass`, thrown from
`ModulesJUnitBatchTestClassGroup._getModulesJUnitTestClasses` and surfaced as
"Unable to create batch test class groups". `TestClassFactory` cached every
JUnit test class in a single static map keyed only by the canonical file,
shared across all `JUnitBatchTestClassGroup` subtypes. When the same test file
was selected by both a non-modules JUnit batch and the modules-integration
batch, whichever ran first cached its variant; if the non-modules batch won,
the modules group later pulled a plain `JUnitTestClass` and cast it to
`ModulesJUnitTestClass`. This was triggered on release-7.4.13.150, where an
`integration-license` batch (plain JUnit) shares a test file with
modules-integration.

## How It Is Being Fixed

Split the shared cache so modules JUnit test classes get their own file-keyed
map, separate from the plain and project-templates JUnit cache. `_newTestClass`
routes a `ModulesJUnitBatchTestClassGroup` to the modules map and always
constructs a `ModulesJUnitTestClass`, while every other `JUnitBatchTestClassGroup`
uses the original map and constructs a `JUnitTestClass`; the nested type check in
the old branch is removed. `getJUnitTestClasses` merges both maps so the report
manifest is unchanged. A modules group can no longer receive a plain
`JUnitTestClass`, which eliminates the cast failure.

## Why Are There No Tests?

jenkins-results-parser has no unit-test harness for `TestClassFactory` (no
existing test references the class), and the batch-construction path runs only
through the Ant/BeanShell CI bridge, not locally. The fix is being verified by
running test-portal-release against release-7.4.13.150 — the branch that
reproduced the crash — with the patched jar.

## PR Check

**pr-check: PASS** — tested on `2b93521c14ab59f6bfb071a0b3b0cda67ec16426`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

_Per-Module Deploy and Integration Test Compile fired on the diff but were trimmed (low value for a Nexus-consumed CI-tooling module; compile + jar already verified). Java Unit Tests omitted — no test covers `TestClassFactory` and the full suite is network-bound._

<!-- pr-check {"result": "success", "sha": "2b93521c14ab59f6bfb071a0b3b0cda67ec16426"} -->
