### PR TITLE
LRCI-7574 Validate test.batch.run.property.query PQL in stable

### DIFF
--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
@@ -1,4 +1,4 @@
 test.batch.run.property.query[functional-tomcat-mysql*-jdk*][test-portal-hotfix-release]=\
-    (testray.component.names ~ "Walkthrough") AND ((portal.acceptance == true) AND (portal.upstream == true)) AND ((app.server.types == null) OR (app.server.types ~ "tomcat")) AND ((database.types == null) OR (database.types ~ "mysql")
+    (testray.component.names ~ "Walkthrough") AND ((portal.acceptance == true) AND (portal.upstream == true)) AND ((app.server.types == null) OR (app.server.types ~ "tomcat")) AND ((database.types == null) OR (database.types ~ "mysql"))
 
 testray.main.component.name=Frontend JS

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties
@@ -1,4 +1,16 @@
 test.batch.run.property.query[functional-tomcat-mysql*-jdk*][test-portal-hotfix-release]=\
-    (testray.component.names ~ "Walkthrough") AND ((portal.acceptance == true) AND (portal.upstream == true)) AND ((app.server.types == null) OR (app.server.types ~ "tomcat")) AND ((database.types == null) OR (database.types ~ "mysql"))
+    (testray.component.names ~ "Walkthrough") AND \
+    (\
+        (portal.acceptance == true) AND \
+        (portal.upstream == true)\
+    ) AND \
+    (\
+        (app.server.types == null) OR \
+        (app.server.types ~ "tomcat")\
+    ) AND \
+    (\
+        (database.types == null) OR \
+        (database.types ~ "mysql")\
+    )
 
 testray.main.component.name=Frontend JS

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -1,0 +1,180 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.test.properties;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Charlotte Wong
+ */
+public class TestPropertiesPQLValidationTest {
+
+	@Test
+	public void testValidatePQL() throws Exception {
+		List<File> testPropertiesFiles = _findTestPropertiesFiles(
+			_getPortalDir());
+
+		List<String> errors = Collections.synchronizedList(new ArrayList<>());
+		List<Future<?>> futures = new ArrayList<>();
+
+		ThreadPoolExecutor threadPoolExecutor =
+			JenkinsResultsParserUtil.getNewThreadPoolExecutor(
+				Runtime.getRuntime(
+				).availableProcessors(),
+				true);
+
+		for (File testPropertiesFile : testPropertiesFiles) {
+			Properties properties = new Properties();
+
+			try (InputStream inputStream = new FileInputStream(
+					testPropertiesFile)) {
+
+				properties.load(inputStream);
+			}
+
+			for (String propertyName : properties.stringPropertyNames()) {
+				if (!propertyName.startsWith(
+						"test.batch.run.property.query")) {
+
+					continue;
+				}
+
+				String value = properties.getProperty(
+					propertyName
+				).trim();
+
+				if (value.contains("${")) {
+					continue;
+				}
+
+				futures.add(
+					threadPoolExecutor.submit(
+						() -> {
+							try {
+								JenkinsResultsParserUtil.validatePQL(
+									value, testPropertiesFile);
+							}
+							catch (RuntimeException runtimeException) {
+								errors.add(
+									"Invalid PQL in property `" +
+										propertyName + "` in " +
+											testPropertiesFile + ": " +
+												runtimeException.getMessage());
+							}
+						}));
+			}
+		}
+
+		threadPoolExecutor.shutdown();
+
+		System.out.println(
+			"Validating " + futures.size() +
+				" test.batch.run.property.query PQL values across " +
+					testPropertiesFiles.size() + " test.properties files");
+
+		for (Future<?> future : futures) {
+			future.get();
+		}
+
+		Assert.assertTrue(
+			"Found invalid PQL:\n" + String.join("\n", errors),
+			errors.isEmpty());
+	}
+
+	private List<File> _findTestPropertiesFiles(File portalDir)
+		throws IOException {
+
+		List<File> testPropertiesFiles = new ArrayList<>();
+
+		Files.walkFileTree(
+			portalDir.toPath(),
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(
+					Path dir, BasicFileAttributes basicFileAttributes) {
+
+					String dirName = dir.getFileName(
+					).toString();
+
+					if (dirName.equals("build") ||
+						dirName.equals("bundles") ||
+						dirName.equals("classes") ||
+						dirName.equals("node_modules") ||
+						dirName.equals("src") ||
+						dirName.equals("test-classes") ||
+						dirName.startsWith(".")) {
+
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+					Path file, BasicFileAttributes basicFileAttributes) {
+
+					if (Objects.equals(
+							file.getFileName(
+							).toString(),
+							"test.properties")) {
+
+						testPropertiesFiles.add(file.toFile());
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFileFailed(
+					Path file, IOException ioException) {
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+
+		return testPropertiesFiles;
+	}
+
+	private File _getPortalDir() {
+		File dir = JenkinsResultsParserUtil.getCanonicalFile(new File("."));
+
+		while (dir != null) {
+			if (Objects.equals(dir.getName(), "liferay-portal")) {
+				return dir;
+			}
+
+			dir = dir.getParentFile();
+		}
+
+		throw new RuntimeException("Unable to find portal directory");
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/properties/TestPropertiesPQLValidationTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -58,9 +58,7 @@ public class TestPropertiesPQLValidationTest {
 			}
 
 			for (String propertyName : properties.stringPropertyNames()) {
-				if (!propertyName.startsWith(
-						"test.batch.run.property.query")) {
-
+				if (!propertyName.startsWith("test.batch.run.property.query")) {
 					continue;
 				}
 
@@ -81,10 +79,9 @@ public class TestPropertiesPQLValidationTest {
 							}
 							catch (RuntimeException runtimeException) {
 								errors.add(
-									"Invalid PQL in property `" +
-										propertyName + "` in " +
-											testPropertiesFile + ": " +
-												runtimeException.getMessage());
+									"Invalid PQL in property `" + propertyName +
+										"` in " + testPropertiesFile + ": " +
+											runtimeException.getMessage());
 							}
 						}));
 			}
@@ -107,7 +104,7 @@ public class TestPropertiesPQLValidationTest {
 	}
 
 	private List<File> _findTestPropertiesFiles(File portalDir)
-		throws IOException {
+		throws Exception {
 
 		List<File> testPropertiesFiles = new ArrayList<>();
 
@@ -122,8 +119,7 @@ public class TestPropertiesPQLValidationTest {
 					String dirName = dir.getFileName(
 					).toString();
 
-					if (dirName.equals("build") ||
-						dirName.equals("bundles") ||
+					if (dirName.equals("build") || dirName.equals("bundles") ||
 						dirName.equals("classes") ||
 						dirName.equals("node_modules") ||
 						dirName.equals("src") ||

--- a/test.properties
+++ b/test.properties
@@ -1550,6 +1550,7 @@
     test.batch.class.names.includes[modules-unit-project-templates-jdk21_zulu]=**/project-templates/**/src/test/**/*Test.java
 
     test.batch.class.names.includes[modules-unit_stable]=\
+        **/jenkins-results-parser/**/TestPropertiesPQLValidationTest.java,\
         **/portal-tools-sample-sql-builder/**/SampleSQLBuilderTest.java,\
         portal-impl/**/Log4jConfigUtilTest.java
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7574

## What Is Being Fixed

The `test.batch.run.property.query` values in module `test.properties` files are PQL expressions that determine which tests run in CI. At least one of these expressions (in `frontend-js-walkthrough-web`) contained an unmatched parenthesis, causing incorrect test selection. There was no automated validation to catch similar mistakes before they reach a stable branch.

## How It Is Being Fixed

The unmatched parenthesis in `modules/apps/frontend-js/frontend-js-walkthrough-web/test.properties` is corrected. A new `TestPropertiesPQLValidationTest` is added to `jenkins-results-parser` that reads every `test.batch.run.property.query` entry across all `test.properties` files in stable and validates each PQL expression, catching malformed queries at test time rather than at CI batch generation time.

## PR Check

**pr-check: PASS** — tested on `462c015e59516f4c509bfedf417658d89502411d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "462c015e59516f4c509bfedf417658d89502411d"} -->