### PR TITLE
LRCI-7681 Use gcloud auth cred-file for WIF-compatible GCP access

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -378,12 +378,13 @@ public class MirrorsGetTask extends Task {
 			if (gcpCredentialsFile != null) {
 				Process process = _executeCommands(
 					new String[] {
-						"gcloud", "auth", "activate-service-account",
-						"--key-file", gcpCredentialsFile.toString()
+						"gcloud", "auth", "login", "--cred-file",
+						gcpCredentialsFile.toString(), "--quiet"
 					});
 
 				if (process.exitValue() != 0) {
-					System.out.println("Unable to activate service account.");
+					System.out.println(
+						"Unable to authenticate with credential file.");
 				}
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7681

## What Is Being Fixed

The WIF migration (LRCI-7279) replaced the long-lived service-account key at /root/.gcloud/ci-jenkins.json with a Workload Identity Federation external_account credential config. MirrorsGetTask._downloadGCPFile still authenticated with `gcloud auth activate-service-account --key-file`, which only accepts service_account keys, so it rejected the WIF config with "The .json key file is not in a valid format." The GCS download then failed and the task fell through to the public releases.liferay.com URL, which 404s for candidate bundles — surfacing as a FileNotFoundException in test-portal-release even though the bundle was present in gs://liferay-releases-candidates.

## How It Is Being Fixed

Replaced the auth command with `gcloud auth login --cred-file=<file> --quiet`, which accepts both service_account and external_account credentials, so it works on already-migrated agents and any still carrying an old key during the rollout. This matches the auth chain CloudBucketUtil._getGCPAuthenticationCommand already uses. The --quiet flag is required: gcloud auth login prompts interactively without it and would hang the headless CI agent.

## Why Are There No Tests?

The change swaps a gcloud subcommand inside an Ant task that only executes on a CI agent (it shells out to gcloud against WIF credentials). It has no local-runnable unit counterpart, and _downloadGCPFile has no existing test. Validated via a live test-portal-release rerun that downloaded the bundle.

## PR Check

**pr-check: PASS** — tested on `a02cd725bbf70b8a98bf8fe9dd24cfc4afa53e66`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a02cd725bbf70b8a98bf8fe9dd24cfc4afa53e66"} -->
