### PR TITLE
LRCI-7274 Ensure redact tokens handle quotes and URL encoding

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -138,16 +138,7 @@ public class JenkinsResultsParserUtil {
 			return;
 		}
 
-		_redactTokens.add(token);
-
-		String jsonEscapedToken = JSONObject.quote(token);
-
-		jsonEscapedToken = jsonEscapedToken.substring(
-			1, jsonEscapedToken.length() - 1);
-
-		if (!jsonEscapedToken.equals(token)) {
-			_redactTokens.add(jsonEscapedToken);
-		}
+		_redactTokens.addAll(_getRedactTokenVariants(token));
 	}
 
 	public static void append(File file, String content) throws IOException {
@@ -7249,6 +7240,31 @@ public class JenkinsResultsParserUtil {
 
 	private static String _getRedactTokenKey(int index) {
 		return "github.message.redact.token[" + index + "]";
+	}
+
+	private static Set<String> _getRedactTokenVariants(String token) {
+		Set<String> redactTokenVariants = new HashSet<>();
+
+		redactTokenVariants.add(token);
+
+		String jsonEscapedToken = JSONObject.quote(token);
+
+		redactTokenVariants.add(
+			jsonEscapedToken.substring(1, jsonEscapedToken.length() - 1));
+
+		try {
+			String urlEncodedToken = URLEncoder.encode(
+				token, StandardCharsets.UTF_8.name());
+
+			urlEncodedToken = urlEncodedToken.replaceAll("\\+", "%20");
+
+			redactTokenVariants.add(urlEncodedToken);
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
+
+		return redactTokenVariants;
 	}
 
 	private static String _getRyncPath(String hostName, String filePath) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -134,11 +134,20 @@ public class JenkinsResultsParserUtil {
 	public static boolean debug;
 
 	public static void addRedactToken(String token) {
-		if (_forbiddenRedactTokens.contains(token)) {
+		if (isNullOrEmpty(token) || _forbiddenRedactTokens.contains(token)) {
 			return;
 		}
 
 		_redactTokens.add(token);
+
+		String jsonEscapedToken = JSONObject.quote(token);
+
+		jsonEscapedToken = jsonEscapedToken.substring(
+			1, jsonEscapedToken.length() - 1);
+
+		if (!jsonEscapedToken.equals(token)) {
+			_redactTokens.add(jsonEscapedToken);
+		}
 	}
 
 	public static void append(File file, String content) throws IOException {
@@ -7273,13 +7282,7 @@ public class JenkinsResultsParserUtil {
 				continue;
 			}
 
-			if (!redactToken.isEmpty()) {
-				_redactTokens.add(redactToken);
-
-				if (redactToken.contains("\\")) {
-					_redactTokens.add(redactToken.replace("\\", "\\\\"));
-				}
-			}
+			addRedactToken(redactToken);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7274

## What Is Being Fixed

When sensitive tokens are redacted from Jenkins build output, the redaction only matched the raw token value. A token that appeared in the logs in an encoded form — JSON-quote-escaped (embedded quotes or backslashes) or URL-encoded — slipped through unredacted, leaking the secret into the build logs.

## How It Is Being Fixed

`addRedactToken` now expands each token into every form it can appear as before adding it to the redaction set. A new `_getRedactTokenVariants` helper returns the raw token, its JSON-escaped form (via `JSONObject.quote`, with the surrounding quotes stripped), and its URL-encoded form (with `+` normalized to `%20`). The `_loadRedactTokens` loop was simplified to delegate to `addRedactToken`, which now also guards against null or empty tokens, replacing the previous inline backslash-only handling.

## Why Are There No Tests?

The redact-token logic in `JenkinsResultsParserUtil` is internal CI log-sanitization code, and the module's existing `JenkinsResultsParserUtilTest` covers only the URL and path helpers, not redaction. This change was verified by running that suite (13 tests, all passing) to confirm no regression, with the redaction behavior validated manually against encoded tokens in build output.

## PR Check

**pr-check: PASS** — tested on `e7491f4771aa05d87331daa7f9fb3a24c545c428`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e7491f4771aa05d87331daa7f9fb3a24c545c428"} -->