### PR TITLE
LRCI-7274 Ensure redact tokens handle quotes and URL encoding (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -138,16 +138,7 @@ public class JenkinsResultsParserUtil {
 			return;
 		}
 
-		_redactTokens.add(token);
-
-		String jsonEscapedToken = JSONObject.quote(token);
-
-		jsonEscapedToken = jsonEscapedToken.substring(
-			1, jsonEscapedToken.length() - 1);
-
-		if (!jsonEscapedToken.equals(token)) {
-			_redactTokens.add(jsonEscapedToken);
-		}
+		_redactTokens.addAll(_getRedactTokenVariants(token));
 	}
 
 	public static void append(File file, String content) throws IOException {
@@ -7249,6 +7240,31 @@ public class JenkinsResultsParserUtil {
 
 	private static String _getRedactTokenKey(int index) {
 		return "github.message.redact.token[" + index + "]";
+	}
+
+	private static Set<String> _getRedactTokenVariants(String token) {
+		Set<String> redactTokenVariants = new HashSet<>();
+
+		redactTokenVariants.add(token);
+
+		String jsonEscapedToken = JSONObject.quote(token);
+
+		redactTokenVariants.add(
+			jsonEscapedToken.substring(1, jsonEscapedToken.length() - 1));
+
+		try {
+			String urlEncodedToken = URLEncoder.encode(
+				token, StandardCharsets.UTF_8.name());
+
+			urlEncodedToken = urlEncodedToken.replaceAll("\\+", "%20");
+
+			redactTokenVariants.add(urlEncodedToken);
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
+
+		return redactTokenVariants;
 	}
 
 	private static String _getRyncPath(String hostName, String filePath) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -134,11 +134,20 @@ public class JenkinsResultsParserUtil {
 	public static boolean debug;
 
 	public static void addRedactToken(String token) {
-		if (_forbiddenRedactTokens.contains(token)) {
+		if (isNullOrEmpty(token) || _forbiddenRedactTokens.contains(token)) {
 			return;
 		}
 
 		_redactTokens.add(token);
+
+		String jsonEscapedToken = JSONObject.quote(token);
+
+		jsonEscapedToken = jsonEscapedToken.substring(
+			1, jsonEscapedToken.length() - 1);
+
+		if (!jsonEscapedToken.equals(token)) {
+			_redactTokens.add(jsonEscapedToken);
+		}
 	}
 
 	public static void append(File file, String content) throws IOException {
@@ -7273,13 +7282,7 @@ public class JenkinsResultsParserUtil {
 				continue;
 			}
 
-			if (!redactToken.isEmpty()) {
-				_redactTokens.add(redactToken);
-
-				if (redactToken.contains("\\")) {
-					_redactTokens.add(redactToken.replace("\\", "\\\\"));
-				}
-			}
+			addRedactToken(redactToken);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -7256,9 +7256,8 @@ public class JenkinsResultsParserUtil {
 			String urlEncodedToken = URLEncoder.encode(
 				token, StandardCharsets.UTF_8.name());
 
-			urlEncodedToken = urlEncodedToken.replaceAll("\\+", "%20");
-
 			redactTokenVariants.add(urlEncodedToken);
+			redactTokenVariants.add(urlEncodedToken.replace("+", "%20"));
 		}
 		catch (UnsupportedEncodingException unsupportedEncodingException) {
 			throw new RuntimeException(unsupportedEncodingException);


### PR DESCRIPTION
[LRCI-7274](https://liferay.atlassian.net/browse/LRCI-7274)

Revises [#4361](https://github.com/pyoo47/liferay-portal/pull/4361) (opened by @michaelhashimoto) with the following follow-up commits:

- [73c29873fd3d](https://github.com/pyoo47/liferay-portal/commit/73c29873fd3d77aacaa0a6e985fc6fdfc1d03e16) LRCI-7274 Redact both URL-encoded forms of tokens with spaces
