### PR TITLE
LRCI-7678 Restore setup-profile-dxp for legacy branch workspaces

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspace.java
@@ -124,6 +124,12 @@ public class PortalWorkspace extends BaseWorkspace {
 
 		super.setUp();
 
+		Job.BuildProfile buildProfile = getBuildProfile();
+
+		if (buildProfile == Job.BuildProfile.DXP) {
+			portalWorkspaceGitRepository.setUpPortalProfile();
+		}
+
 		portalWorkspaceGitRepository.setUpTCKHome();
 
 		updateOSBAsahModule();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -129,6 +130,53 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 	public String getPortalPrivateRepositoryDirName() {
 		return JenkinsResultsParserUtil.getGitDirectoryName(
 			"liferay-portal-ee", getUpstreamBranchName() + "-private");
+	}
+
+	public void setUpPortalProfile() {
+		String setupProfileDXPBranchNames;
+
+		try {
+			setupProfileDXPBranchNames =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"portal.setup.profile.dxp.branch.names");
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(
+					setupProfileDXPBranchNames)) {
+
+				return;
+			}
+		}
+		catch (IOException ioException) {
+			return;
+		}
+
+		List<String> setupProfileDXPBranchNamesList = Arrays.asList(
+			setupProfileDXPBranchNames.split(","));
+
+		if (!setupProfileDXPBranchNamesList.contains(getUpstreamBranchName())) {
+			return;
+		}
+
+		Retryable<Object> setupProfileDXPRetryable = new Retryable<Object>(
+			true, _SETUP_PROFILE_DXP_RETRY_COUNT,
+			_SETUP_PROFILE_DXP_RETRY_DELAY, true) {
+
+			@Override
+			public Object execute() {
+				try {
+					AntUtil.callTarget(
+						getDirectory(), "build.xml", "setup-profile-dxp");
+				}
+				catch (AntException antException) {
+					throw new RuntimeException(antException);
+				}
+
+				return null;
+			}
+
+		};
+
+		setupProfileDXPRetryable.executeWithRetries();
 	}
 
 	public void setUpTCKHome() {
@@ -391,6 +439,10 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 					"test.", Environment.get("HOSTNAME"), ".properties")),
 			_getPortalTestProperties(), true);
 	}
+
+	private static final int _SETUP_PROFILE_DXP_RETRY_COUNT = 2;
+
+	private static final int _SETUP_PROFILE_DXP_RETRY_DELAY = 5;
 
 	private Properties _appServerProperties;
 	private boolean _setUpBinariesCache;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7678

## What Is Being Fixed

When setting up portal workspaces for DXP builds, the `setup-profile-dxp` step was no longer being applied. Legacy branches that depend on that profile being configured were left without it, since the workspace setup path never invoked the target.

## How It Is Being Fixed

`PortalWorkspace` now checks the build profile during setup and, when it is `DXP`, calls a new `setUpPortalProfile()` on `PortalWorkspaceGitRepository`. That method reads the `portal.setup.profile.dxp.branch.names` build property and, only when the current upstream branch is in that comma-separated list, runs the `setup-profile-dxp` Ant target against `build.xml`. The call is wrapped in a `Retryable` (2 retries, 5s delay) for resilience, and the method returns early when the property is unset or the branch is not listed, so non-legacy branches are unaffected.

## Why Are There No Tests?

This change is in `jenkins-results-parser`, CI tooling exercised by live CI runs rather than the standard unit/integration test harness. There is no test-harness path for this build-orchestration behavior.

## PR Check

**pr-check: PASS** — tested on `b2f656506b58608955cf80d467b336f894a2423e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b2f656506b58608955cf80d467b336f894a2423e"} -->
