### PR TITLE
LRCI-7573 Capture OOM heap dumps to S3 across all CI Ant phases (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -16,6 +16,8 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 
 import java.util.ArrayList;
@@ -231,6 +233,50 @@ public class CloudBucketUtil {
 			!destinationFileName.equals("build-database.json")) {
 
 			_validateChecksumFile(destinationFile, s3SourcePath);
+		}
+	}
+
+	public static long getNewestS3ObjectLastModified(String s3DirPath)
+		throws IOException, TimeoutException {
+
+		Matcher s3ObjectPathMatcher = _s3ObjectPathPattern.matcher(s3DirPath);
+
+		if (!s3ObjectPathMatcher.find()) {
+			throw new RuntimeException("Invalid S3 object path: " + s3DirPath);
+		}
+
+		Process process = JenkinsResultsParserUtil.executeBashCommands(
+			true,
+			JenkinsResultsParserUtil.combine(
+				"aws s3api list-objects-v2 --bucket ",
+				s3ObjectPathMatcher.group("bucketName"), " --prefix ",
+				s3ObjectPathMatcher.group("objectPath"),
+				" --query \"sort_by(Contents, &LastModified)[-1]",
+				".LastModified\" --output text"));
+
+		String lastModified = JenkinsResultsParserUtil.readInputStream(
+			process.getInputStream());
+
+		lastModified = lastModified.replace(
+			"Finished executing Bash commands.", "");
+
+		lastModified = lastModified.trim();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(lastModified) ||
+			lastModified.equals("None")) {
+
+			return Long.MIN_VALUE;
+		}
+
+		try {
+			OffsetDateTime offsetDateTime = OffsetDateTime.parse(lastModified);
+
+			Instant instant = offsetDateTime.toInstant();
+
+			return instant.toEpochMilli();
+		}
+		catch (DateTimeParseException dateTimeParseException) {
+			return Long.MIN_VALUE;
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -236,13 +236,15 @@ public class CloudBucketUtil {
 		}
 	}
 
-	public static long getNewestS3ObjectLastModified(String s3DirPath)
+	public static long getNewestS3ObjectLastModified(String s3ObjectPath)
 		throws IOException, TimeoutException {
 
-		Matcher s3ObjectPathMatcher = _s3ObjectPathPattern.matcher(s3DirPath);
+		Matcher s3ObjectPathMatcher = _s3ObjectPathPattern.matcher(
+			s3ObjectPath);
 
 		if (!s3ObjectPathMatcher.find()) {
-			throw new RuntimeException("Invalid S3 object path: " + s3DirPath);
+			throw new RuntimeException(
+				"Invalid S3 object path: " + s3ObjectPath);
 		}
 
 		Process process = JenkinsResultsParserUtil.executeBashCommands(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -249,10 +249,11 @@ public class CloudBucketUtil {
 			true,
 			JenkinsResultsParserUtil.combine(
 				"aws s3api list-objects-v2 --bucket ",
-				s3ObjectPathMatcher.group("bucketName"), " --prefix ",
+				s3ObjectPathMatcher.group("bucketName"),
+				" --output text --prefix ",
 				s3ObjectPathMatcher.group("objectPath"),
 				" --query \"sort_by(Contents, &LastModified)[-1]",
-				".LastModified\" --output text"));
+				".LastModified\""));
 
 		String lastModified = JenkinsResultsParserUtil.readInputStream(
 			process.getInputStream());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -65,12 +65,13 @@ public class HeapDumpCloudUploader {
 			return;
 		}
 
-		LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+		LocalDateTime currentLocalDateTime = LocalDateTime.now(ZoneOffset.UTC);
 
-		String yearMonth = now.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+		String currentYearMonth = currentLocalDateTime.format(
+			DateTimeFormatter.ofPattern("yyyy-MM"));
 
 		String s3Key = JenkinsResultsParserUtil.combine(
-			heapDumpsBasePath, "/", yearMonth, "/", _masterHostname, "/",
+			heapDumpsBasePath, "/", currentYearMonth, "/", _masterHostname, "/",
 			_jobName, "/", _buildNumber, "/", _phase, "/", _slaveHostname,
 			".hprof.gz");
 
@@ -155,23 +156,23 @@ public class HeapDumpCloudUploader {
 	}
 
 	private boolean _isThrottled(String heapDumpsS3Path, File hprofFile) {
-		long lastModifiedMillis;
+		long newestS3ObjectLastModified;
 
 		try {
-			lastModifiedMillis = CloudBucketUtil.getNewestS3ObjectLastModified(
-				heapDumpsS3Path);
+			newestS3ObjectLastModified =
+				CloudBucketUtil.getNewestS3ObjectLastModified(heapDumpsS3Path);
 		}
 		catch (IOException | TimeoutException exception) {
 			return false;
 		}
 
-		if (lastModifiedMillis == Long.MIN_VALUE) {
+		if (newestS3ObjectLastModified == Long.MIN_VALUE) {
 			return false;
 		}
 
 		long elapsedMillis =
 			JenkinsResultsParserUtil.getCurrentTimeMillis() -
-				lastModifiedMillis;
+				newestS3ObjectLastModified;
 
 		long minutesAgo = elapsedMillis / (60 * 1000);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -134,6 +134,11 @@ public class HeapDumpCloudUploader {
 			CloudBucketUtil.uploadS3File(s3Key, gzippedFile);
 
 			CloudBucketUtil.uploadS3Object("", sentinelS3Path);
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"INFO: Heap dump uploaded. To download:\naws s3 cp ",
+					s3Key, " /tmp/", _slaveHostname, ".hprof.gz"));
 		}
 		catch (IOException ioException) {
 			System.out.println(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -70,7 +70,8 @@ public class HeapDumpCloudUploader {
 			return;
 		}
 
-		String heapDumpsBasePath = "s3://" + s3BucketName + "/heap-dumps";
+		String heapDumpsBasePath = JenkinsResultsParserUtil.combine(
+			"s3://", s3BucketName, "/heap-dumps");
 
 		String sentinelS3Path = heapDumpsBasePath + "/last-upload";
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -75,10 +75,10 @@ public class HeapDumpCloudUploader {
 			return;
 		}
 
-		String yearMonth = LocalDate.now(
-		).format(
-			DateTimeFormatter.ofPattern("yyyy-MM")
-		);
+		LocalDate localDate = LocalDate.now();
+
+		String yearMonth = localDate.format(
+			DateTimeFormatter.ofPattern("yyyy-MM"));
 
 		String key = JenkinsResultsParserUtil.combine(
 			"heap-dumps/", yearMonth, "/", _masterHostname, "/", _jobName, "/",
@@ -91,8 +91,10 @@ public class HeapDumpCloudUploader {
 		File gzippedFile = new File(file.getAbsolutePath() + ".gz");
 
 		try (FileInputStream fileInputStream = new FileInputStream(file);
+
 			FileOutputStream fileOutputStream = new FileOutputStream(
 				gzippedFile);
+
 			GZIPOutputStream gzipOutputStream = new GZIPOutputStream(
 				fileOutputStream) {
 
@@ -111,7 +113,7 @@ public class HeapDumpCloudUploader {
 		catch (IOException ioException) {
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
-					"ERROR: Failed to gzip heap dump ", file.getAbsolutePath(),
+					"ERROR: Unable to gzip heap dump ", file.getAbsolutePath(),
 					": ", ioException.getMessage()));
 
 			return null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -56,7 +56,7 @@ public class HeapDumpCloudUploader {
 		}
 		catch (IOException ioException) {
 			System.out.println(
-				"ERROR: Unable to read env.S3_BUCKET_NAME: " +
+				"ERROR: Unable to read \"env.S3_BUCKET_NAME\": " +
 					ioException.getMessage());
 
 			return;
@@ -64,7 +64,8 @@ public class HeapDumpCloudUploader {
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(s3BucketName)) {
 			System.out.println(
-				"INFO: S3_BUCKET_NAME not set, skipping heap dump upload");
+				"INFO: \"S3_BUCKET_NAME\" is not set, skipping heap dump " +
+					"upload");
 
 			return;
 		}
@@ -80,11 +81,11 @@ public class HeapDumpCloudUploader {
 				Matcher matcher = _s3ListingDateTimePattern.matcher(listing);
 
 				if (matcher.find()) {
-					String dateTimeStr = JenkinsResultsParserUtil.combine(
+					String dateTimeString = JenkinsResultsParserUtil.combine(
 						matcher.group("date"), " ", matcher.group("time"));
 
 					LocalDateTime uploadDateTime = LocalDateTime.parse(
-						dateTimeStr,
+						dateTimeString,
 						DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
 
 					long uploadMillis = uploadDateTime.toInstant(
@@ -137,8 +138,8 @@ public class HeapDumpCloudUploader {
 
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
-					"INFO: Heap dump uploaded. To download:\naws s3 cp ",
-					s3Key, " /tmp/", _slaveHostname, ".hprof.gz"));
+					"INFO: Heap dump uploaded. To download:\naws s3 cp ", s3Key,
+					" /tmp/", _slaveHostname, ".hprof.gz"));
 		}
 		catch (IOException ioException) {
 			System.out.println(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -27,13 +27,13 @@ import java.util.zip.GZIPOutputStream;
 public class HeapDumpCloudUploader {
 
 	public HeapDumpCloudUploader(
-		String phase, String masterHostname, String jobName, String buildNumber,
+		String buildNumber, String jobName, String masterHostname, String phase,
 		String slaveHostname) {
 
-		_phase = phase;
-		_masterHostname = masterHostname;
-		_jobName = jobName;
 		_buildNumber = buildNumber;
+		_jobName = jobName;
+		_masterHostname = masterHostname;
+		_phase = phase;
 		_slaveHostname = slaveHostname;
 	}
 
@@ -46,25 +46,9 @@ public class HeapDumpCloudUploader {
 			return;
 		}
 
-		String s3BucketName;
+		String s3BucketName = _getS3BucketName();
 
-		try {
-			s3BucketName = JenkinsResultsParserUtil.getBuildProperty(
-				"env.S3_BUCKET_NAME");
-		}
-		catch (IOException ioException) {
-			System.out.println(
-				"ERROR: Unable to read \"env.S3_BUCKET_NAME\": " +
-					ioException.getMessage());
-
-			return;
-		}
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(s3BucketName)) {
-			System.out.println(
-				"INFO: \"S3_BUCKET_NAME\" is not set, skipping heap dump " +
-					"upload");
-
+		if (s3BucketName == null) {
 			return;
 		}
 
@@ -107,6 +91,32 @@ public class HeapDumpCloudUploader {
 		finally {
 			gzippedFile.delete();
 		}
+	}
+
+	private String _getS3BucketName() {
+		String s3BucketName;
+
+		try {
+			s3BucketName = JenkinsResultsParserUtil.getBuildProperty(
+				"env.S3_BUCKET_NAME");
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"ERROR: Unable to read \"env.S3_BUCKET_NAME\": " +
+					ioException.getMessage());
+
+			return null;
+		}
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(s3BucketName)) {
+			System.out.println(
+				"INFO: \"S3_BUCKET_NAME\" is not set, skipping heap dump " +
+					"upload");
+
+			return null;
+		}
+
+		return s3BucketName;
 	}
 
 	private File _gzip(File file) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -52,10 +52,10 @@ public class HeapDumpCloudUploader {
 			return;
 		}
 
-		String heapDumpsBasePath = JenkinsResultsParserUtil.combine(
+		String heapDumpsS3Path = JenkinsResultsParserUtil.combine(
 			"s3://", s3BucketName, "/heap-dumps");
 
-		if (_isThrottled(heapDumpsBasePath, hprofFile)) {
+		if (_isThrottled(heapDumpsS3Path, hprofFile)) {
 			return;
 		}
 
@@ -71,7 +71,7 @@ public class HeapDumpCloudUploader {
 			DateTimeFormatter.ofPattern("yyyy-MM"));
 
 		String s3Key = JenkinsResultsParserUtil.combine(
-			heapDumpsBasePath, "/", currentYearMonth, "/", _masterHostname, "/",
+			heapDumpsS3Path, "/", currentYearMonth, "/", _masterHostname, "/",
 			_jobName, "/", _buildNumber, "/", _phase, "/", _slaveHostname,
 			".hprof.gz");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -5,6 +5,7 @@
 
 package com.liferay.jenkins.results.parser.testray;
 
+import com.liferay.jenkins.results.parser.CloudBucketUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 
 import java.io.File;
@@ -12,9 +13,13 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.Deflater;
 import java.util.zip.GZIPOutputStream;
 
@@ -43,30 +48,70 @@ public class HeapDumpCloudUploader {
 			return;
 		}
 
-		TestrayCloudBucket testrayCloudBucket =
-			TestrayCloudBucket.getInstance();
+		String s3BucketName;
 
-		long latestTimestamp = testrayCloudBucket.getLatestObjectTimestamp(
-			"heap-dumps/");
+		try {
+			s3BucketName = JenkinsResultsParserUtil.getBuildProperty(
+				"env.S3_BUCKET_NAME");
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"ERROR: Unable to read env.S3_BUCKET_NAME: " +
+					ioException.getMessage());
 
-		if (latestTimestamp != Long.MIN_VALUE) {
-			long elapsedMillis =
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					latestTimestamp;
+			return;
+		}
 
-			long minutesAgo = elapsedMillis / (60 * 1000);
+		if (JenkinsResultsParserUtil.isNullOrEmpty(s3BucketName)) {
+			System.out.println(
+				"INFO: S3_BUCKET_NAME not set, skipping heap dump upload");
 
-			if (minutesAgo < _THROTTLE_MINUTES) {
-				System.out.println(
-					JenkinsResultsParserUtil.combine(
-						"INFO: Skipping heap dump upload, last dump was ",
-						String.valueOf(minutesAgo),
-						" minutes ago (throttle window: ",
-						String.valueOf(_THROTTLE_MINUTES),
-						" min). Local file: ", hprofFile.getAbsolutePath()));
+			return;
+		}
 
-				return;
+		String heapDumpsBasePath = "s3://" + s3BucketName + "/heap-dumps";
+
+		String sentinelS3Path = heapDumpsBasePath + "/last-upload";
+
+		try {
+			String listing = CloudBucketUtil.listS3Files(sentinelS3Path, true);
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(listing)) {
+				Matcher matcher = _s3ListingDateTimePattern.matcher(listing);
+
+				if (matcher.find()) {
+					String dateTimeStr = JenkinsResultsParserUtil.combine(
+						matcher.group("date"), " ", matcher.group("time"));
+
+					LocalDateTime uploadDateTime = LocalDateTime.parse(
+						dateTimeStr,
+						DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+					long uploadMillis = uploadDateTime.toInstant(
+						ZoneOffset.UTC).toEpochMilli();
+
+					long elapsedMillis =
+						JenkinsResultsParserUtil.getCurrentTimeMillis() -
+							uploadMillis;
+
+					long minutesAgo = elapsedMillis / (60 * 1000);
+
+					if (minutesAgo < _THROTTLE_MINUTES) {
+						System.out.println(
+							JenkinsResultsParserUtil.combine(
+								"INFO: Skipping heap dump upload, last dump was ",
+								String.valueOf(minutesAgo),
+								" minutes ago (throttle window: ",
+								String.valueOf(_THROTTLE_MINUTES),
+								" min). Local file: ",
+								hprofFile.getAbsolutePath()));
+
+						return;
+					}
+				}
 			}
+		}
+		catch (IOException | TimeoutException exception) {
 		}
 
 		File gzippedFile = _gzip(hprofFile);
@@ -75,16 +120,29 @@ public class HeapDumpCloudUploader {
 			return;
 		}
 
-		LocalDate localDate = LocalDate.now();
+		LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
 
-		String yearMonth = localDate.format(
-			DateTimeFormatter.ofPattern("yyyy-MM"));
+		String yearMonth = now.format(DateTimeFormatter.ofPattern("yyyy-MM"));
 
-		String key = JenkinsResultsParserUtil.combine(
-			"heap-dumps/", yearMonth, "/", _masterHostname, "/", _jobName, "/",
-			_buildNumber, "/", _phase, "/", _slaveHostname, ".hprof.gz");
+		String s3Key = JenkinsResultsParserUtil.combine(
+			heapDumpsBasePath, "/", yearMonth, "/", _masterHostname, "/",
+			_jobName, "/", _buildNumber, "/", _phase, "/", _slaveHostname,
+			".hprof.gz");
 
-		testrayCloudBucket.createTestrayCloudObject(key, gzippedFile);
+		try {
+			CloudBucketUtil.uploadS3File(s3Key, gzippedFile);
+
+			CloudBucketUtil.uploadS3Object("", sentinelS3Path);
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"ERROR: Unable to upload heap dump: ",
+					ioException.getMessage()));
+		}
+		finally {
+			gzippedFile.delete();
+		}
 	}
 
 	private File _gzip(File file) {
@@ -121,6 +179,9 @@ public class HeapDumpCloudUploader {
 
 		return gzippedFile;
 	}
+
+	private static final Pattern _s3ListingDateTimePattern = Pattern.compile(
+		"(?<date>\\d{4}-\\d{2}-\\d{2})\\s+(?<time>\\d{2}:\\d{2}:\\d{2})");
 
 	private static final int _THROTTLE_MINUTES = 30;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -88,7 +88,8 @@ public class HeapDumpCloudUploader {
 						DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
 
 					long uploadMillis = uploadDateTime.toInstant(
-						ZoneOffset.UTC).toEpochMilli();
+						ZoneOffset.UTC
+					).toEpochMilli();
 
 					long elapsedMillis =
 						JenkinsResultsParserUtil.getCurrentTimeMillis() -
@@ -99,9 +100,9 @@ public class HeapDumpCloudUploader {
 					if (minutesAgo < _THROTTLE_MINUTES) {
 						System.out.println(
 							JenkinsResultsParserUtil.combine(
-								"INFO: Skipping heap dump upload, last dump was ",
+								"INFO: Skipping heap dump upload, last was ",
 								String.valueOf(minutesAgo),
-								" minutes ago (throttle window: ",
+								" min ago (throttle window: ",
 								String.valueOf(_THROTTLE_MINUTES),
 								" min). Local file: ",
 								hprofFile.getAbsolutePath()));
@@ -180,10 +181,10 @@ public class HeapDumpCloudUploader {
 		return gzippedFile;
 	}
 
+	private static final int _THROTTLE_MINUTES = 30;
+
 	private static final Pattern _s3ListingDateTimePattern = Pattern.compile(
 		"(?<date>\\d{4}-\\d{2}-\\d{2})\\s+(?<time>\\d{2}:\\d{2}:\\d{2})");
-
-	private static final int _THROTTLE_MINUTES = 30;
 
 	private final String _buildNumber;
 	private final String _jobName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -18,8 +18,6 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.zip.Deflater;
 import java.util.zip.GZIPOutputStream;
 
@@ -73,48 +71,8 @@ public class HeapDumpCloudUploader {
 		String heapDumpsBasePath = JenkinsResultsParserUtil.combine(
 			"s3://", s3BucketName, "/heap-dumps");
 
-		String sentinelS3Path = heapDumpsBasePath + "/last-upload";
-
-		try {
-			String listing = CloudBucketUtil.listS3Files(sentinelS3Path, true);
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(listing)) {
-				Matcher matcher = _s3ListingDateTimePattern.matcher(listing);
-
-				if (matcher.find()) {
-					String dateTimeString = JenkinsResultsParserUtil.combine(
-						matcher.group("date"), " ", matcher.group("time"));
-
-					LocalDateTime uploadDateTime = LocalDateTime.parse(
-						dateTimeString,
-						DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-
-					long uploadMillis = uploadDateTime.toInstant(
-						ZoneOffset.UTC
-					).toEpochMilli();
-
-					long elapsedMillis =
-						JenkinsResultsParserUtil.getCurrentTimeMillis() -
-							uploadMillis;
-
-					long minutesAgo = elapsedMillis / (60 * 1000);
-
-					if (minutesAgo < _THROTTLE_MINUTES) {
-						System.out.println(
-							JenkinsResultsParserUtil.combine(
-								"INFO: Skipping heap dump upload, last was ",
-								String.valueOf(minutesAgo),
-								" min ago (throttle window: ",
-								String.valueOf(_THROTTLE_MINUTES),
-								" min). Local file: ",
-								hprofFile.getAbsolutePath()));
-
-						return;
-					}
-				}
-			}
-		}
-		catch (IOException | TimeoutException exception) {
+		if (_isThrottled(heapDumpsBasePath, hprofFile)) {
+			return;
 		}
 
 		File gzippedFile = _gzip(hprofFile);
@@ -134,8 +92,6 @@ public class HeapDumpCloudUploader {
 
 		try {
 			CloudBucketUtil.uploadS3File(s3Key, gzippedFile);
-
-			CloudBucketUtil.uploadS3Object("", sentinelS3Path);
 
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
@@ -188,10 +144,42 @@ public class HeapDumpCloudUploader {
 		return gzippedFile;
 	}
 
-	private static final int _THROTTLE_MINUTES = 30;
+	private boolean _isThrottled(String heapDumpsS3Path, File hprofFile) {
+		long lastModifiedMillis;
 
-	private static final Pattern _s3ListingDateTimePattern = Pattern.compile(
-		"(?<date>\\d{4}-\\d{2}-\\d{2})\\s+(?<time>\\d{2}:\\d{2}:\\d{2})");
+		try {
+			lastModifiedMillis = CloudBucketUtil.getNewestS3ObjectLastModified(
+				heapDumpsS3Path);
+		}
+		catch (IOException | TimeoutException exception) {
+			return false;
+		}
+
+		if (lastModifiedMillis == Long.MIN_VALUE) {
+			return false;
+		}
+
+		long elapsedMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis() -
+				lastModifiedMillis;
+
+		long minutesAgo = elapsedMillis / (60 * 1000);
+
+		if (minutesAgo >= _THROTTLE_MINUTES) {
+			return false;
+		}
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"INFO: Skipping heap dump upload, last was ",
+				String.valueOf(minutesAgo), " min ago (throttle window: ",
+				String.valueOf(_THROTTLE_MINUTES), " min). Local file: ",
+				hprofFile.getAbsolutePath()));
+
+		return true;
+	}
+
+	private static final int _THROTTLE_MINUTES = 30;
 
 	private final String _buildNumber;
 	private final String _jobName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/HeapDumpCloudUploader.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.testray;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import java.util.zip.Deflater;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * @author Charlotte Wong
+ */
+public class HeapDumpCloudUploader {
+
+	public HeapDumpCloudUploader(
+		String phase, String masterHostname, String jobName, String buildNumber,
+		String slaveHostname) {
+
+		_phase = phase;
+		_masterHostname = masterHostname;
+		_jobName = jobName;
+		_buildNumber = buildNumber;
+		_slaveHostname = slaveHostname;
+	}
+
+	public void upload() {
+		File hprofFile = new File(
+			JenkinsResultsParserUtil.combine(
+				"/tmp/ant-heap-dump-", _phase, ".hprof"));
+
+		if (!hprofFile.exists()) {
+			return;
+		}
+
+		TestrayCloudBucket testrayCloudBucket =
+			TestrayCloudBucket.getInstance();
+
+		long latestTimestamp = testrayCloudBucket.getLatestObjectTimestamp(
+			"heap-dumps/");
+
+		if (latestTimestamp != Long.MIN_VALUE) {
+			long elapsedMillis =
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					latestTimestamp;
+
+			long minutesAgo = elapsedMillis / (60 * 1000);
+
+			if (minutesAgo < _THROTTLE_MINUTES) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"INFO: Skipping heap dump upload, last dump was ",
+						String.valueOf(minutesAgo),
+						" minutes ago (throttle window: ",
+						String.valueOf(_THROTTLE_MINUTES),
+						" min). Local file: ", hprofFile.getAbsolutePath()));
+
+				return;
+			}
+		}
+
+		File gzippedFile = _gzip(hprofFile);
+
+		if (gzippedFile == null) {
+			return;
+		}
+
+		String yearMonth = LocalDate.now(
+		).format(
+			DateTimeFormatter.ofPattern("yyyy-MM")
+		);
+
+		String key = JenkinsResultsParserUtil.combine(
+			"heap-dumps/", yearMonth, "/", _masterHostname, "/", _jobName, "/",
+			_buildNumber, "/", _phase, "/", _slaveHostname, ".hprof.gz");
+
+		testrayCloudBucket.createTestrayCloudObject(key, gzippedFile);
+	}
+
+	private File _gzip(File file) {
+		File gzippedFile = new File(file.getAbsolutePath() + ".gz");
+
+		try (FileInputStream fileInputStream = new FileInputStream(file);
+			FileOutputStream fileOutputStream = new FileOutputStream(
+				gzippedFile);
+			GZIPOutputStream gzipOutputStream = new GZIPOutputStream(
+				fileOutputStream) {
+
+				{
+					def.setLevel(Deflater.BEST_COMPRESSION);
+				}
+			}) {
+
+			byte[] buffer = new byte[8192];
+			int length;
+
+			while ((length = fileInputStream.read(buffer)) > 0) {
+				gzipOutputStream.write(buffer, 0, length);
+			}
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"ERROR: Failed to gzip heap dump ", file.getAbsolutePath(),
+					": ", ioException.getMessage()));
+
+			return null;
+		}
+
+		return gzippedFile;
+	}
+
+	private static final int _THROTTLE_MINUTES = 30;
+
+	private final String _buildNumber;
+	private final String _jobName;
+	private final String _masterHostname;
+	private final String _phase;
+	private final String _slaveHostname;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
@@ -325,25 +325,6 @@ public class TestrayCloudBucket {
 		parallelExecutor.execute();
 	}
 
-	public long getLatestObjectTimestamp(String prefix) {
-		Storage storage = _getStorage();
-
-		Page<Blob> blobPage = storage.list(
-			getName(), Storage.BlobListOption.prefix(prefix));
-
-		long latest = Long.MIN_VALUE;
-
-		for (Blob blob : blobPage.iterateAll()) {
-			Long createTime = blob.getCreateTime();
-
-			if ((createTime != null) && (createTime > latest)) {
-				latest = createTime;
-			}
-		}
-
-		return latest;
-	}
-
 	public String getName() {
 		return _name;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
@@ -334,14 +334,10 @@ public class TestrayCloudBucket {
 		long latest = Long.MIN_VALUE;
 
 		for (Blob blob : blobPage.iterateAll()) {
-			if (blob.getCreateTime() == null) {
-				continue;
-			}
+			Long createTime = blob.getCreateTime();
 
-			long millis = blob.getCreateTime();
-
-			if (millis > latest) {
-				latest = millis;
+			if ((createTime != null) && (createTime > latest)) {
+				latest = createTime;
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
@@ -325,6 +325,29 @@ public class TestrayCloudBucket {
 		parallelExecutor.execute();
 	}
 
+	public long getLatestObjectTimestamp(String prefix) {
+		Storage storage = _getStorage();
+
+		Page<Blob> blobPage = storage.list(
+			getName(), Storage.BlobListOption.prefix(prefix));
+
+		long latest = Long.MIN_VALUE;
+
+		for (Blob blob : blobPage.iterateAll()) {
+			if (blob.getCreateTime() == null) {
+				continue;
+			}
+
+			long millis = blob.getCreateTime();
+
+			if (millis > latest) {
+				latest = millis;
+			}
+		}
+
+		return latest;
+	}
+
 	public String getName() {
 		return _name;
 	}


### PR DESCRIPTION
[LRCI-7573](https://liferay.atlassian.net/browse/LRCI-7573)

Revises [#4351](https://github.com/pyoo47/liferay-portal/pull/4351) (opened by @CharlotteFrancis) with the following follow-up commits:

- [6db95f2a0b97](https://github.com/pyoo47/liferay-portal/commit/6db95f2a0b97873ff8f5966fcd47d50fc1c85fa7) LRCI-7573 Consistency
- [a5320e781aaf](https://github.com/pyoo47/liferay-portal/commit/a5320e781aaf25975a7e7aa212e095d42150bd16) LRCI-7573 Add getNewestS3ObjectLastModified to CloudBucketUtil
- [64c90a788bc2](https://github.com/pyoo47/liferay-portal/commit/64c90a788bc23761c77493d031db5753413975cc) LRCI-7573 Simplify _isThrottled using getNewestS3ObjectLastModified
- [98036c630078](https://github.com/pyoo47/liferay-portal/commit/98036c63007892d8f33597518451ddcc2477a562) LRCI-7573 Simplify HeapDumpCloudUploader
- [0907bcb8249d](https://github.com/pyoo47/liferay-portal/commit/0907bcb8249d05c0504bc62d3fa4d7ac53467a65) LRCI-7573 Rename
- [30048f24e226](https://github.com/pyoo47/liferay-portal/commit/30048f24e22659da94024742de00307fd124abd8) LRCI-7573 Sort
- [17c8a6207102](https://github.com/pyoo47/liferay-portal/commit/17c8a6207102d9db6372b5573808111cfa543bf1) LRCI-7573 Consistency
