### PR TITLE
LRCI-7717 Fall back to user content reports without Google credentials

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuildReport.java
@@ -137,6 +137,10 @@ public abstract class BaseTopLevelBuildReport
 
 	@Override
 	public TestrayCloudObject getBuildReportTestrayCloudObject() {
+		if (!TestrayCloudBucket.hasGoogleApplicationCredentials()) {
+			return null;
+		}
+
 		JenkinsMaster jenkinsMaster = getJenkinsMaster();
 
 		TestrayCloudBucket testrayCloudBucket =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7717

## What Is Being Fixed

When Google application credentials are not available, `getBuildReportTestrayCloudObject()` still attempted to obtain a `TestrayCloudBucket` instance, which requires those credentials. The build-report lookup failed outright instead of degrading gracefully, even though a user-content copy of the report is available.

## How It Is Being Fixed

`BaseTopLevelBuildReport.getBuildReportTestrayCloudObject()` now returns null up front when `TestrayCloudBucket.hasGoogleApplicationCredentials()` reports no credentials. A null cloud object lets `URLTopLevelBuildReport.getBuildReportJSONObject()` proceed to its existing fallbacks — the user-content build report URL and then the Testray URL — so reports stay readable in environments without Google credentials.

## Why Are There No Tests?

This is a defensive guard in jenkins-results-parser, a CI build-report tool. Its behavior depends on live runtime Google credentials and cloud-bucket state rather than pure logic, and it is exercised by CI runs; the module's unit suite has no parallel-name counterpart for it.

## PR Check

**pr-check: PASS** — tested on `35e3810a2f29a2c632dd150dbce61b9792632614`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "35e3810a2f29a2c632dd150dbce61b9792632614"} -->
