### PR TITLE
LRCI-7419 Remove deprecated binaries-cache from build scripts

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -919,20 +919,12 @@ information.
 		<attribute default="" name="gradlejvmargs" />
 		<attribute default="" name="outputproperty" />
 		<attribute default="" name="refreshdependencies" />
-		<attribute default="true" name="setupbinariescache" />
 		<attribute default="true" name="stacktrace" />
 		<attribute name="task" />
 		<attribute default="" name="test.name" />
 		<element implicit="true" name="args" optional="true" />
 
 		<sequential>
-			<if>
-				<equals arg1="@{setupbinariescache}" arg2="true" />
-				<then>
-					<setup-binaries-cache unless:true="${setup.binaries.cache.executed}" />
-				</then>
-			</if>
-
 			<if>
 				<not>
 					<available file="${project.dir}/tools/${build.binaries.gradle.file}" />
@@ -1241,7 +1233,7 @@ information.
 
 					<echo>Stopping all running Gradle Daemon processes.</echo>
 
-					<gradle-execute dir="." forcedcacheenabled="false" setupbinariescache="false" task="">
+					<gradle-execute dir="." forcedcacheenabled="false" task="">
 						<arg value="--stop" />
 					</gradle-execute>
 				</then>
@@ -1801,51 +1793,6 @@ artifact.url=${remote.repository.cdn.url}/com/liferay/portal/com.liferay.${proce
 		</sequential>
 	</macrodef>
 
-	<macrodef name="setup-binaries-cache">
-		<sequential>
-			<if>
-				<and>
-					<not>
-						<equals arg1="${build.binaries.cache.dir}" arg2="" />
-					</not>
-					<available file="${project.dir}/${build.binaries.cache.dir}" type="dir" />
-				</and>
-				<then>
-					<if>
-						<not>
-							<isset property="env.JENKINS_HOME" />
-						</not>
-						<then>
-							<property location="${project.dir}/${build.binaries.cache.dir}" name="build.binaries.cache.dir.absolute.path" />
-
-							<echo>Updating ${build.binaries.cache.dir.absolute.path}.</echo>
-
-							<retry retrycount="3" retrydelay="30000">
-								<exec dir="${project.dir}/${build.binaries.cache.dir}" executable="git" failonerror="true">
-									<arg value="pull" />
-									<arg value="--rebase" />
-									<arg value="${build.binaries.cache.url}" />
-								</exec>
-							</retry>
-						</then>
-					</if>
-
-					<condition else="true" property="sync.dir.symbolic" value="false">
-						<os family="windows" />
-					</condition>
-
-					<sync-dir
-						dir="${project.dir}/${build.binaries.cache.dir}/.gradle/caches/modules-2/files-2.1"
-						symbolic="${sync.dir.symbolic}"
-						toDir="${project.dir}/.gradle/caches/modules-2/files-2.1"
-					/>
-				</then>
-			</if>
-
-			<property name="setup.binaries.cache.executed" value="true" />
-		</sequential>
-	</macrodef>
-
 	<macrodef name="setup-libs">
 		<sequential>
 			<gradle-execute task="setUpLibs">
@@ -1941,14 +1888,12 @@ artifact.url=${remote.repository.cdn.url}/com/liferay/portal/com.liferay.${proce
 	</macrodef>
 
 	<macrodef name="setup-sdk">
-		<attribute default="true" name="setupbinariescache" />
-
 		<sequential>
 			<lstopwatch action="start" name="setup.sdk" />
 
 			<antcall inheritAll="false" target="update-gradle-properties" />
 
-			<gradle-execute setupbinariescache="@{setupbinariescache}" task="setUpPortalTools">
+			<gradle-execute task="setUpPortalTools">
 				<arg value="--build-file=${project.dir}/modules/util.gradle" />
 			</gradle-execute>
 
@@ -2047,35 +1992,9 @@ artifact.url=${remote.repository.cdn.url}/com/liferay/portal/com.liferay.${proce
 						</then>
 					</if>
 
-					<if>
-						<and>
-							<available file="${project.dir}/${build.binaries.cache.dir}/.yarn/offline-cache" type="dir" />
-							<isset property="env.JENKINS_HOME" />
-						</and>
-						<then>
-							<sync-dir
-								dir="${project.dir}/${build.binaries.cache.dir}/.yarn/offline-cache"
-								symbolic="${sync.dir.symbolic}"
-								toDir="${project.dir}/modules/node_modules_cache"
-							/>
-
-							<if>
-								<available file="${project.dir}/${build.binaries.cache.dir}/.yarn/dxp/apps/osb/osb-faro/offline-cache" type="dir" />
-								<then>
-									<sync-dir
-										dir="${project.dir}/${build.binaries.cache.dir}/.yarn/dxp/apps/osb/osb-faro/offline-cache"
-										symbolic="${sync.dir.symbolic}"
-										toDir="${project.dir}/modules/dxp/apps/osb/osb-faro/node_modules_cache"
-									/>
-								</then>
-							</if>
-						</then>
-						<else>
-							<gradle-execute dir="${project.dir}/modules" task="setUpYarnOfflineCache">
-								<arg value="--build-file=${project.dir}/modules/util.gradle" />
-							</gradle-execute>
-						</else>
-					</if>
+					<gradle-execute dir="${project.dir}/modules" task="setUpYarnOfflineCache">
+						<arg value="--build-file=${project.dir}/modules/util.gradle" />
+					</gradle-execute>
 
 					<if>
 						<not>
@@ -2276,7 +2195,6 @@ rerun your task.
 					<propertyref name="aspectj.configuration" />
 					<propertyref name="baseline.jar.report.level" />
 					<propertyref name="baseline.jar.report.only.dirty.packages" />
-					<propertyref name="build.binaries.cache.dir" />
 					<propertyref name="compile.jsp.include" />
 					<propertyref name="git.working.branch.name" />
 					<propertyref if:set="gradle.update.file.versions.excludes" name="gradle.update.file.versions.excludes" unless:blank="${gradle.update.file.versions.excludes}" />

--- a/build-releng.xml
+++ b/build-releng.xml
@@ -12,7 +12,7 @@
 
 		<ant antfile="build-maven.xml" inheritAll="false" target="jar-sources" />
 
-		<gradle-execute dir="${project.dir}/modules" setupbinariescache="false" task="portalSourcesJar">
+		<gradle-execute dir="${project.dir}/modules" task="portalSourcesJar">
 			<arg value="--build-file=${project.dir}/modules/releng.gradle" />
 		</gradle-execute>
 	</target>

--- a/build-test.xml
+++ b/build-test.xml
@@ -2500,7 +2500,7 @@ war.path=${app.server.portal.dir}/</echo>
 
 					<get-poshi-java-jdk-opts />
 
-					<gradle-execute dir="@{build.gradle.dir}" failonerror="@{failonerror}" setupbinariescache="false" stacktrace="false" task="@{task}">
+					<gradle-execute dir="@{build.gradle.dir}" failonerror="@{failonerror}" stacktrace="false" task="@{task}">
 						<arg value="--build-file=@{build.gradle.file}" />
 						<arg value="-Ptmp.maven.repository.dir=../.m2-tmp" />
 						<env key="ANT_OPTS" value="${poshi.java.jdk.opts}" />
@@ -2508,7 +2508,7 @@ war.path=${app.server.portal.dir}/</echo>
 					</gradle-execute>
 				</then>
 				<else>
-					<gradle-execute dir="@{build.gradle.dir}" failonerror="@{failonerror}" setupbinariescache="false" stacktrace="false" task="@{task}">
+					<gradle-execute dir="@{build.gradle.dir}" failonerror="@{failonerror}" stacktrace="false" task="@{task}">
 						<arg value="--build-file=@{build.gradle.file}" />
 						<arg value="-Ptmp.maven.repository.dir=../.m2-tmp" />
 					</gradle-execute>

--- a/build.properties
+++ b/build.properties
@@ -58,9 +58,6 @@
 ## Build
 ##
 
-    build.binaries.cache.dir=../${build.binaries.cache.repository.name}
-    build.binaries.cache.repository.name=liferay-binaries-cache-2020
-    build.binaries.cache.url=https://github.com/liferay/${build.binaries.cache.repository.name}.git
     build.binaries.gradle.file=gradle-8.5.LIFERAY-PATCHED-1-bin.zip
     build.binaries.gradle.url=https://releases-cdn.liferay.com/tools/gradle/${build.binaries.gradle.file}
     build.bnd.print.enabled=false

--- a/build.xml
+++ b/build.xml
@@ -172,27 +172,6 @@ testray.build.type=EE Development (@{to.branch.name})</echo>
 	</macrodef>
 
 	<target name="all">
-		<if>
-			<not>
-				<or>
-					<equals arg1="${build.binaries.cache.dir}" arg2="" />
-					<available file="${project.dir}/${build.binaries.cache.dir}" type="dir" />
-				</or>
-			</not>
-			<then>
-				<property location="${project.dir}/${build.binaries.cache.dir}" name="build.binaries.cache.dir.absolute.path" />
-
-				<echo>
-Please clone the repository at https://github.com/liferay/${build.binaries.cache.repository.name}
-into ${build.binaries.cache.dir.absolute.path} to have a cached copy of all
-Gradle dependencies used during the build.
-
-Set the property "build.binaries.cache.dir" to an empty value to suppress this
-message.
-				</echo>
-			</then>
-		</if>
-
 		<property name="gradle.execute.silent" value="true" />
 
 		<antcall target="clean" />
@@ -257,7 +236,7 @@ message.
 
 		<setup-sdk />
 
-		<gradle-execute setupbinariescache="false" task="deployReleng">
+		<gradle-execute task="deployReleng">
 			<arg value="--build-file=${project.dir}/modules/releng.gradle" />
 		</gradle-execute>
 	</target>
@@ -557,7 +536,7 @@ message.
 	<target name="deploy-portal-license-enterprise-app">
 		<property name="artifact.name" value="com.liferay.portal.license.enterprise.app" />
 
-		<gradle-execute outputproperty="jar.file" setupbinariescache="false" task="printDependencyPath">
+		<gradle-execute outputproperty="jar.file" task="printDependencyPath">
 			<arg value="--build-file=${project.dir}/modules/util.gradle" />
 			<arg value="--quiet" />
 			<arg value="-Dorg.gradle.internal.launcher.welcomeMessageEnabled=false" />
@@ -1188,23 +1167,6 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 		</if>
 	</target>
 
-	<target name="update-binaries-cache">
-		<copy
-			overwrite="false"
-			todir="${build.binaries.cache.dir}/.gradle/caches/modules-2/files-2.1"
-		>
-			<fileset
-				dir="${project.dir}/.gradle/caches/modules-2/files-2.1"
-			>
-				<size units="Mi" value="100" when="less" />
-			</fileset>
-		</copy>
-
-		<gradle-execute dir="${project.dir}/modules" task="updateYarnBinariesCache">
-			<arg value="--build-file=${project.dir}/modules/util.gradle" />
-		</gradle-execute>
-	</target>
-
 	<target name="update-gradle-cache">
 		<execute>
 			git reset --hard HEAD
@@ -1214,21 +1176,21 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 		<delete dir="${basedir}/.gradle" />
 
-		<setup-sdk setupbinariescache="false" />
+		<setup-sdk />
 
-		<gradle-execute dir="modules" forcedcacheenabled="false" setupbinariescache="false" task="clean">
+		<gradle-execute dir="modules" forcedcacheenabled="false" task="clean">
 			<arg value="--continue" />
 			<arg value="--parallel" />
 		</gradle-execute>
 
-		<gradle-execute dir="modules" forcedcacheenabled="false" setupbinariescache="false" task="classes">
+		<gradle-execute dir="modules" forcedcacheenabled="false" task="classes">
 			<arg value="--continue" />
 			<arg value="--parallel" />
 			<arg value="testClasses" />
 			<arg value="testIntegrationClasses" />
 		</gradle-execute>
 
-		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" setupbinariescache="false" task="spotbugsMain">
+		<gradle-execute dir="modules/sdk/gradle-util" failonerror="false" forcedcacheenabled="false" task="spotbugsMain">
 			<arg value="--continue" />
 			<arg value="--parallel" />
 		</gradle-execute>

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -245,7 +245,7 @@ ${oversize.files.jsp}</fail>
 	</target>
 
 	<target name="update-gradle-cache">
-		<gradle-execute forcedcacheenabled="false" setupbinariescache="false" task="updateGradleCache">
+		<gradle-execute forcedcacheenabled="false" task="updateGradleCache">
 			<arg value="--build-file=build-test.gradle" />
 			<arg value="-Dmaven.local.ignore=true" />
 		</gradle-execute>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7419

## What Is Being Fixed

liferay-portal's root Ant scripts still carried the `setup-binaries-cache` macro and the `build.binaries.cache.*` properties after CI stopped cloning `liferay-binaries-cache-2020` on slaves. On a slave where `build.binaries.cache.dir` was still injected (legacy env) and the clone directory existed without its nested `.gradle/caches/modules-2/files-2.1` path, the `sync-dir` inside `setup-binaries-cache` failed during post-build cleanup and masqueraded as an infrastructure error (observed in `test-portal-acceptance-pullrequest(master)` build #2363 on test-1-41).

## How It Is Being Fixed

Removed the `setup-binaries-cache` macrodef and every call site from `build.xml` and `build-common.xml`, including the `setupbinariescache` attribute on the `gradle-execute` and `setup-sdk` macros and all `setupbinariescache="false"` call sites across `build.xml`, `build-common.xml`, `build-test.xml`, `build-releng.xml`, and `portal-web/build.xml`. Dropped the `build.binaries.cache.dir`, `build.binaries.cache.repository.name`, and `build.binaries.cache.url` properties from `build.properties` (keeping the unrelated `build.binaries.gradle.*` gradle-distribution mirror), the `build.binaries.cache.dir` propertyref, the "Please clone…" warning in target `all`, and the `update-binaries-cache` target. In `setup-yarn` the binaries-cache `.yarn/offline-cache` branch was dead once the property is gone, so the if/else collapses to its existing non-cache path (`gradle setUpYarnOfflineCache`). The change is Ant-only; `modules/util.gradle`'s now-inert `setUpYarnOfflineCache`/`updateYarnBinariesCache` tasks are intentionally left for a possible follow-up.

Note: the removed `update-binaries-cache` Ant target has no in-repo callers, but a release/patcher CI job could still invoke `ant update-binaries-cache`. Please confirm no such job depends on it before merging.

## Why Are There No Tests?

The change only removes dead Ant build-script machinery; these root build scripts have no unit-test harness and are exercised only by the CI build / PR tester. Verified locally: all five XML files remain well-formed, the SourceFormatter reports no changes on the touched files, and `ant setup-sdk` ran the modified `gradle-execute`/`setup-sdk` macros to `BUILD SUCCESSFUL`.

## PR Check

**pr-check: PASS** — tested on `974722358ecaaf3a877e0606f1ecf1b25b0e359c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Full Portal Build matched on `portal-web/build.xml` but was trimmed: the change touches no compiled sources, macro consistency is proven by a successful `ant setup-sdk`, and the authoritative full build runs on CI for this PR.

<!-- pr-check {"result": "success", "sha": "974722358ecaaf3a877e0606f1ecf1b25b0e359c"} -->