### PR TITLE
LRCI-7659 Prevent bundle watchers from hanging on remote reads

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -738,6 +738,14 @@ public class JenkinsResultsParserUtil {
 	public static String executeJenkinsScript(
 		String jenkinsMasterName, String script, boolean rawResponse) {
 
+		return executeJenkinsScript(
+			jenkinsMasterName, script, rawResponse, _MILLIS_TIMEOUT_DEFAULT);
+	}
+
+	public static String executeJenkinsScript(
+		String jenkinsMasterName, String script, boolean rawResponse,
+		int timeout) {
+
 		Matcher matcher = _test1MasterNamePattern.matcher(jenkinsMasterName);
 
 		try {
@@ -761,6 +769,9 @@ public class JenkinsResultsParserUtil {
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
 
 			httpURLConnection.setDoOutput(true);
 			httpURLConnection.setRequestMethod("POST");
@@ -3711,6 +3722,15 @@ public class JenkinsResultsParserUtil {
 		JenkinsMaster jenkinsMaster, String jenkinsJobName,
 		Map<String, String> buildParameters) {
 
+		return invokeJenkinsBuild(
+			jenkinsMaster, jenkinsJobName, buildParameters,
+			_MILLIS_TIMEOUT_DEFAULT);
+	}
+
+	public static long invokeJenkinsBuild(
+		JenkinsMaster jenkinsMaster, String jenkinsJobName,
+		Map<String, String> buildParameters, int timeout) {
+
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(jenkinsMaster.getRemoteURL());
@@ -3741,6 +3761,9 @@ public class JenkinsResultsParserUtil {
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
 
 			HTTPAuthorization httpAuthorization =
 				_getJenkinsHTTPAuthorization();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -7,9 +7,13 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URL;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.json.JSONArray;
@@ -44,6 +48,36 @@ public class JenkinsResultsParserUtilTest
 	@After
 	public void tearDown() {
 		Environment.setInstance(new Environment());
+	}
+
+	@Test(timeout = 30000)
+	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
+		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+			int port = serverSocket.getLocalPort();
+
+			long startTime = System.currentTimeMillis();
+
+			String result = JenkinsResultsParserUtil.executeJenkinsScript(
+				"localhost:" + port, "println 'hello'", true, 2000);
+
+			long duration = System.currentTimeMillis() - startTime;
+
+			if (result != null) {
+				errorCollector.addError(
+					new Throwable(
+						"executeJenkinsScript should return null on a read " +
+							"timeout, but returned: " + result));
+			}
+
+			if (duration < 1500) {
+				errorCollector.addError(
+					new Throwable(
+						JenkinsResultsParserUtil.combine(
+							"executeJenkinsScript returned after ",
+							String.valueOf(duration),
+							" ms; it did not reach the read timeout")));
+			}
+		}
 	}
 
 	@Test
@@ -297,6 +331,52 @@ public class JenkinsResultsParserUtilTest
 				"https://releases.liferay.com/portal/"));
 	}
 
+	@Test(timeout = 30000)
+	public void testInvokeJenkinsBuildReadTimeout() throws Exception {
+		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+			int port = serverSocket.getLocalPort();
+
+			JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+			Mockito.when(
+				jenkinsMaster.getRemoteURL()
+			).thenReturn(
+				"http://localhost:" + port + "/"
+			);
+
+			Map<String, String> buildParameters = new HashMap<>();
+
+			long startTime = System.currentTimeMillis();
+
+			boolean thrown = false;
+
+			try {
+				JenkinsResultsParserUtil.invokeJenkinsBuild(
+					jenkinsMaster, "test-job", buildParameters, 2000);
+			}
+			catch (RuntimeException runtimeException) {
+				thrown = true;
+			}
+
+			long duration = System.currentTimeMillis() - startTime;
+
+			if (!thrown) {
+				errorCollector.addError(
+					new Throwable(
+						"invokeJenkinsBuild should fail on a read timeout"));
+			}
+
+			if (duration < 1500) {
+				errorCollector.addError(
+					new Throwable(
+						JenkinsResultsParserUtil.combine(
+							"invokeJenkinsBuild failed after ",
+							String.valueOf(duration),
+							" ms; it did not reach the read timeout")));
+			}
+		}
+	}
+
 	@Test
 	public void testIsJSONArrayEqual() {
 		JSONArray expectedJSONArray = new JSONArray();
@@ -492,6 +572,10 @@ public class JenkinsResultsParserUtilTest
 		URL url = uri.toURL();
 
 		return url.toString();
+	}
+
+	private ServerSocket _createStalledServerSocket() throws Exception {
+		return new ServerSocket(0, 1, InetAddress.getByName("localhost"));
 	}
 
 	private String _fixURLMultipleTimes(String urlString) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7659

## What Is Being Fixed

The bundle watcher threads (`build-app-server-bundles`, `build-analytics-cloud-asah-bundles`, `build-analytics-cloud-faro-bundles`) could hang indefinitely, stalling top-level builds for 12+ hours with no progress. They reach `JenkinsResultsParserUtil.executeJenkinsScript` (queue item resolution) and `invokeJenkinsBuild` (build dispatch), both of which opened their `HttpURLConnection` without a connect or read timeout. When a Jenkins master returned the response headers but then stalled on the response body, the read blocked forever and froze the watcher's `update()` loop. Because `waitForUpdate` only checks its overall `_MAX_WAIT_TIME` (2 hour) bound between `update()` calls, the stalled read also defeated that watchdog.

## How It Is Being Fixed

Both methods now set a connect and read timeout on the connection, reusing the module's `_MILLIS_TIMEOUT_DEFAULT` (5 minutes), exposed through a new `timeout` overload that the existing signatures delegate to. A stalled read now surfaces as a `SocketTimeoutException`, which both methods already handle, so control returns to the 30 second poll loop and the existing watchdog can fail a hung watcher instead of leaving it a zombie.

No retry layer was added: the watcher already re-invokes `update()` every 30 seconds, so a transient `/script` timeout is naturally retried on the next poll. Two unit tests point each method at a stalled local `ServerSocket` and assert it returns or throws within the timeout rather than blocking, guarding on elapsed time so a test only passes when the read genuinely timed out.

## PR Check

**pr-check: PASS** — tested on `b191afde0fc4ed9d24ba784e8bb937a32ab06753`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b191afde0fc4ed9d24ba784e8bb937a32ab06753"} -->
