### PR TITLE
LRCI-7707 Set the PARENT_BUILD_URL on invoked builds

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
@@ -66,6 +66,7 @@ public class ArchiveBinariesCachePortalControllerBuildRunner
 		invocationParameters.put(
 			"JENKINS_GITHUB_BRANCH_USERNAME",
 			buildData.getJenkinsGitHubUsername());
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
 		invocationParameters.put(
 			"PORTAL_GIT_COMMIT", buildData.getPortalBranchSHA());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
@@ -351,6 +351,16 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 
 		Build build = getBuild();
 
+		Build parentBuild = build.getParentBuild();
+
+		if (parentBuild != null) {
+			String parentBuildURL = parentBuild.getBuildURL();
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(parentBuildURL)) {
+				build.setParameterValue("PARENT_BUILD_URL", parentBuildURL);
+			}
+		}
+
 		Map<String, String> buildParameters = new HashMap<>(
 			build.getParameters());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
@@ -236,6 +236,10 @@ public class GenerateReportsControllerBuildRunner
 	}
 
 	private void _invoke(Map<String, String> invocationParameters) {
+		BuildData buildData = getBuildData();
+
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
+
 		Properties buildProperties = null;
 
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
@@ -263,6 +263,8 @@ public class PoshiReleasePortalTopLevelBuildRunner
 				_getGitHubBranchUsername("JENKINS_GITHUB_URL"));
 			invocationParameters.put(
 				"JENKINS_TOP_LEVEL_BUILD_URL", buildData.getBuildURL());
+			invocationParameters.put(
+				"PARENT_BUILD_URL", buildData.getBuildURL());
 
 			PullRequest pullRequest = entry.getValue();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
@@ -130,6 +130,7 @@ public class QAWebsitesControllerBuildRunner
 		invocationParameters.put(
 			"JENKINS_GITHUB_BRANCH_USERNAME",
 			_getGitHubBranchUsername("JENKINS_GITHUB_URL"));
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
 		invocationParameters.put(
 			"TEST_QA_WEBSITES_BRANCH_NAME",
 			_getGitHubBranchName("QA_WEBSITES_GITHUB_URL"));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SingleUpstreamPortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SingleUpstreamPortalControllerBuildRunner.java
@@ -70,6 +70,7 @@ public class SingleUpstreamPortalControllerBuildRunner
 		invocationParameters.put(
 			"JENKINS_GITHUB_BRANCH_USERNAME",
 			buildData.getJenkinsGitHubUsername());
+		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
 		invocationParameters.put(
 			"PORTAL_GIT_COMMIT", buildData.getPortalBranchSHA());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResultsConsistencyReportControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResultsConsistencyReportControllerBuildRunner.java
@@ -128,6 +128,8 @@ public class TestResultsConsistencyReportControllerBuildRunner
 			invocationParameters.put(
 				"JENKINS_GITHUB_BRANCH_USERNAME",
 				buildData.getJenkinsGitHubUsername());
+			invocationParameters.put(
+				"PARENT_BUILD_URL", buildData.getBuildURL());
 			invocationParameters.put("PORTAL_UPSTREAM_BRANCH_NAME", branchName);
 
 			invocationParameters.putAll(buildData.getBuildParameters());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestSuiteMultipleUpstreamPortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestSuiteMultipleUpstreamPortalControllerBuildRunner.java
@@ -92,6 +92,8 @@ public class TestSuiteMultipleUpstreamPortalControllerBuildRunner
 			invocationParameters.put(
 				"JENKINS_GITHUB_BRANCH_USERNAME",
 				buildData.getJenkinsGitHubUsername());
+			invocationParameters.put(
+				"PARENT_BUILD_URL", buildData.getBuildURL());
 			invocationParameters.put("PORTAL_GIT_COMMIT", portalBranchSHA);
 			invocationParameters.put(
 				"PORTAL_GITHUB_URL", buildData.getPortalGitHubURL());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
@@ -327,6 +327,9 @@ public abstract class TopLevelBuildRunner<T extends TopLevelBuildData>
 			throw new RuntimeException(ioException);
 		}
 
+		invocationParameters.put(
+			"PARENT_BUILD_URL", _topLevelBuild.getBuildURL());
+
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(getBaseInvocationURL(cohortName, jobName));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -410,6 +410,7 @@ public abstract class BaseBundlePersistentResource
 		buildParameters.put("AXIS_VARIABLE", _getAxisVariable());
 		buildParameters.put("BUILD_PRIORITY", _BUILD_PRIORITY);
 		buildParameters.put("JOB_VARIANT", _JOB_VARIANT);
+		buildParameters.put("PARENT_BUILD_URL", getCurrentTopLevelBuildURL());
 		buildParameters.put("SLAVE_LABEL", "slave-bundle-builder");
 
 		setProducerQueueId(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7707

## What Is Being Fixed

Builds invoked by a controller, top-level, or persistent-resource runner did not
carry a reference back to the build that invoked them. Without a PARENT_BUILD_URL
parameter, an invoked build has no record of its parent, making the build hierarchy
hard to reconstruct from the build parameters alone.

## How It Is Being Fixed

The invoking build's URL is now passed as a PARENT_BUILD_URL invocation parameter
across the build runners that launch downstream builds (archive binaries cache,
generate reports, Poshi release, QA websites, single upstream, test results
consistency, test suite multiple upstream, and the top-level runner) and on the
persistent-resource bundle build. The DefaultBuildUpdater additionally propagates
the parent build URL when reinvoking a build, guarding against a missing parent or
empty URL so the parameter is only set when a real parent URL is available.

## Why Are There No Tests?

These changes wire a PARENT_BUILD_URL invocation parameter into the Jenkins build
runners. The behavior is only observable in live CI build invocations and is not
coverable by unit or integration tests; the jenkins-results-parser classes touched
have no unit test counterparts.

## PR Check

**pr-check: PASS** — tested on `a4ec9ffb2b4ee7b19538b2329846615b8250a2cb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a4ec9ffb2b4ee7b19538b2329846615b8250a2cb"} -->
