### PR TITLE
LRCI-7698 Remove scancode service_account key fallback

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
@@ -368,21 +368,9 @@ public class ScanCodeCloudBucket {
 
 	private Storage _getStorage() {
 		try {
-			Storage storage = _getBucketStorage(
-				JenkinsResultsParserUtil.getBuildProperty(
-					"google.application.crendential.file[scancode]"));
-
-			if (storage != null) {
-				return storage;
-			}
-		}
-		catch (Exception exception) {
-		}
-
-		try {
 			return _getBucketStorage(
 				JenkinsResultsParserUtil.getBuildProperty(
-					"scancode.credentials.file"));
+					"google.application.crendential.file[scancode]"));
 		}
 		catch (Exception exception) {
 			exception.printStackTrace();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7698

## What Is Being Fixed

`ScanCodeCloudBucket._getStorage()` carried a second-tier fallback that read the `scancode.credentials.file` service_account key. Under the WIF migration (LRCI-7279), the fully-WIF fleet authenticates through the `external_account` credential file (`google.application.crendential.file[scancode]`), so the service_account fallback is dead code — and keeping a live private key wired as a fallback is exactly what the migration set out to remove.

## How It Is Being Fixed

Deletes the fallback `try` block (and its companion local) from `_getStorage()`, leaving the single WIF credential lookup that `GoogleCredentials.fromStream` already accepts. The companion removals — the `scancode.credentials.file` property and the committed `ci-scancode.json` key — land in liferay-jenkins-ee.

## Why Are There No Tests

This removes a credential-resolution branch whose behavior depends on live GCS/WIF credentials; there is no unit-testable surface and no existing counterpart test for `ScanCodeCloudBucket`. It was validated on the fully-WIF fleet via the `analyze_docker_image` pipeline run, and the WIF scancode principal's bucket access was confirmed on the AWS nodes before removal.

## PR Check

**pr-check: PASS** — tested on `f92df6d4d9f288276428bbd1e26eddfc77c57c4b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f92df6d4d9f288276428bbd1e26eddfc77c57c4b"} -->
