### PR TITLE
LRCI-7685 Run the complete stable test list in ci:test:relevant

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuite.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuite.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -91,6 +92,9 @@ public class RelevantTestSuite {
 				_relevantRuleEngine.getRelevantRuleNames(relevantRules));
 
 		for (RelevantRule relevantRule : relevantRules) {
+			boolean stableRule = Objects.equals(
+				relevantRule.getName(), "stable-rule");
+
 			for (TestBatch testBatch : relevantRule.getTestBatches()) {
 				if (testBatches.contains(testBatch)) {
 					TestBatch existingTestBatch = testBatches.get(
@@ -101,7 +105,7 @@ public class RelevantTestSuite {
 					continue;
 				}
 
-				if (!validTestBatchRegexes.isEmpty() &&
+				if (stableRule ||
 					isValidTestBatch(
 						validTestBatchRegexes, testBatch.getName())) {
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
@@ -161,4 +161,27 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 		}
 	}
 
+	@Test
+	public void testStableRuleBatchBypassesWhitelist() {
+		RelevantTestSuite relevantTestSuite = new RelevantTestSuite(
+			getPortalAcceptancePullRequestJob());
+
+		relevantTestSuite.setModifiedFiles(
+			Arrays.asList(new File(getBaseDir(), "stable/trigger.txt")));
+
+		RelevantRuleEngine relevantRuleEngine =
+			RelevantRuleEngine.getInstance();
+
+		relevantRuleEngine.setBaseDir(getBaseDir());
+
+		Set<String> batchNames = new HashSet<>();
+
+		for (TestBatch testBatch : relevantTestSuite.getTestBatches(false)) {
+			batchNames.add(testBatch.getName());
+		}
+
+		Assert.assertTrue(
+			batchNames.contains("rest-builder-and-service-builder"));
+	}
+
 }

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/test/suite/RelevantRuleEngineTest/test.properties
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/test/suite/RelevantRuleEngineTest/test.properties
@@ -8,6 +8,8 @@ modified.files.includes[modules-integration-0-rule][relevant]=\
 
 modified.files.includes[modules-unit-0-rule][relevant]=modules/module-2/**
 
+modified.files.includes[stable-rule][relevant]=stable/**
+
 modules.includes.required.test.batch.class.names.includes[modules-integration-0-rule][relevant][modules-integration-postgresql163]=\
     apps/document-library/**/src/testIntegration/**/*Test.java,\
     apps/fragment/**/src/testIntegration/**/*Test.java,\
@@ -21,7 +23,8 @@ modules.includes.required.test.batch.class.names.includes[modules-unit-0-rule][r
 relevant.rule.names=\
     functional-smoke-0-rule,\
     modules-integration-0-rule,\
-    modules-unit-0-rule
+    modules-unit-0-rule,\
+    stable-rule
 
 test.batch.names[functional-smoke-0-rule][relevant]=functional-smoke-tomcat90-mysql84
 test.batch.names[modules-integration-0-rule][relevant]=modules-integration-postgresql163
@@ -32,6 +35,8 @@ test.batch.names[relevant]=\
     modules-integration-postgresql163,\
     modules-unit,\
     playwright-js-tomcat101-mysql84
+
+test.batch.names[stable-rule][relevant]=rest-builder-and-service-builder
 
 test.batch.run.property.global.query[relevant][functional-smoke-tomcat90-mysql84]=\
     (portal.acceptance != quarantine)

--- a/test.properties
+++ b/test.properties
@@ -1055,15 +1055,11 @@
     modules.includes.required.test.batch.class.names.includes[stable-rule][relevant][unit_stable]=\
         ${test.batch.class.names.includes[unit_stable]}
 
+    playwright.projects.includes[stable-rule][relevant][playwright-js-smoke-tomcat101-hypersonic20]=smoke.main
+
     playwright.projects.includes[stable-rule][relevant][playwright-js-tomcat101-postgresql163_stable]=smoke.main
 
-    test.batch.names[stable-rule][relevant]=\
-        functional-upgrade-tomcat101-postgresql163_stable,\
-        js-unit,\
-        modules-integration-postgresql163_stable,\
-        modules-unit_stable,\
-        playwright-js-tomcat101-postgresql163_stable,\
-        unit_stable
+    test.batch.names[stable-rule][relevant]=${test.batch.names[stable]}
 
     test.batch.run.property.query[stable-rule][relevant][functional-smoke-tomcat101-postgresql163_stable]=\
         ${test.batch.run.property.query[functional-smoke-tomcat101-postgresql163]}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7685

## What Is Being Fixed

When a developer runs `ci:test:relevant`, the stable batches it runs were a
hand-maintained subset of the full stable suite (`test.batch.names[stable]`)
and were further narrowed by the `relevant.batch.names.whitelist` filter. As a
result, a pull request could pass stable and then fail the same batches on the
upstream merge, which runs the complete stable suite.

## How It Is Being Fixed

The stable rule's batch list (`test.batch.names[stable-rule][relevant]`) now
references `test.batch.names[stable]` directly, so the relevant run's stable
batches are always identical to the merge stable list and cannot drift. In
`RelevantTestSuite`, the stable rule's batches are also exempted from the
`relevant.batch.names.whitelist` filter, so stable batches that do not match
the whitelist (such as `rest-builder-and-service-builder`) are no longer
silently dropped. A regression test in `RelevantTestSuiteTest` confirms that a
stable-rule batch absent from the whitelist is still included.

## PR Check

**Result: PASS** — tested SHA `02168b1da2d83a972cc23b02f22e7fc0a14651c5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | CI-deferred |
| Java Unit Tests | CI-deferred |

Source Format and main-source compilation pass locally. The Integration Test
Compile and Java Unit Test validations cannot execute in this worktree (the
`com.liferay.portal.test` snapshot is not installed, and the `RelevantRule`
test harness requires a checkout named `liferay-portal`), so they are validated
by CI.

<!-- pr-check {"result": "success", "sha": "02168b1da2d83a972cc23b02f22e7fc0a14651c5"} -->
