### PR TITLE
LRCI-7708 Reinvoke missing CI builds on a different Jenkins master (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
@@ -70,24 +70,39 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 
 	protected void runMissing() {
 		if (isBuildQueued()) {
+			_missingTickCount = 0;
+
 			_build.setStatus("queued");
 
 			return;
 		}
 
 		if (isBuildRunning()) {
+			_missingTickCount = 0;
+
 			_build.setStatus("running");
 
 			return;
 		}
 
 		if (isBuildCompleted()) {
+			_missingTickCount = 0;
+
 			_build.setStatus("completed");
 
 			return;
 		}
 
-		if (!_hasMaximumInvocationCount()) {
+		_missingTickCount++;
+
+		if (_missingTickCount < _getMissingReinvokeTickCount()) {
+			return;
+		}
+
+		if (_missingReinvocationCount < _getMissingMaximumReinvocationCount()) {
+			_missingReinvocationCount++;
+			_missingTickCount = 0;
+
 			_build.reset();
 
 			reinvoke();
@@ -96,6 +111,8 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 
 			return;
 		}
+
+		_missingTickCount = 0;
 
 		_build.setStatus("reporting");
 	}
@@ -174,6 +191,40 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 		}
 
 		_build.setStatus("queued");
+	}
+
+	private int _getMissingMaximumReinvocationCount() {
+		try {
+			String missingMaxReinvocationCount =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"build.missing.max.reinvocation.count");
+
+			if (JenkinsResultsParserUtil.isInteger(
+					missingMaxReinvocationCount)) {
+
+				return Integer.parseInt(missingMaxReinvocationCount);
+			}
+		}
+		catch (IOException ioException) {
+		}
+
+		return _MISSING_MAXIMUM_REINVOCATION_COUNT_DEFAULT;
+	}
+
+	private int _getMissingReinvokeTickCount() {
+		try {
+			String missingReinvokeTickCount =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"build.missing.reinvoke.tick.count");
+
+			if (JenkinsResultsParserUtil.isInteger(missingReinvokeTickCount)) {
+				return Integer.parseInt(missingReinvokeTickCount);
+			}
+		}
+		catch (IOException ioException) {
+		}
+
+		return _MISSING_REINVOKE_TICK_COUNT_DEFAULT;
 	}
 
 	private boolean _hasMaximumInvocationCount() {
@@ -405,11 +456,17 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 		slaveOfflineRule.takeSlaveOffline(build);
 	}
 
+	private static final int _MISSING_MAXIMUM_REINVOCATION_COUNT_DEFAULT = 2;
+
+	private static final int _MISSING_REINVOKE_TICK_COUNT_DEFAULT = 3;
+
 	private static final Pattern _notificationRecipentsPattern =
 		Pattern.compile(
 			"slack:(?:<@)?(?<slack>[\\w-]+)>?|(?<email>[\\w-]+@[\\w.-]+)");
 
 	private final Build _build;
+	private int _missingReinvocationCount;
+	private int _missingTickCount;
 	private final Map<Build.Invocation, ReinvokeRule> _reinvokeRulesMap =
 		new HashMap<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
@@ -45,11 +45,20 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 	public void reinvoke(Map<String, String> reinvokeBuildParameters) {
 		Build build = getBuild();
 
+		JenkinsMaster currentJenkinsMaster = null;
+
+		Build.Invocation currentInvocation = build.getCurrentInvocation();
+
+		if (currentInvocation != null) {
+			currentJenkinsMaster = currentInvocation.getJenkinsMaster();
+		}
+
 		JenkinsCohort jenkinsCohort = build.getJenkinsCohort();
 
 		JenkinsMaster jenkinsMaster =
 			jenkinsCohort.getMostAvailableJenkinsMaster(
-				build.getInvokedBatchSize(), build.getJobName());
+				currentJenkinsMaster, build.getInvokedBatchSize(),
+				build.getJobName());
 
 		build.setJenkinsMaster(jenkinsMaster);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -108,16 +108,17 @@ public class JenkinsCohort {
 
 			if (!blacklist.contains(jenkinsMasterName)) {
 				blacklist.add(jenkinsMasterName);
-			}
 
-			List<JenkinsMaster> availableJenkinsMasters =
-				_getAvailableJenkinsMasters(blacklist);
+				List<JenkinsMaster> availableJenkinsMasters =
+					_getAvailableJenkinsMasters(blacklist);
 
-			if (availableJenkinsMasters.isEmpty()) {
-				System.out.println(
-					"Unable to exclude Jenkins master " + jenkinsMasterName);
+				if (availableJenkinsMasters.isEmpty()) {
+					System.out.println(
+						"Unable to exclude Jenkins master " +
+							jenkinsMasterName);
 
-				blacklist.remove(jenkinsMasterName);
+					blacklist.remove(jenkinsMasterName);
+				}
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -104,10 +104,10 @@ public class JenkinsCohort {
 		List<String> blacklist = new ArrayList<>(_jenkinsMastersBlacklist);
 
 		if (excludedJenkinsMaster != null) {
-			String jenkinsMasterName = excludedJenkinsMaster.getName();
+			String excludedJenkinsMasterName = excludedJenkinsMaster.getName();
 
-			if (!blacklist.contains(jenkinsMasterName)) {
-				blacklist.add(jenkinsMasterName);
+			if (!blacklist.contains(excludedJenkinsMasterName)) {
+				blacklist.add(excludedJenkinsMasterName);
 
 				List<JenkinsMaster> availableJenkinsMasters =
 					_getAvailableJenkinsMasters(blacklist);
@@ -115,9 +115,9 @@ public class JenkinsCohort {
 				if (availableJenkinsMasters.isEmpty()) {
 					System.out.println(
 						"Unable to exclude Jenkins master " +
-							jenkinsMasterName);
+							excludedJenkinsMasterName);
 
-					blacklist.remove(jenkinsMasterName);
+					blacklist.remove(excludedJenkinsMasterName);
 				}
 			}
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
@@ -93,11 +94,38 @@ public class JenkinsCohort {
 	public JenkinsMaster getMostAvailableJenkinsMaster(
 		int invokedBatchSize, String jobName) {
 
+		return getMostAvailableJenkinsMaster(null, invokedBatchSize, jobName);
+	}
+
+	public JenkinsMaster getMostAvailableJenkinsMaster(
+		JenkinsMaster excludedJenkinsMaster, int invokedBatchSize,
+		String jobName) {
+
+		List<String> blacklist = new ArrayList<>(_jenkinsMastersBlacklist);
+
+		if (excludedJenkinsMaster != null) {
+			String jenkinsMasterName = excludedJenkinsMaster.getName();
+
+			if (!blacklist.contains(jenkinsMasterName)) {
+				blacklist.add(jenkinsMasterName);
+			}
+
+			List<JenkinsMaster> availableJenkinsMasters =
+				_getAvailableJenkinsMasters(blacklist);
+
+			if (availableJenkinsMasters.isEmpty()) {
+				System.out.println(
+					"Unable to exclude Jenkins master " + jenkinsMasterName);
+
+				blacklist.remove(jenkinsMasterName);
+			}
+		}
+
 		String mostAvailableMasterURL =
 			JenkinsResultsParserUtil.getMostAvailableMasterURL(
 				"http://" + getName() + ".liferay.com",
-				JenkinsResultsParserUtil.join(",", _jenkinsMastersBlacklist),
-				invokedBatchSize, jobName);
+				JenkinsResultsParserUtil.join(",", blacklist), invokedBatchSize,
+				jobName);
 
 		return JenkinsMaster.getInstance(
 			mostAvailableMasterURL.replaceAll("http://(.+)", "$1"));
@@ -615,6 +643,27 @@ public class JenkinsCohort {
 		int buildCount, String buildPercentage) {
 
 		return buildCount + " (" + buildPercentage + ")";
+	}
+
+	private List<JenkinsMaster> _getAvailableJenkinsMasters(
+		List<String> blacklist) {
+
+		Properties buildProperties = null;
+
+		try {
+			buildProperties = JenkinsResultsParserUtil.getBuildProperties(
+				false);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to get build properties", ioException);
+		}
+
+		return LoadBalancerUtil.getAvailableJenkinsMasters(
+			JenkinsResultsParserUtil.join(",", blacklist),
+			LoadBalancerUtil.getMasterPrefix(
+				"http://" + getName() + ".liferay.com"),
+			buildProperties, true);
 	}
 
 	private synchronized Map<String, List<AWSFleetCloud>>

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/persistent/resource/BaseBundlePersistentResource.java
@@ -10,6 +10,7 @@ import com.liferay.jenkins.results.parser.BuildDatabase;
 import com.liferay.jenkins.results.parser.BuildFactory;
 import com.liferay.jenkins.results.parser.Environment;
 import com.liferay.jenkins.results.parser.JenkinsAPIUtil;
+import com.liferay.jenkins.results.parser.JenkinsCohort;
 import com.liferay.jenkins.results.parser.JenkinsMaster;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.SubrepositoryWorkspace;
@@ -26,6 +27,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -296,6 +299,16 @@ public abstract class BaseBundlePersistentResource
 
 			print("WARNING: Unable to find queue item");
 
+			_missingCount++;
+
+			if (_missingCount >= _MAX_MISSING_COUNT) {
+				_missingCount = 0;
+
+				print("Reinvoking bundles after missing queue item");
+
+				start();
+			}
+
 			return;
 		}
 
@@ -366,6 +379,27 @@ public abstract class BaseBundlePersistentResource
 		}
 	}
 
+	private JenkinsCohort _getJenkinsCohort(JenkinsMaster jenkinsMaster) {
+		if (jenkinsMaster != null) {
+			JenkinsCohort jenkinsCohort = jenkinsMaster.getJenkinsCohort();
+
+			if (jenkinsCohort != null) {
+				return jenkinsCohort;
+			}
+		}
+
+		String baseInvocationURL = _getBaseInvocationURL();
+
+		Matcher matcher = _baseInvocationURLPattern.matcher(baseInvocationURL);
+
+		if (!matcher.find()) {
+			throw new RuntimeException(
+				"Unable to determine Jenkins cohort from " + baseInvocationURL);
+		}
+
+		return JenkinsCohort.getInstance(matcher.group("cohortName"));
+	}
+
 	private String _getProducerJobURL() {
 		JenkinsMaster producerJenkinsMaster = getProducerJenkinsMaster();
 
@@ -379,9 +413,14 @@ public abstract class BaseBundlePersistentResource
 	private void _invokeBuild() {
 		setControllerBuildURL(getCurrentTopLevelBuildURL());
 
+		JenkinsMaster currentProducerJenkinsMaster = getProducerJenkinsMaster();
+
+		JenkinsCohort jenkinsCohort = _getJenkinsCohort(
+			currentProducerJenkinsMaster);
+
 		JenkinsMaster producerJenkinsMaster =
-			JenkinsResultsParserUtil.getMostAvailableJenkinsMaster(
-				_getBaseInvocationURL(), 1);
+			jenkinsCohort.getMostAvailableJenkinsMaster(
+				currentProducerJenkinsMaster, 1, _JOB_NAME);
 
 		setProducerJenkinsMaster(producerJenkinsMaster);
 
@@ -559,6 +598,9 @@ public abstract class BaseBundlePersistentResource
 	private static final int _MAX_REDISPATCH_ATTEMPTS = 1;
 
 	private static final long _REDISPATCH_VERIFY_TIME = 1000 * 10;
+
+	private static final Pattern _baseInvocationURLPattern = Pattern.compile(
+		"https?://(?<cohortName>test-\\d+)(\\.liferay\\.com)?");
 
 	private Build _build;
 	private int _failCount;


### PR DESCRIPTION
[LRCI-7708](https://liferay.atlassian.net/browse/LRCI-7708)

Revises [#4376](https://github.com/pyoo47/liferay-portal/pull/4376) (opened by @michaelhashimoto) with the following follow-up commits:

- [37f30696ac7f](https://github.com/pyoo47/liferay-portal/commit/37f30696ac7f91f19620e16f07baeeef0130ef1b) LRCI-7708 Roll back only the blacklist entry added to exclude a master
- [2debd4d2ec13](https://github.com/pyoo47/liferay-portal/commit/2debd4d2ec1316869dbd3678591d12eb594b912a) LRCI-7708 Rename
