### PR TITLE
LRCI-7659 Prevent bundle watchers from hanging on remote reads (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -655,8 +655,10 @@ public class JenkinsResultsParserUtil {
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
 
-			httpURLConnection.setConnectTimeout(timeout);
-			httpURLConnection.setReadTimeout(timeout);
+			if (timeout != 0) {
+				httpURLConnection.setConnectTimeout(timeout);
+				httpURLConnection.setReadTimeout(timeout);
+			}
 
 			httpURLConnection.setDoOutput(true);
 			httpURLConnection.setRequestMethod("POST");
@@ -3657,8 +3659,10 @@ public class JenkinsResultsParserUtil {
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
 
-			httpURLConnection.setConnectTimeout(timeout);
-			httpURLConnection.setReadTimeout(timeout);
+			if (timeout != 0) {
+				httpURLConnection.setConnectTimeout(timeout);
+				httpURLConnection.setReadTimeout(timeout);
+			}
 
 			HTTPAuthorization httpAuthorization =
 				_getJenkinsHTTPAuthorization();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -623,6 +623,14 @@ public class JenkinsResultsParserUtil {
 	public static String executeJenkinsScript(
 		String jenkinsMasterName, String script, boolean rawResponse) {
 
+		return executeJenkinsScript(
+			jenkinsMasterName, script, rawResponse, _MILLIS_TIMEOUT_DEFAULT);
+	}
+
+	public static String executeJenkinsScript(
+		String jenkinsMasterName, String script, boolean rawResponse,
+		int timeout) {
+
 		Matcher matcher = _test1MasterNamePattern.matcher(jenkinsMasterName);
 
 		try {
@@ -646,6 +654,9 @@ public class JenkinsResultsParserUtil {
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
 
 			httpURLConnection.setDoOutput(true);
 			httpURLConnection.setRequestMethod("POST");
@@ -3606,6 +3617,15 @@ public class JenkinsResultsParserUtil {
 		JenkinsMaster jenkinsMaster, String jenkinsJobName,
 		Map<String, String> buildParameters) {
 
+		return invokeJenkinsBuild(
+			jenkinsMaster, jenkinsJobName, buildParameters,
+			_MILLIS_TIMEOUT_DEFAULT);
+	}
+
+	public static long invokeJenkinsBuild(
+		JenkinsMaster jenkinsMaster, String jenkinsJobName,
+		Map<String, String> buildParameters, int timeout) {
+
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(jenkinsMaster.getRemoteURL());
@@ -3636,6 +3656,9 @@ public class JenkinsResultsParserUtil {
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
 
 			HTTPAuthorization httpAuthorization =
 				_getJenkinsHTTPAuthorization();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -52,7 +52,7 @@ public class JenkinsResultsParserUtilTest
 
 	@Test(timeout = 30000)
 	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
-		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+		try (ServerSocket serverSocket = _createServerSocket()) {
 			int port = serverSocket.getLocalPort();
 
 			long startTime = System.currentTimeMillis();
@@ -333,7 +333,7 @@ public class JenkinsResultsParserUtilTest
 
 	@Test(timeout = 30000)
 	public void testInvokeJenkinsBuildReadTimeout() throws Exception {
-		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+		try (ServerSocket serverSocket = _createServerSocket()) {
 			int port = serverSocket.getLocalPort();
 
 			JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
@@ -574,7 +574,7 @@ public class JenkinsResultsParserUtilTest
 		return url.toString();
 	}
 
-	private ServerSocket _createStalledServerSocket() throws Exception {
+	private ServerSocket _createServerSocket() throws Exception {
 		return new ServerSocket(0, 1, InetAddress.getByName("localhost"));
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -7,9 +7,13 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URL;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.json.JSONArray;
@@ -44,6 +48,36 @@ public class JenkinsResultsParserUtilTest
 	@After
 	public void tearDown() {
 		Environment.setInstance(new Environment());
+	}
+
+	@Test(timeout = 30000)
+	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
+		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+			int port = serverSocket.getLocalPort();
+
+			long startTime = System.currentTimeMillis();
+
+			String result = JenkinsResultsParserUtil.executeJenkinsScript(
+				"localhost:" + port, "println 'hello'", true, 2000);
+
+			long duration = System.currentTimeMillis() - startTime;
+
+			if (result != null) {
+				errorCollector.addError(
+					new Throwable(
+						"executeJenkinsScript should return null on a read " +
+							"timeout, but returned: " + result));
+			}
+
+			if (duration < 1500) {
+				errorCollector.addError(
+					new Throwable(
+						JenkinsResultsParserUtil.combine(
+							"executeJenkinsScript returned after ",
+							String.valueOf(duration),
+							" ms; it did not reach the read timeout")));
+			}
+		}
 	}
 
 	@Test
@@ -297,6 +331,52 @@ public class JenkinsResultsParserUtilTest
 				"https://releases.liferay.com/portal/"));
 	}
 
+	@Test(timeout = 30000)
+	public void testInvokeJenkinsBuildReadTimeout() throws Exception {
+		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+			int port = serverSocket.getLocalPort();
+
+			JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+			Mockito.when(
+				jenkinsMaster.getRemoteURL()
+			).thenReturn(
+				"http://localhost:" + port + "/"
+			);
+
+			Map<String, String> buildParameters = new HashMap<>();
+
+			long startTime = System.currentTimeMillis();
+
+			boolean thrown = false;
+
+			try {
+				JenkinsResultsParserUtil.invokeJenkinsBuild(
+					jenkinsMaster, "test-job", buildParameters, 2000);
+			}
+			catch (RuntimeException runtimeException) {
+				thrown = true;
+			}
+
+			long duration = System.currentTimeMillis() - startTime;
+
+			if (!thrown) {
+				errorCollector.addError(
+					new Throwable(
+						"invokeJenkinsBuild should fail on a read timeout"));
+			}
+
+			if (duration < 1500) {
+				errorCollector.addError(
+					new Throwable(
+						JenkinsResultsParserUtil.combine(
+							"invokeJenkinsBuild failed after ",
+							String.valueOf(duration),
+							" ms; it did not reach the read timeout")));
+			}
+		}
+	}
+
 	@Test
 	public void testIsJSONArrayEqual() {
 		JSONArray expectedJSONArray = new JSONArray();
@@ -492,6 +572,10 @@ public class JenkinsResultsParserUtilTest
 		URL url = uri.toURL();
 
 		return url.toString();
+	}
+
+	private ServerSocket _createStalledServerSocket() throws Exception {
+		return new ServerSocket(0, 1, InetAddress.getByName("localhost"));
 	}
 
 	private String _fixURLMultipleTimes(String urlString) {


### PR DESCRIPTION
[LRCI-7659](https://liferay.atlassian.net/browse/LRCI-7659)

Revises [#4371](https://github.com/pyoo47/liferay-portal/pull/4371) (opened by @CalumR23) with the following follow-up commits:

- [cd670804abf9](https://github.com/pyoo47/liferay-portal/commit/cd670804abf9b08501609b933d28a5a0928453c3) LRCI-7659 Consistency
- [9f09a3ebeecf](https://github.com/pyoo47/liferay-portal/commit/9f09a3ebeecf888ce585d8a3bfe7847b9af2c1ea) LRCI-7659 Rename
