### PR TITLE
LRCI-7740 Limit batch test tasks to each module's own test classes

### DIFF
--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -40,7 +40,7 @@ ext {
 		"com.liferay.gradle.plugins.theme.builder.version": "2.0.17",
 		"com.liferay.portal.tools.bundle.support.version": "3.7.5",
 		"com.liferay.portal.tools.service.builder.version": "1.0.501",
-		"com.liferay.portal.tools.rest.builder.version": "1.0.470",
+		"com.liferay.portal.tools.rest.builder.version": "1.0.471",
 		"com.liferay.portal.tools.soy.builder.version": "3.0.4",
 		"com.liferay.portal.tools.theme.builder.version": "1.1.9",
 		"com.liferay.portal.vulcan.api.version": "9.3.1"
@@ -655,9 +655,19 @@ gradle.beforeProject {
 			}
 
 			compileTestJava {
-				configurations.compileOnly.allDependencies.withType(ProjectDependency) {
-					if (!it.dependencyProject.name.endsWith("-theme")) {
-						mustRunAfter "${it.dependencyProject.path}:processResources"
+				for (ProjectDependency projectDependency in configurations.compileOnly.allDependencies.withType(ProjectDependency)) {
+					Project dependencyProject = projectDependency.dependencyProject
+
+					if (!dependencyProject.name.endsWith("-theme")) {
+						mustRunAfter "${dependencyProject.path}:processResources"
+					}
+				}
+
+				for (ProjectDependency projectDependency in configurations.testImplementation.allDependencies.withType(ProjectDependency)) {
+					Project dependencyProject = projectDependency.dependencyProject
+
+					if (!dependencyProject.name.endsWith("-theme")) {
+						mustRunAfter "${dependencyProject.path}:processResources"
 					}
 				}
 			}
@@ -1052,21 +1062,25 @@ private boolean _containsProject(
 }
 
 private List<String> _getTestClasses(Task task) {
-	return task.project.gradle.testClasses.collect {
-		String testClass ->
+	List<String> testClasses = []
 
-		if (testClass.startsWith("/modules/")) {
-			String projectPath = task.project.path.replace(':' as char, '/' as char)
+	Project project = task.project
 
-			String javaPath = "/modules" + projectPath + "/src/" + task.name + "/java/"
+	String javaDirName = "src/" + task.name + "/java/"
 
-			if (testClass.startsWith(javaPath)) {
-				testClass = testClass.replace(javaPath, "")
-			}
+	for (String testClass : project.gradle.testClasses) {
+		String testJavaClass = testClass.replace(".class", ".java")
+
+		String javaFileName = javaDirName + testJavaClass
+
+		File javaFile = project.file(javaFileName)
+
+		if (javaFile.exists()) {
+			testClasses.add(testClass)
 		}
-
-		return testClass
 	}
+
+	return testClasses
 }
 
 private boolean _hasTestClasses(Task task, String testClassesDirName) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7740

## What Is Being Fixed

In the `modules-unit` batch, each module's Gradle `test` task was configured with the whole axis's test-class list as its `include` patterns rather than just its own. For `:apps:portal-search-opensearch2:portal-search-opensearch2-impl:test` this meant an include list spanning dozens of unrelated modules against an opensearch2-only `--tests` filter; the empty intersection tripped Gradle's `failOnNoMatchingTests`, aborting the task and cascading to ~455 non-pass results in build #279 (169 "was not executed" plus 286 "untested") across `modules-unit-jdk8`. This is the remaining non-git root of the opensearch2 cascade tracked by LRCI-7629 (parent LRCI-7731).

## How It Is Being Fixed

`_getTestClasses` in `modules/build.gradle` now filters the axis group to only the classes whose test source exists in the current project, so `include _getTestClasses(it)` scopes every test task to its own module. The obsolete `/modules/`-prefix branch is dropped, since the group entries are package-relative. Separately, `compileTestJava` now declares `mustRunAfter ...:processResources` for `testImplementation` project dependencies — mirroring the adjacent `compileTestIntegrationJava` block — closing the ordering gap where `portal-search-opensearch2-impl`'s test compile read `portal-search-test-util:processResources` output without a declared dependency.

## Why Are There No Tests?

The change is CI build-distribution logic in `modules/build.gradle` — Gradle build-script configuration that is not unit-testable, and whose distribution code path runs only under CI batch conditions (`testClassGroupIndex`). It is validated by the CI `modules-unit-opensearch2` batch rather than local unit tests. The companion `compileTestJava` ordering fix was verified locally: the `portal-search-test-util:processResources` implicit-dependency warning is resolved and the task now runs in the correct order.

## PR Check

**pr-check: PASS** — tested on `155fa119952588030d958ca81607cc06f1b26e3a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "155fa119952588030d958ca81607cc06f1b26e3a"} -->
