### PR TITLE
LRCI-7685 relevant-suite validation throwaway

### DIFF
--- a/lrci-7685-stable-rule-trigger.txt
+++ b/lrci-7685-stable-rule-trigger.txt
@@ -1,0 +1,1 @@
+# LRCI-7685 stable-rule validation trigger - inert root file so stable-rule matches in ci:test:relevant. Safe to delete.

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuite.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuite.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -91,6 +92,9 @@ public class RelevantTestSuite {
 				_relevantRuleEngine.getRelevantRuleNames(relevantRules));
 
 		for (RelevantRule relevantRule : relevantRules) {
+			boolean stableRule = Objects.equals(
+				relevantRule.getName(), "stable-rule");
+
 			for (TestBatch testBatch : relevantRule.getTestBatches()) {
 				if (testBatches.contains(testBatch)) {
 					TestBatch existingTestBatch = testBatches.get(
@@ -101,7 +105,7 @@ public class RelevantTestSuite {
 					continue;
 				}
 
-				if (!validTestBatchRegexes.isEmpty() &&
+				if (stableRule ||
 					isValidTestBatch(
 						validTestBatchRegexes, testBatch.getName())) {
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
@@ -161,4 +161,27 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 		}
 	}
 
+	@Test
+	public void testStableRuleBatchBypassesWhitelist() {
+		RelevantTestSuite relevantTestSuite = new RelevantTestSuite(
+			getPortalAcceptancePullRequestJob());
+
+		relevantTestSuite.setModifiedFiles(
+			Arrays.asList(new File(getBaseDir(), "stable/trigger.txt")));
+
+		RelevantRuleEngine relevantRuleEngine =
+			RelevantRuleEngine.getInstance();
+
+		relevantRuleEngine.setBaseDir(getBaseDir());
+
+		Set<String> batchNames = new HashSet<>();
+
+		for (TestBatch testBatch : relevantTestSuite.getTestBatches(false)) {
+			batchNames.add(testBatch.getName());
+		}
+
+		Assert.assertTrue(
+			batchNames.contains("rest-builder-and-service-builder"));
+	}
+
 }

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/test/suite/RelevantRuleEngineTest/test.properties
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/test/suite/RelevantRuleEngineTest/test.properties
@@ -8,6 +8,8 @@ modified.files.includes[modules-integration-0-rule][relevant]=\
 
 modified.files.includes[modules-unit-0-rule][relevant]=modules/module-2/**
 
+modified.files.includes[stable-rule][relevant]=stable/**
+
 modules.includes.required.test.batch.class.names.includes[modules-integration-0-rule][relevant][modules-integration-postgresql163]=\
     apps/document-library/**/src/testIntegration/**/*Test.java,\
     apps/fragment/**/src/testIntegration/**/*Test.java,\
@@ -21,7 +23,8 @@ modules.includes.required.test.batch.class.names.includes[modules-unit-0-rule][r
 relevant.rule.names=\
     functional-smoke-0-rule,\
     modules-integration-0-rule,\
-    modules-unit-0-rule
+    modules-unit-0-rule,\
+    stable-rule
 
 test.batch.names[functional-smoke-0-rule][relevant]=functional-smoke-tomcat90-mysql84
 test.batch.names[modules-integration-0-rule][relevant]=modules-integration-postgresql163
@@ -32,6 +35,8 @@ test.batch.names[relevant]=\
     modules-integration-postgresql163,\
     modules-unit,\
     playwright-js-tomcat101-mysql84
+
+test.batch.names[stable-rule][relevant]=rest-builder-and-service-builder
 
 test.batch.run.property.global.query[relevant][functional-smoke-tomcat90-mysql84]=\
     (portal.acceptance != quarantine)

--- a/test.properties
+++ b/test.properties
@@ -1055,15 +1055,11 @@
     modules.includes.required.test.batch.class.names.includes[stable-rule][relevant][unit_stable]=\
         ${test.batch.class.names.includes[unit_stable]}
 
+    playwright.projects.includes[stable-rule][relevant][playwright-js-smoke-tomcat101-hypersonic20]=smoke.main
+
     playwright.projects.includes[stable-rule][relevant][playwright-js-tomcat101-postgresql163_stable]=smoke.main
 
-    test.batch.names[stable-rule][relevant]=\
-        functional-upgrade-tomcat101-postgresql163_stable,\
-        js-unit,\
-        modules-integration-postgresql163_stable,\
-        modules-unit_stable,\
-        playwright-js-tomcat101-postgresql163_stable,\
-        unit_stable
+    test.batch.names[stable-rule][relevant]=${test.batch.names[stable]}
 
     test.batch.run.property.query[stable-rule][relevant][functional-smoke-tomcat101-postgresql163_stable]=\
         ${test.batch.run.property.query[functional-smoke-tomcat101-postgresql163]}


### PR DESCRIPTION
Throwaway PR to run the **relevant** suite against candidate-jar jenkins-ee branch `pyoo47/LRCI-7685` (pyoo47/liferay-jenkins-ee#4972). Carries Calum's LRCI-7685 portal commit so `test.properties` has the full stable list; validates that ci:test:relevant runs the complete stable list. Safe to close/delete after the run.