### PR TITLE
LRCI-7759 Add ability to generate build properties for local usage

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
@@ -65,6 +65,8 @@ public class EnvironmentBuildProperties extends Properties {
 
 			load(new StringReader(contents));
 
+			_loadLocalProperties(urlString, checkCache);
+
 			return;
 		}
 		catch (IOException ioException) {
@@ -99,6 +101,8 @@ public class EnvironmentBuildProperties extends Properties {
 		}
 		catch (IOException ioException) {
 		}
+
+		_loadLocalProperties(urlString, checkCache);
 	}
 
 	public EnvironmentBuildProperties(File file) throws IOException {
@@ -179,6 +183,31 @@ public class EnvironmentBuildProperties extends Properties {
 		sb.append(_simpleDateFormat.format(new Date()));
 
 		return sb.toString();
+	}
+
+	private void _loadLocalProperties(String urlString, boolean checkCache) {
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				System.getenv("MASTER_NETWORK_NAME"))) {
+
+			return;
+		}
+
+		Matcher matcher = _propertiesURLPattern.matcher(urlString);
+
+		if (!matcher.matches()) {
+			return;
+		}
+
+		try {
+			String content = _toString(
+				JenkinsResultsParserUtil.combine(
+					matcher.group(1), "-local", matcher.group(2)),
+				checkCache);
+
+			load(new StringReader(content));
+		}
+		catch (IOException ioException) {
+		}
 	}
 
 	private String _toString(String url, boolean checkCache)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7759

## What Is Being Fixed

`EnvironmentBuildProperties` loads build properties from a remote URL, but there
was no way to layer local overrides on top of those properties when running
outside the CI master network. This made it hard to iterate on build property
changes locally.

## How It Is Being Fixed

A new `_loadLocalProperties` helper runs after the remote properties load. When
the `MASTER_NETWORK_NAME` environment variable is unset (i.e. local usage), it
derives a sibling `-local` URL from the original properties URL and loads that
content over the existing properties, letting local values override the remote
ones. On the CI master network the helper short-circuits, preserving existing
behavior. The helper is invoked from both load paths in the class.

## Why Are There No Tests?

This is CI tooling in the `jenkins-results-parser` module, which has no unit test
harness for this property-loading path.

## PR Check

**pr-check: PASS** — tested on `5ad515c82d1141ec6de322c6e08d25d6c5fd5591`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5ad515c82d1141ec6de322c6e08d25d6c5fd5591"} -->
