### PR TITLE
LRCI-7740 Limit batch test tasks to each module's own test classes (revised)

### DIFF
--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -655,9 +655,19 @@ gradle.beforeProject {
 			}
 
 			compileTestJava {
-				configurations.compileOnly.allDependencies.withType(ProjectDependency) {
-					if (!it.dependencyProject.name.endsWith("-theme")) {
-						mustRunAfter "${it.dependencyProject.path}:processResources"
+				for (ProjectDependency projectDependency in configurations.compileOnly.allDependencies.withType(ProjectDependency)) {
+					Project dependencyProject = projectDependency.dependencyProject
+
+					if (!dependencyProject.name.endsWith("-theme")) {
+						mustRunAfter "${dependencyProject.path}:processResources"
+					}
+				}
+
+				for (ProjectDependency projectDependency in configurations.testImplementation.allDependencies.withType(ProjectDependency)) {
+					Project dependencyProject = projectDependency.dependencyProject
+
+					if (!dependencyProject.name.endsWith("-theme")) {
+						mustRunAfter "${dependencyProject.path}:processResources"
 					}
 				}
 			}
@@ -1052,21 +1062,25 @@ private boolean _containsProject(
 }
 
 private List<String> _getTestClasses(Task task) {
-	return task.project.gradle.testClasses.collect {
-		String testClass ->
+	List<String> testClasses = []
 
-		if (testClass.startsWith("/modules/")) {
-			String projectPath = task.project.path.replace(':' as char, '/' as char)
+	Project project = task.project
 
-			String javaPath = "/modules" + projectPath + "/src/" + task.name + "/java/"
+	String javaDirName = "src/" + task.name + "/java/"
 
-			if (testClass.startsWith(javaPath)) {
-				testClass = testClass.replace(javaPath, "")
-			}
+	for (String testClass : project.gradle.testClasses) {
+		String testJavaClass = testClass.replace(".class", ".java")
+
+		String javaFileName = javaDirName + testJavaClass
+
+		File javaFile = project.file(javaFileName)
+
+		if (javaFile.exists()) {
+			testClasses.add(testClass)
 		}
-
-		return testClass
 	}
+
+	return testClasses
 }
 
 private boolean _hasTestClasses(Task task, String testClassesDirName) {

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -655,19 +655,15 @@ gradle.beforeProject {
 			}
 
 			compileTestJava {
-				for (ProjectDependency projectDependency in configurations.compileOnly.allDependencies.withType(ProjectDependency)) {
-					Project dependencyProject = projectDependency.dependencyProject
-
-					if (!dependencyProject.name.endsWith("-theme")) {
-						mustRunAfter "${dependencyProject.path}:processResources"
+				configurations.compileOnly.allDependencies.withType(ProjectDependency) {
+					if (!it.dependencyProject.name.endsWith("-theme")) {
+						mustRunAfter "${it.dependencyProject.path}:processResources"
 					}
 				}
 
-				for (ProjectDependency projectDependency in configurations.testImplementation.allDependencies.withType(ProjectDependency)) {
-					Project dependencyProject = projectDependency.dependencyProject
-
-					if (!dependencyProject.name.endsWith("-theme")) {
-						mustRunAfter "${dependencyProject.path}:processResources"
+				configurations.testImplementation.allDependencies.withType(ProjectDependency) {
+					if (!it.dependencyProject.name.endsWith("-theme")) {
+						mustRunAfter "${it.dependencyProject.path}:processResources"
 					}
 				}
 			}


### PR DESCRIPTION
- [LRCI-7740](https://liferay.atlassian.net/browse/LRCI-7740)

Revises [#4379](https://github.com/pyoo47/liferay-portal/pull/4379) (opened by @CalumR23) with the following follow-up commit:

- [f646f2522a1d](https://github.com/pyoo47/liferay-portal/commit/f646f2522a1de6b94e6c0b0dd43fb6b52363a1e3) LRCI-7740 Consistency

@CalumR23's commit was rebased onto current master; the `modules/build.gradle` `rest.builder.version` conflict was resolved to master's `1.0.472`. The follow-up reverts `compileTestJava` to the live `withType(ProjectDependency) { }` form used by the adjacent `compileTestIntegrationJava`, so its `mustRunAfter` ordering still registers (the `for`-loop snapshot ran before the module's dependencies were declared) and the file keeps one form.
