### PR TITLE
LRCI-7759 Support generating build properties for local usage

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -484,7 +484,7 @@ public class AnalyticsCloudClient {
 							ObjectMapperHolder._objectMapper.readerFor(
 								Metric[].class);
 
-						metrics = objectReader.readValue(jsonNode);
+						metrics = objectReader.readValue(metricsJsonNode);
 					}
 
 					performanceMetric.setMetrics(() -> metrics);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -624,85 +624,94 @@ public class AnalyticsCloudClient {
 		String[] selectedMetrics, Integer size, Sort[] sorts, Long tagId,
 		Long vocabularyId) {
 
-		String url = String.join(
+		String location = String.join(
 			StringPool.BLANK, liferayAnalyticsFaroBackendURL,
 			"/api/1.0/asset-metric/objectEntry", path);
 
 		if (categoryId != null) {
-			url = HttpComponentsUtil.addParameter(
-				url, "categoryId", categoryId);
+			location = HttpComponentsUtil.addParameter(
+				location, "categoryId", categoryId);
 		}
 
 		if (Validator.isNotNull(dataSourceId)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "dataSourceId", dataSourceId);
+			location = HttpComponentsUtil.addParameter(
+				location, "dataSourceId", dataSourceId);
 		}
 
 		if (Validator.isNotNull(externalReferenceCode)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "externalReferenceCode", externalReferenceCode);
+			location = HttpComponentsUtil.addParameter(
+				location, "externalReferenceCode", externalReferenceCode);
 		}
 
 		if (Validator.isNotNull(filterString)) {
-			url = HttpComponentsUtil.addParameter(url, "filter", filterString);
+			location = HttpComponentsUtil.addParameter(
+				location, "filter", filterString);
 		}
 
 		if (Validator.isNotNull(groupBy)) {
-			url = HttpComponentsUtil.addParameter(url, "groupBy", groupBy);
+			location = HttpComponentsUtil.addParameter(
+				location, "groupBy", groupBy);
 		}
 
 		if (!groupIds.isEmpty()) {
-			url = HttpComponentsUtil.addParameter(
-				url, "groupIds", StringUtil.merge(groupIds, StringPool.COMMA));
+			location = HttpComponentsUtil.addParameter(
+				location, "groupIds",
+				StringUtil.merge(groupIds, StringPool.COMMA));
 		}
 
 		if (Validator.isNotNull(metricType)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "assetSummaryMetricType", metricType);
+			location = HttpComponentsUtil.addParameter(
+				location, "assetSummaryMetricType", metricType);
 		}
 
 		if (Validator.isNotNull(objectType)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "objectType", objectType);
+			location = HttpComponentsUtil.addParameter(
+				location, "objectType", objectType);
 		}
 
 		if (page != null) {
-			url = HttpComponentsUtil.addParameter(url, "page", page);
+			location = HttpComponentsUtil.addParameter(location, "page", page);
 		}
 
 		if (rangeKey != null) {
-			url = HttpComponentsUtil.addParameter(url, "rangeKey", rangeKey);
+			location = HttpComponentsUtil.addParameter(
+				location, "rangeKey", rangeKey);
 		}
 
 		if (ArrayUtil.isNotEmpty(selectedMetrics)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "selectedMetrics",
+			location = HttpComponentsUtil.addParameter(
+				location, "selectedMetrics",
 				StringUtil.merge(selectedMetrics, StringPool.COMMA));
 		}
 
 		if (size != null) {
-			url = HttpComponentsUtil.addParameter(url, "size", size);
+			location = HttpComponentsUtil.addParameter(location, "size", size);
 		}
 
 		if (ArrayUtil.isNotEmpty(sorts)) {
+			List<String> sortStrings = new ArrayList<>();
+
 			for (Sort sort : sorts) {
-				url = HttpComponentsUtil.addParameter(
-					url, "sort", sort.getFieldName());
-				url = HttpComponentsUtil.addParameter(
-					url, "sort", sort.isReverse() ? "desc" : "asc");
+				sortStrings.add(sort.getFieldName());
+				sortStrings.add(sort.isReverse() ? "desc" : "asc");
 			}
+
+			location = HttpComponentsUtil.addParameter(
+				location, "sort",
+				StringUtil.merge(sortStrings, StringPool.COMMA));
 		}
 
 		if (tagId != null) {
-			url = HttpComponentsUtil.addParameter(url, "tagId", tagId);
+			location = HttpComponentsUtil.addParameter(
+				location, "tagId", tagId);
 		}
 
 		if (vocabularyId != null) {
-			url = HttpComponentsUtil.addParameter(
-				url, "vocabularyId", vocabularyId);
+			location = HttpComponentsUtil.addParameter(
+				location, "vocabularyId", vocabularyId);
 		}
 
-		return url;
+		return location;
 	}
 
 	private String _getLocation(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -32,7 +32,6 @@ import com.liferay.object.model.ObjectDefinitionTable;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -686,19 +685,12 @@ public class AnalyticsCloudClient {
 		}
 
 		if (ArrayUtil.isNotEmpty(sorts)) {
-			StringBundler sb = new StringBundler((sorts.length * 4) - 1);
-
-			for (int i = 0; i < sorts.length; i++) {
-				if (i > 0) {
-					sb.append(StringPool.COMMA);
-				}
-
-				sb.append(sorts[i].getFieldName());
-				sb.append(StringPool.COLON);
-				sb.append(sorts[i].isReverse() ? "desc" : "asc");
+			for (Sort sort : sorts) {
+				url = HttpComponentsUtil.addParameter(
+					url, "sort", sort.getFieldName());
+				url = HttpComponentsUtil.addParameter(
+					url, "sort", sort.isReverse() ? "desc" : "asc");
 			}
-
-			url = HttpComponentsUtil.addParameter(url, "sort", sb.toString());
 		}
 
 		if (tagId != null) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -71,7 +71,7 @@ public class PerformanceAssetConsumptionResourceImpl
 				contextCompany.getCompanyId()),
 			categoryId, groupBy, Arrays.asList(groupIds),
 			contextAcceptLanguage.getPreferredLocale(), "viewsMetric",
-			objectType, pagination.getPage(), rangeKey,
+			objectType, pagination.getPage() - 1, rangeKey,
 			pagination.getPageSize(), tagId, vocabularyId);
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -58,8 +58,9 @@ public class PerformanceTopAssetResourceImpl
 		return analyticsCloudClient.getPerformanceTopAsset(
 			_analyticsSettingsManager.getAnalyticsConfiguration(
 				contextCompany.getCompanyId()),
-			assetFilterString, Arrays.asList(groupIds), pagination.getPage(),
-			rangeKey, pagination.getPageSize(), sorts);
+			assetFilterString, Arrays.asList(groupIds),
+			pagination.getPage() - 1, rangeKey, pagination.getPageSize(),
+			sorts);
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -323,9 +323,9 @@ public class PerformanceAssetConsumptionResourceTest
 					"L_CMS_BLOG", testCompany.getCompanyId());
 
 		long categoryId = RandomTestUtil.nextLong();
-		int page = 2;
+		int page = RandomTestUtil.nextInt();
 		int rangeKey = RandomTestUtil.nextInt();
-		int size = 5;
+		int size = RandomTestUtil.nextInt();
 		long tagId = RandomTestUtil.nextLong();
 		long vocabularyId = RandomTestUtil.nextLong();
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -350,7 +350,7 @@ public class PerformanceAssetConsumptionResourceTest
 				StringPool.COMMA),
 			"groupIds", location);
 		_assertParameter(objectDefinition.getName(), "objectType", location);
-		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(page - 1), "page", location);
 		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 		_assertParameter(String.valueOf(size), "size", location);
 		_assertParameter(String.valueOf(tagId), "tagId", location);

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -197,7 +197,7 @@ public class PerformanceTopAssetResourceTest
 			}
 
 			sb.append(sorts[i].getFieldName());
-			sb.append(StringPool.COLON);
+			sb.append(StringPool.COMMA);
 			sb.append(sorts[i].isReverse() ? "desc" : "asc");
 		}
 
@@ -325,7 +325,7 @@ public class PerformanceTopAssetResourceTest
 
 		_assertParameter(dataSourceId, "dataSourceId", location);
 		_assertParameter(assetFilterString, "filter", location);
-		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(page - 1), "page", location);
 		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 		_assertParameter(String.valueOf(pageSize), "size", location);
 
@@ -337,7 +337,7 @@ public class PerformanceTopAssetResourceTest
 			}
 
 			sb.append(sorts[i].getFieldName());
-			sb.append(StringPool.COLON);
+			sb.append(StringPool.COMMA);
 			sb.append(sorts[i].isReverse() ? "desc" : "asc");
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
@@ -26,16 +26,22 @@ import java.util.regex.Pattern;
 public class EnvironmentBuildProperties extends Properties {
 
 	public static Environment getCurrentEnvironment() {
+		String jenkinsURL = System.getenv("JENKINS_URL");
+
+		if (!JenkinsResultsParserUtil.isURL(jenkinsURL)) {
+			return Environment.LOCAL;
+		}
+
 		String masterNetworkName = System.getenv("MASTER_NETWORK_NAME");
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(masterNetworkName) &&
-			(masterNetworkName.equals("aws-network") ||
-			 masterNetworkName.equals("gcp-network"))) {
+			(masterNetworkName.equals("cloud-network") ||
+			 masterNetworkName.equals("nuc-network"))) {
 
-			return Environment.AWS;
+			return Environment.DB;
 		}
 
-		return Environment.DB;
+		return Environment.AWS;
 	}
 
 	public static String toURLString(File file) throws IOException {
@@ -154,7 +160,7 @@ public class EnvironmentBuildProperties extends Properties {
 
 	public enum Environment {
 
-		AWS("aws-master", "aws"), DB("master", "db");
+		AWS("aws-master", "aws"), DB("master", "db"), LOCAL("master", "local");
 
 		public String getBranchName() {
 			return _branchName;
@@ -185,10 +191,16 @@ public class EnvironmentBuildProperties extends Properties {
 		return sb.toString();
 	}
 
-	private void _loadLocalProperties(String urlString, boolean checkCache) {
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(
-				System.getenv("JENKINS_URL"))) {
+	private boolean _isLocal() {
+		if (getCurrentEnvironment() == Environment.LOCAL) {
+			return true;
+		}
 
+		return false;
+	}
+
+	private void _loadLocalProperties(String urlString, boolean checkCache) {
+		if (!_isLocal()) {
 			return;
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildProperties.java
@@ -65,6 +65,8 @@ public class EnvironmentBuildProperties extends Properties {
 
 			load(new StringReader(contents));
 
+			_loadLocalProperties(urlString, checkCache);
+
 			return;
 		}
 		catch (IOException ioException) {
@@ -99,6 +101,8 @@ public class EnvironmentBuildProperties extends Properties {
 		}
 		catch (IOException ioException) {
 		}
+
+		_loadLocalProperties(urlString, checkCache);
 	}
 
 	public EnvironmentBuildProperties(File file) throws IOException {
@@ -179,6 +183,31 @@ public class EnvironmentBuildProperties extends Properties {
 		sb.append(_simpleDateFormat.format(new Date()));
 
 		return sb.toString();
+	}
+
+	private void _loadLocalProperties(String urlString, boolean checkCache) {
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				System.getenv("JENKINS_URL"))) {
+
+			return;
+		}
+
+		Matcher matcher = _propertiesURLPattern.matcher(urlString);
+
+		if (!matcher.matches()) {
+			return;
+		}
+
+		try {
+			String content = _toString(
+				JenkinsResultsParserUtil.combine(
+					matcher.group(1), "-local", matcher.group(2)),
+				checkCache);
+
+			load(new StringReader(content));
+		}
+		catch (IOException ioException) {
+		}
 	}
 
 	private String _toString(String url, boolean checkCache)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildPropertiesUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/EnvironmentBuildPropertiesUtil.java
@@ -63,6 +63,18 @@ public class EnvironmentBuildPropertiesUtil {
 						"github.webhook.url[aws-staging]"));
 			}
 
+			if (environment != EnvironmentBuildProperties.Environment.LOCAL) {
+				for (String propertyName :
+						environmentBuildProperties.stringPropertyNames()) {
+
+					environmentBuildProperties.setProperty(
+						propertyName,
+						SecretsUtil.getSecret(
+							environmentBuildProperties.getProperty(
+								propertyName)));
+				}
+			}
+
 			environmentBuildProperties.store(environmentBuildPropertiesFile);
 
 			System.out.println("Writing " + environmentBuildPropertiesFile);

--- a/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
@@ -22,6 +22,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
@@ -23,6 +23,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
@@ -24,6 +24,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
@@ -47,7 +47,7 @@ test('Generate a new token after expired', async ({
 			const rowToken = page.getByTestId(`row-token-${tokenId}`);
 
 			expect(await rowToken.textContent()).toBe(
-				`Token ending in${tokenId}Expired`
+				`Token Ending In${tokenId}Expired`
 			);
 		});
 

--- a/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
@@ -24,6 +24,7 @@ import {closeSessions} from './utils/sessions';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
+++ b/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
@@ -143,7 +143,7 @@ export class SegmentsPage {
 
 	async clickDuplicateButton() {
 		const duplicateButton = this.page.getByRole('button', {
-			name: 'Duplicate Segment Property',
+			name: 'Duplicate Property',
 		});
 		await duplicateButton.click();
 	}
@@ -253,7 +253,9 @@ export class SegmentsPage {
 			exact: true,
 			name: tabName,
 		});
-		const propertyLocator = this.page.getByText(propertyName);
+		const propertyLocator = this.page.getByText(propertyName, {
+			exact: true,
+		});
 		const isPropertyVisible = await propertyLocator.isVisible();
 
 		if (!isPropertyVisible) {

--- a/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
+++ b/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
@@ -32,6 +32,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-78863': {enabled: true, system: true},
+		'LPS-178052': {enabled: true},
 	}),
 	instanceSettingsPagesTest,
 	pageEditorPagesTest,
@@ -295,9 +296,11 @@ test(
 
 		// Create an organization, a user, and assign the user to the organization
 
+		const organizationName = getRandomString();
+
 		const organization =
 			await apiHelpers.headlessAdminUser.postOrganization({
-				name: getRandomString(),
+				name: organizationName,
 			});
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount({
@@ -318,7 +321,9 @@ test(
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: page.getByRole('menuitem', {name: 'Edit'}),
-			trigger: page.getByRole('button', {name: 'Show Actions'}),
+			trigger: page
+				.locator('tr', {hasText: organizationName})
+				.getByRole('button', {name: 'Show Actions'}),
 		});
 
 		await clickAndExpectToBeVisible({
@@ -1802,7 +1807,7 @@ test(
 			await editUserPage.lastNameInput.fill('userln');
 			await editUserPage.screenNameInput.fill('usersn');
 
-			const tagInputFied = page.getByLabel('Tags', {exact: true});
+			const tagInputFied = page.getByRole('combobox', {name: 'Tags'});
 			await tagInputFied.fill('tagName');
 			await tagInputFied.press('Enter');
 			await page.locator('body').click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7759
https://liferay.atlassian.net/browse/LRCI-7786

## What Is Being Fixed

The build-properties generator only understood the AWS and DB Jenkins environments, keyed off `aws-network`/`gcp-network` master network names, and always resolved every property value through the secrets store. There was no way to generate build properties for a local (non-Jenkins) run, and the network-name mapping no longer matched the current `cloud-network` and `nuc-network` names.

## How It Is Being Fixed

A `LOCAL` environment is added and selected whenever `JENKINS_URL` is absent or not a URL, with AWS now the fallback environment otherwise. The network-name mapping is updated to route `cloud-network`/`nuc-network` to DB and everything else to AWS. When the resolved environment is `LOCAL`, `EnvironmentBuildProperties` additionally loads the matching `-local` properties overlay, and `EnvironmentBuildPropertiesUtil` skips secret resolution so local values are written verbatim; for the AWS and DB environments every property is still resolved through the secrets store when generating mirror values.

## Why Are There No Tests?

The `jenkins-results-parser` module is CI build tooling, and this code path (environment detection from process env vars and secret resolution for mirror generation) has no existing unit-test harness; it was verified manually.

## PR Check

**pr-check: PASS** — tested on `8604a087275a59dc0ceb7b1e3ea530f86c4b1f7d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8604a087275a59dc0ceb7b1e3ea530f86c4b1f7d"} -->
