### PR TITLE
LRCI-7747 Document env.S3_BUCKET_NAME and the rebalance threshold

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PropertyValidator.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PropertyValidator.java
@@ -398,9 +398,10 @@ public class PropertyValidator {
 		new HashSet<>(
 			Arrays.asList(
 				"cloud.fleet.primary.label", "dist.node.axis.count",
-				"failure.report.compare.length.max",
+				"env.S3_BUCKET_NAME", "failure.report.compare.length.max",
 				"failure.report.similarity.threshold",
 				"jenkins.osb.jenkins.web.master.url",
+				"jenkins.queue.rebalance.threshold",
 				"master.auto.scaling.group.name",
 				"one.password.access.token.key", "one.password.connect.url",
 				"scancode.s3.bucket", "test.history.batch.maximum.duration",


### PR DESCRIPTION
- [LRCI-7747](https://liferay.atlassian.net/browse/LRCI-7747)
- [LRCI-7709](https://liferay.atlassian.net/browse/LRCI-7709)

## Summary

`PropertyValidatorTest` flagged two build properties that are consumed via `getBuildProperty` but defined as a key in neither a `liferay-jenkins-ee` `commands/build-*.properties` file nor the validator allowlist, keeping the `modules-unit` batch red:

- `env.S3_BUCKET_NAME` (LRCI-7747): an environment variable set on the AWS masters, read by `HeapDumpCloudUploader`.
- `jenkins.queue.rebalance.threshold` (LRCI-7709): an optional tuning multiplier read by `BuildQueueRebalancer`, with a code-side default.

Both are runtime false positives. This adds them to the validator's `_documentedDefaultPropertyNames` allowlist, alongside the existing sibling bucket and threshold keys. `PropertyValidatorTest` passes locally.
