### PR TITLE
LRCI-7754 Remove dead google.cloud.translation.service.key path

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4688,100 +4688,6 @@ tell application "Safari" to quit
 		</sequential>
 	</macrodef>
 
-	<macrodef name="prepare-selenium-google-cloud-translation-properties">
-		<sequential>
-			<if>
-				<isset property="google.cloud.translation.service.key.type" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.type=${google.cloud.translation.service.key.type}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.project.id" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.project.id=${google.cloud.translation.service.key.project.id}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.private.key.id" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.private.key.id=${google.cloud.translation.service.key.private.key.id}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.private.key" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.private.key=${google.cloud.translation.service.key.private.key}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.client.email" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.client.email=${google.cloud.translation.service.key.client.email}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.client.id" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.client.id=${google.cloud.translation.service.key.client.id}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.auth.uri" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.auth.uri=${google.cloud.translation.service.key.auth.uri}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.token.uri" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.token.uri=${google.cloud.translation.service.key.token.uri}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.auth.provider.x509.cert.url" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.auth.provider.x509.cert.url=${google.cloud.translation.service.key.auth.provider.x509.cert.url}
-					</echo>
-				</then>
-			</if>
-
-			<if>
-				<isset property="google.cloud.translation.service.key.client.x509.cert.url" />
-				<then>
-					<echo append="true" file="${test.ext.properties.file}">
-						google.cloud.translation.service.key.client.x509.cert.url=${google.cloud.translation.service.key.client.x509.cert.url}
-					</echo>
-				</then>
-			</if>
-		</sequential>
-	</macrodef>
-
 	<macrodef name="prepare-selenium-google-properties">
 		<sequential>
 			<if>
@@ -14323,7 +14229,6 @@ enterprise.product.enterprise.search.enabled=false</echo>
 		<prepare-selenium-email-properties />
 		<prepare-selenium-facebook-properties />
 		<prepare-selenium-google-cloud-autotagging-properties />
-		<prepare-selenium-google-cloud-translation-properties />
 		<prepare-selenium-google-properties />
 		<prepare-selenium-object-storage-salesforce-properties />
 		<prepare-selenium-object-storage-sugarcrm-properties />

--- a/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
+++ b/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
@@ -471,71 +471,7 @@ definition {
 	macro setGoogleCloudTranslationServiceKey() {
 		var wifCredentialsFile = "/root/.gcloud/translate.json";
 
-		var wifCredentialsFileExists = FileUtil.exists(${wifCredentialsFile});
-
-		if (${wifCredentialsFileExists} == "true") {
-			var attributes = FileUtil.read(${wifCredentialsFile});
-
-			return ${attributes};
-		}
-
-		var lineSeparater = "\n";
-		var value1 = PropsUtil.get("google.cloud.translation.service.key.type");
-		var value2 = PropsUtil.get("google.cloud.translation.service.key.project.id");
-		var value3 = PropsUtil.get("google.cloud.translation.service.key.private.key.id");
-		var value5 = PropsUtil.get("google.cloud.translation.service.key.client.email");
-		var value6 = PropsUtil.get("google.cloud.translation.service.key.client.id");
-		var value7 = PropsUtil.get("google.cloud.translation.service.key.auth.uri");
-		var value8 = PropsUtil.get("google.cloud.translation.service.key.token.uri");
-		var value9 = PropsUtil.get("google.cloud.translation.service.key.auth.provider.x509.cert.url");
-		var value10 = PropsUtil.get("google.cloud.translation.service.key.client.x509.cert.url");
-		var keys = PropsUtil.get("google.cloud.translation.service.key.private.key");
-		var list = ListUtil.newList();
-
-		for (var key : list ${keys}) {
-			var value = '''${lineSeparater}${key}''';
-
-			ListUtil.add(${list}, ${value});
-		}
-
-		var value4 = ListUtil.toString(${list}, "");
-
-		var value4 = '''-----BEGIN PRIVATE KEY-----${value4}=${lineSeparater}-----END PRIVATE KEY-----${lineSeparater}''';
-		var attribute1 = '''"type" : "${value1}"''';
-		var attribute2 = '''"project_id" : "${value2}"''';
-		var attribute3 = '''"private_key_id" : "${value3}"''';
-		var attribute4 = '''"private_key" : "${value4}"''';
-		var attribute5 = '''"client_email" : "${value5}"''';
-		var attribute6 = '''"client_id" : "${value6}"''';
-		var attribute7 = '''"auth_uri" : "${value7}"''';
-		var attribute8 = '''"token_uri" : "${value8}"''';
-		var attribute9 = '''"auth_provider_x509_cert_url" : "${value9}"''';
-		var attribute10 = '''"client_x509_cert_url" : "${value10}"''';
-		var list = ListUtil.newList();
-
-		ListUtil.add(${list}, ${attribute1});
-
-		ListUtil.add(${list}, ${attribute2});
-
-		ListUtil.add(${list}, ${attribute3});
-
-		ListUtil.add(${list}, ${attribute4});
-
-		ListUtil.add(${list}, ${attribute5});
-
-		ListUtil.add(${list}, ${attribute6});
-
-		ListUtil.add(${list}, ${attribute7});
-
-		ListUtil.add(${list}, ${attribute8});
-
-		ListUtil.add(${list}, ${attribute9});
-
-		ListUtil.add(${list}, ${attribute10});
-
-		var attributes = ListUtil.toString(${list});
-
-		var attributes = '''{${attributes}}''';
+		var attributes = FileUtil.read(${wifCredentialsFile});
 
 		return ${attributes};
 	}


### PR DESCRIPTION
## Related JIRA

- [LRCI-7754](https://liferay.atlassian.net/browse/LRCI-7754)

## Summary

Workload Identity Federation (`/root/.gcloud/translate.json`) is now the sole credential path on the CI fleet (LPD-87418 and LRCI-7371 closed; LRCI-7699 removed the jenkins-ee plumbing), so the `google.cloud.translation.service.key.*` property path is dead.

This removes the `prepare-selenium-google-cloud-translation-properties` macrodef and its invocation from `build-test.xml`, and collapses `setGoogleCloudTranslationServiceKey()` in `Translations.macro` to read `translate.json` directly. The sole consumer, the `AutoTranslationGoogle` functional test, reached the property fallback only when that file was absent, which never happens on the WIF fleet.
