### PR TITLE
LRCI-7659 Prevent bundle watchers from hanging on remote reads

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -652,8 +652,10 @@ public class JenkinsResultsParserUtil {
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
 
-			httpURLConnection.setConnectTimeout(timeout);
-			httpURLConnection.setReadTimeout(timeout);
+			if (timeout != 0) {
+				httpURLConnection.setConnectTimeout(timeout);
+				httpURLConnection.setReadTimeout(timeout);
+			}
 
 			httpURLConnection.setDoOutput(true);
 			httpURLConnection.setRequestMethod("POST");
@@ -3687,8 +3689,10 @@ public class JenkinsResultsParserUtil {
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
 
-			httpURLConnection.setConnectTimeout(timeout);
-			httpURLConnection.setReadTimeout(timeout);
+			if (timeout != 0) {
+				httpURLConnection.setConnectTimeout(timeout);
+				httpURLConnection.setReadTimeout(timeout);
+			}
 
 			HTTPAuthorization httpAuthorization = getJenkinsHTTPAuthorization();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -620,6 +620,14 @@ public class JenkinsResultsParserUtil {
 	public static String executeJenkinsScript(
 		String jenkinsMasterName, String script, boolean rawResponse) {
 
+		return executeJenkinsScript(
+			jenkinsMasterName, script, rawResponse, _MILLIS_TIMEOUT_DEFAULT);
+	}
+
+	public static String executeJenkinsScript(
+		String jenkinsMasterName, String script, boolean rawResponse,
+		int timeout) {
+
 		Matcher matcher = _test1MasterNamePattern.matcher(jenkinsMasterName);
 
 		try {
@@ -643,6 +651,9 @@ public class JenkinsResultsParserUtil {
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
 
 			httpURLConnection.setDoOutput(true);
 			httpURLConnection.setRequestMethod("POST");
@@ -3636,6 +3647,15 @@ public class JenkinsResultsParserUtil {
 		JenkinsMaster jenkinsMaster, String jenkinsJobName,
 		Map<String, String> buildParameters) {
 
+		return invokeJenkinsBuild(
+			jenkinsMaster, jenkinsJobName, buildParameters,
+			_MILLIS_TIMEOUT_DEFAULT);
+	}
+
+	public static long invokeJenkinsBuild(
+		JenkinsMaster jenkinsMaster, String jenkinsJobName,
+		Map<String, String> buildParameters, int timeout) {
+
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(jenkinsMaster.getRemoteURL());
@@ -3666,6 +3686,9 @@ public class JenkinsResultsParserUtil {
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();
+
+			httpURLConnection.setConnectTimeout(timeout);
+			httpURLConnection.setReadTimeout(timeout);
 
 			HTTPAuthorization httpAuthorization = getJenkinsHTTPAuthorization();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -705,9 +705,9 @@ public class JenkinsResultsParserUtil {
 			return combine(jenkinsMasterName, ":\n", rawResponseText);
 		}
 		catch (IOException ioException) {
-			System.out.println("Unable to execute Jenkins script");
-
-			ioException.printStackTrace();
+			System.out.println(
+				"WARNING: Unable to execute Jenkins script: " +
+					ioException.getMessage());
 		}
 
 		return null;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -52,7 +52,7 @@ public class JenkinsResultsParserUtilTest
 
 	@Test(timeout = 30000)
 	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
-		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+		try (ServerSocket serverSocket = _createServerSocket()) {
 			int port = serverSocket.getLocalPort();
 
 			long startTime = System.currentTimeMillis();
@@ -333,7 +333,7 @@ public class JenkinsResultsParserUtilTest
 
 	@Test(timeout = 30000)
 	public void testInvokeJenkinsBuildReadTimeout() throws Exception {
-		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+		try (ServerSocket serverSocket = _createServerSocket()) {
 			int port = serverSocket.getLocalPort();
 
 			JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
@@ -574,7 +574,7 @@ public class JenkinsResultsParserUtilTest
 		return url.toString();
 	}
 
-	private ServerSocket _createStalledServerSocket() throws Exception {
+	private ServerSocket _createServerSocket() throws Exception {
 		return new ServerSocket(0, 1, InetAddress.getByName("localhost"));
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -7,9 +7,13 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.net.URL;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.json.JSONArray;
@@ -44,6 +48,36 @@ public class JenkinsResultsParserUtilTest
 	@After
 	public void tearDown() {
 		Environment.setInstance(new Environment());
+	}
+
+	@Test(timeout = 30000)
+	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
+		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+			int port = serverSocket.getLocalPort();
+
+			long startTime = System.currentTimeMillis();
+
+			String result = JenkinsResultsParserUtil.executeJenkinsScript(
+				"localhost:" + port, "println 'hello'", true, 2000);
+
+			long duration = System.currentTimeMillis() - startTime;
+
+			if (result != null) {
+				errorCollector.addError(
+					new Throwable(
+						"executeJenkinsScript should return null on a read " +
+							"timeout, but returned: " + result));
+			}
+
+			if (duration < 1500) {
+				errorCollector.addError(
+					new Throwable(
+						JenkinsResultsParserUtil.combine(
+							"executeJenkinsScript returned after ",
+							String.valueOf(duration),
+							" ms; it did not reach the read timeout")));
+			}
+		}
 	}
 
 	@Test
@@ -297,6 +331,52 @@ public class JenkinsResultsParserUtilTest
 				"https://releases.liferay.com/portal/"));
 	}
 
+	@Test(timeout = 30000)
+	public void testInvokeJenkinsBuildReadTimeout() throws Exception {
+		try (ServerSocket serverSocket = _createStalledServerSocket()) {
+			int port = serverSocket.getLocalPort();
+
+			JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+			Mockito.when(
+				jenkinsMaster.getRemoteURL()
+			).thenReturn(
+				"http://localhost:" + port + "/"
+			);
+
+			Map<String, String> buildParameters = new HashMap<>();
+
+			long startTime = System.currentTimeMillis();
+
+			boolean thrown = false;
+
+			try {
+				JenkinsResultsParserUtil.invokeJenkinsBuild(
+					jenkinsMaster, "test-job", buildParameters, 2000);
+			}
+			catch (RuntimeException runtimeException) {
+				thrown = true;
+			}
+
+			long duration = System.currentTimeMillis() - startTime;
+
+			if (!thrown) {
+				errorCollector.addError(
+					new Throwable(
+						"invokeJenkinsBuild should fail on a read timeout"));
+			}
+
+			if (duration < 1500) {
+				errorCollector.addError(
+					new Throwable(
+						JenkinsResultsParserUtil.combine(
+							"invokeJenkinsBuild failed after ",
+							String.valueOf(duration),
+							" ms; it did not reach the read timeout")));
+			}
+		}
+	}
+
 	@Test
 	public void testIsJSONArrayEqual() {
 		JSONArray expectedJSONArray = new JSONArray();
@@ -492,6 +572,10 @@ public class JenkinsResultsParserUtilTest
 		URL url = uri.toURL();
 
 		return url.toString();
+	}
+
+	private ServerSocket _createStalledServerSocket() throws Exception {
+		return new ServerSocket(0, 1, InetAddress.getByName("localhost"));
 	}
 
 	private String _fixURLMultipleTimes(String urlString) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -62,20 +62,15 @@ public class JenkinsResultsParserUtilTest
 
 			long duration = System.currentTimeMillis() - startTime;
 
-			if (result != null) {
-				errorCollector.addError(
-					new Throwable(
-						"executeJenkinsScript should return null on a read " +
-							"timeout, but returned: " + result));
-			}
+			testEquals(null, result);
 
 			if (duration < 1500) {
 				errorCollector.addError(
 					new Throwable(
 						JenkinsResultsParserUtil.combine(
-							"executeJenkinsScript returned after ",
-							String.valueOf(duration),
-							" ms; it did not reach the read timeout")));
+							"The read timeout was not reached after ",
+							JenkinsResultsParserUtil.toDurationString(
+								duration))));
 			}
 		}
 	}
@@ -362,17 +357,16 @@ public class JenkinsResultsParserUtilTest
 
 			if (!thrown) {
 				errorCollector.addError(
-					new Throwable(
-						"invokeJenkinsBuild should fail on a read timeout"));
+					new Throwable("A RuntimeException was not thrown"));
 			}
 
 			if (duration < 1500) {
 				errorCollector.addError(
 					new Throwable(
 						JenkinsResultsParserUtil.combine(
-							"invokeJenkinsBuild failed after ",
-							String.valueOf(duration),
-							" ms; it did not reach the read timeout")));
+							"The read timeout was not reached after ",
+							JenkinsResultsParserUtil.toDurationString(
+								duration))));
 			}
 		}
 	}


### PR DESCRIPTION
[LRCI-7659](https://liferay.atlassian.net/browse/LRCI-7659)

Adds connect and read timeouts to the bundle watcher's remote calls (`executeJenkinsScript` for queue-item resolution and `invokeJenkinsBuild` for dispatch) so a stalled Jenkins response surfaces as a `SocketTimeoutException` and returns control to the poll loop instead of hanging the watcher indefinitely. A failed script execution now logs a `WARNING:` line matching the existing convention.
