### PR TITLE
LRCI-7766 Fix RelevantTestSuiteTest engine init broken by as-used sort (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
@@ -33,6 +33,8 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 
 	@Test
 	public void testJUnitTestSelectorMerge() throws IOException {
+		getRelevantRuleEngine();
+
 		RelevantTestSuite relevantTestSuite = new RelevantTestSuite(
 			getPortalAcceptancePullRequestJob());
 
@@ -40,11 +42,6 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 			Arrays.asList(
 				new File(getBaseDir(), "text_file_0.txt"),
 				new File(getBaseDir(), "modules/module-1/text_file_1.txt")));
-
-		RelevantRuleEngine relevantRuleEngine =
-			RelevantRuleEngine.getInstance();
-
-		relevantRuleEngine.setBaseDir(getBaseDir());
 
 		JUnitTestBatch jUnitTestBatch = null;
 
@@ -81,6 +78,8 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 
 	@Test
 	public void testPlaywrightTestSelectorMerge() {
+		getRelevantRuleEngine();
+
 		RelevantTestSuite relevantTestSuite = new RelevantTestSuite(
 			getPortalAcceptancePullRequestJob());
 
@@ -88,11 +87,6 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 			Arrays.asList(
 				new File(getBaseDir(), "modules/module-1/text_file_1.txt"),
 				new File(getBaseDir(), "modules/module-2/text_file_2.txt")));
-
-		RelevantRuleEngine relevantRuleEngine =
-			RelevantRuleEngine.getInstance();
-
-		relevantRuleEngine.setBaseDir(getBaseDir());
 
 		PlaywrightTestBatch playwrightTestBatch = null;
 
@@ -125,6 +119,8 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 
 	@Test
 	public void testPoshiTestSelectorMerge() throws IOException {
+		getRelevantRuleEngine();
+
 		RelevantTestSuite relevantTestSuite = new RelevantTestSuite(
 			getPortalAcceptancePullRequestJob());
 
@@ -132,11 +128,6 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 			Arrays.asList(
 				new File(getBaseDir(), "test.properties"),
 				new File(getBaseDir(), "modules/module-2/text_file_2.txt")));
-
-		RelevantRuleEngine relevantRuleEngine =
-			RelevantRuleEngine.getInstance();
-
-		relevantRuleEngine.setBaseDir(getBaseDir());
 
 		PoshiTestBatch poshiTestBatch = null;
 
@@ -163,10 +154,7 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 
 	@Test
 	public void testStableRuleBatchBypassesWhitelist() {
-		RelevantRuleEngine relevantRuleEngine = RelevantRuleEngine.getInstance(
-			getPortalAcceptancePullRequestJob());
-
-		relevantRuleEngine.setBaseDir(getBaseDir());
+		getRelevantRuleEngine();
 
 		RelevantTestSuite relevantTestSuite = new RelevantTestSuite(
 			getPortalAcceptancePullRequestJob());

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/test/suite/RelevantTestSuiteTest.java
@@ -163,18 +163,18 @@ public class RelevantTestSuiteTest extends BaseRelevantRuleTestCase {
 
 	@Test
 	public void testStableRuleBatchBypassesWhitelist() {
-		RelevantRuleEngine relevantRuleEngine =
-			RelevantRuleEngine.getInstance();
+		RelevantRuleEngine relevantRuleEngine = RelevantRuleEngine.getInstance(
+			getPortalAcceptancePullRequestJob());
 
 		relevantRuleEngine.setBaseDir(getBaseDir());
-
-		Set<String> batchNames = new HashSet<>();
 
 		RelevantTestSuite relevantTestSuite = new RelevantTestSuite(
 			getPortalAcceptancePullRequestJob());
 
 		relevantTestSuite.setModifiedFiles(
 			Arrays.asList(new File(getBaseDir(), "stable/trigger.txt")));
+
+		Set<String> batchNames = new HashSet<>();
 
 		for (TestBatch testBatch : relevantTestSuite.getTestBatches(false)) {
 			batchNames.add(testBatch.getName());


### PR DESCRIPTION
[LRCI-7766](https://liferay.atlassian.net/browse/LRCI-7766)

Revises [#4394](https://github.com/pyoo47/liferay-portal/pull/4394) (opened by @liferay-continuous-integration) with the following follow-up commits:

- [327103164f97](https://github.com/pyoo47/liferay-portal/commit/327103164f9731c46f8a9cb5d4b0d61b653721bf) LRCI-7766 Consistency
