### PR TITLE
LRCI-7745 Connect as sys for Oracle upgrade import; raise batch RAM

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6633,7 +6633,7 @@ ${custom.upgrade.properties}</echo>
 											<os family="windows" />
 											<then>
 												<exec executable="${oracle.sqlplus.executable}" failonerror="true">
-													<arg value="${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+													<arg value="sys/${oracle.admin.password} as sysdba" />
 													<arg value="@create.sql" />
 													<arg value="${database.username}" />
 													<arg value="${database.password}" />
@@ -15810,7 +15810,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									sqlplus /nolog <<-'EOF'
 									whenever sqlerror exit failure
-									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
+									connect sys/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -15997,7 +15997,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					<elseif>
 						<equals arg1="${database.type}" arg2="oracle" />
 						<then>
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;whenever sqlerror continue&#10;set heading off&#10;set feedback off&#10;set pagesize 0&#10;set linesize 1000&#10;set trimspool on&#10;drop user lportal cascade;&#10;select directory_name || ',' || directory_path from dba_directories where directory_name='DATA_PUMP_DIR';&#10;exit&#10;" output="data.pump.log">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;whenever sqlerror continue&#10;set heading off&#10;set feedback off&#10;set pagesize 0&#10;set linesize 1000&#10;set trimspool on&#10;drop user lportal cascade;&#10;select directory_name || ',' || directory_path from dba_directories where directory_name='DATA_PUMP_DIR';&#10;exit&#10;" output="data.pump.log">
 								<arg value="/nolog" />
 							</exec>
 
@@ -16028,7 +16028,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 

--- a/test.properties
+++ b/test.properties
@@ -1645,6 +1645,7 @@
 
     test.batch.max.subgroup.size=5
 
+    test.batch.minimum.slave.ram[functional-upgrade-tomcat101-oracle193]=24
     test.batch.minimum.slave.ram[js-unit]=24
     test.batch.minimum.slave.ram[modules-integration*]=24
     test.batch.minimum.slave.ram[portal-license-smoke-mysql84]=24


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7745

**What is being fixed:** The functional-upgrade-tomcat101-oracle193 batch was failing on the Oracle 19.3 upgrade path. The upgrade DB import performed its privileged `as sysdba` operations using the configured admin (SYSTEM) account rather than SYS, and the batch was being scheduled onto slaves without enough RAM, so Oracle + Tomcat + Chrome + Elasticsearch exhausted memory mid-upgrade and the node died.

**How it is being fixed:** In build-test.xml, the Oracle `as sysdba` connections used during the upgrade DB import (create user, privilege grants, and the data-pump drop/import) now connect as `sys` instead of `${oracle.admin.user}`. In test.properties, functional-upgrade-tomcat101-oracle193 is given a minimum slave RAM of 24 GB so it is scheduled onto a node with enough headroom.

Tested here: https://test-1-45.liferay.com/userContent/jobs/test-portal-acceptance-pullrequest%28master%29/builds/1570/jenkins-report.html
