### PR TITLE
LRCI-7786 Cache OP Connect reads from the mirrors shared drive

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -10,12 +10,16 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthoriza
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,10 +34,6 @@ import org.json.JSONObject;
 public abstract class SecretsUtil {
 
 	public static String getSecret(String key) {
-		if (!_isSecretsConfigured()) {
-			return key;
-		}
-
 		Matcher matcher = _secretReferencePattern.matcher(key);
 
 		if (matcher.matches()) {
@@ -52,46 +52,15 @@ public abstract class SecretsUtil {
 	public static String getSecret(
 		String vaultName, String itemTitle, String fieldLabel) {
 
-		if (!_isSecretsConfigured()) {
-			return null;
-		}
-
-		Vault vault = Vault.getInstance(vaultName);
-
-		if (vault == null) {
-			System.out.println("Vault Not Found: " + vaultName);
-
-			return null;
-		}
-
-		Item item = vault.getItem(itemTitle);
-
-		if (item == null) {
-			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"Item Not Found: ", vaultName, "/", itemTitle));
-
-			return null;
-		}
-
-		ItemField itemField = item.getItemField(fieldLabel);
-
-		if (itemField != null) {
-			return itemField.getValue();
-		}
-
-		ItemFile itemFile = item.getItemFile(fieldLabel);
-
-		if (itemFile != null) {
-			return itemFile.getValue();
-		}
-
-		System.out.println(
+		String cachedSecret = _getCachedSecret(
 			JenkinsResultsParserUtil.combine(
-				"Field Not Found: op://", vaultName, "/", itemTitle, "/",
-				fieldLabel));
+				"op://", vaultName, "/", itemTitle, "/", fieldLabel));
 
-		return null;
+		if (cachedSecret != null) {
+			return cachedSecret;
+		}
+
+		return _getSecretFromConnect(vaultName, itemTitle, fieldLabel);
 	}
 
 	public static boolean isSecretProperty(String value) {
@@ -102,6 +71,48 @@ public abstract class SecretsUtil {
 		Matcher matcher = _secretReferencePattern.matcher(value);
 
 		return matcher.matches();
+	}
+
+	public static void writeSecretsCache(
+			File cacheFile, File propertiesRootDirectory)
+		throws IOException {
+
+		if (!_isSecretsConfigured()) {
+			System.out.println(
+				"Secrets are not configured, unable to write 1Password cache");
+
+			return;
+		}
+
+		JSONObject jsonObject = new JSONObject();
+
+		for (String secretKey :
+				_getReferencedSecretKeys(propertiesRootDirectory)) {
+
+			Matcher matcher = _secretReferencePattern.matcher(secretKey);
+
+			if (!matcher.matches()) {
+				continue;
+			}
+
+			String secret = _getSecretFromConnect(
+				matcher.group("vaultName"), matcher.group("itemTitle"),
+				matcher.group("fieldLabel"));
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
+				jsonObject.put(secretKey, secret);
+			}
+			else {
+				System.out.println("Unable to resolve secret: " + secretKey);
+			}
+		}
+
+		JenkinsResultsParserUtil.write(cacheFile, jsonObject.toString());
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Wrote ", String.valueOf(jsonObject.length()), " secrets to ",
+				cacheFile.toString()));
 	}
 
 	private static synchronized String _getAccessToken() {
@@ -147,12 +158,59 @@ public abstract class SecretsUtil {
 		return _accessToken;
 	}
 
+	private static synchronized String _getCachedSecret(String key) {
+		if (!_cachedSecretsLoaded) {
+			_loadCachedSecrets();
+		}
+
+		if (_cachedSecrets == null) {
+			return null;
+		}
+
+		return _cachedSecrets.get(key);
+	}
+
 	private static synchronized String _getConnectURL() {
 		if (_connectURL != null) {
 			return _connectURL;
 		}
 
 		String connectURL;
+
+		try {
+			String connectURLToken = JenkinsResultsParserUtil.getBuildProperty(
+				"one.password.connect.url.key");
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(connectURLToken)) {
+				Process process = JenkinsResultsParserUtil.executeBashCommands(
+					new File("."), true, false, 60000,
+					JenkinsResultsParserUtil.combine(
+						"aws ssm get-parameter --name \"", connectURLToken,
+						"\" --with-decryption | jq -r .Parameter.Value"));
+
+				connectURL = JenkinsResultsParserUtil.readInputStream(
+					process.getInputStream());
+
+				connectURL = connectURL.replace(
+					"Finished executing Bash commands.", "");
+
+				connectURL = connectURL.trim();
+			}
+			else {
+				connectURL = "";
+			}
+		}
+		catch (IOException | TimeoutException exception) {
+			connectURL = "";
+		}
+
+		if (JenkinsResultsParserUtil.isURL(connectURL)) {
+			JenkinsResultsParserUtil.addRedactToken(connectURL);
+
+			_connectURL = connectURL;
+
+			return _connectURL;
+		}
 
 		try {
 			connectURL = JenkinsResultsParserUtil.getBuildProperty(
@@ -187,6 +245,196 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
+	private static Set<String> _getReferencedSecretKeys(
+		File propertiesRootDirectory) {
+
+		Set<String> secretKeys = new TreeSet<>();
+
+		List<File> propertiesFiles = JenkinsResultsParserUtil.findFiles(
+			propertiesRootDirectory, ".*\\.properties");
+
+		for (File propertiesFile : propertiesFiles) {
+			Properties properties = new Properties();
+
+			try {
+				String content = JenkinsResultsParserUtil.read(propertiesFile);
+
+				if (!JenkinsResultsParserUtil.isNullOrEmpty(content)) {
+					properties.load(new StringReader(content));
+				}
+			}
+			catch (IOException ioException) {
+				continue;
+			}
+
+			for (String propertyName : properties.stringPropertyNames()) {
+				String value = properties.getProperty(propertyName);
+
+				if (isSecretProperty(value)) {
+					secretKeys.add(value);
+				}
+			}
+		}
+
+		return secretKeys;
+	}
+
+	private static String _getSecretFromConnect(
+		String vaultName, String itemTitle, String fieldLabel) {
+
+		if (!_isSecretsConfigured()) {
+			return null;
+		}
+
+		Vault vault = Vault.getInstance(vaultName);
+
+		if (vault == null) {
+			System.out.println("Vault Not Found: " + vaultName);
+
+			return null;
+		}
+
+		Item item = vault.getItem(itemTitle);
+
+		if (item == null) {
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"Item Not Found: ", vaultName, "/", itemTitle));
+
+			return null;
+		}
+
+		int secretRetriesMax = _getSecretRetriesMax();
+
+		for (int i = 0; i <= secretRetriesMax; i++) {
+			if (i > 0) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"Retrying op://", vaultName, "/", itemTitle, "/",
+						fieldLabel, " (attempt ", String.valueOf(i + 1), " of ",
+						String.valueOf(secretRetriesMax + 1), ")"));
+
+				JenkinsResultsParserUtil.sleep(
+					_getSecretRetryPeriodSeconds() * 1000L);
+
+				item.refresh();
+			}
+
+			try {
+				ItemField itemField = item.getItemField(fieldLabel);
+
+				if (itemField != null) {
+					String value = itemField.getValue();
+
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+						return value;
+					}
+				}
+
+				ItemFile itemFile = item.getItemFile(fieldLabel);
+
+				if (itemFile != null) {
+					String value = itemFile.getValue();
+
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+						return value;
+					}
+				}
+			}
+			catch (Exception exception) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"Unable to resolve op://", vaultName, "/", itemTitle,
+						"/", fieldLabel, ": ", exception.getMessage()));
+			}
+		}
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Field Not Found: op://", vaultName, "/", itemTitle, "/",
+				fieldLabel));
+
+		return null;
+	}
+
+	private static synchronized int _getSecretRetriesMax() {
+		if (_secretRetriesMax != null) {
+			return _secretRetriesMax;
+		}
+
+		int secretRetriesMax;
+
+		try {
+			String value = JenkinsResultsParserUtil.getBuildProperty(
+				"one.password.secret.retries.max");
+
+			if (JenkinsResultsParserUtil.isInteger(value)) {
+				secretRetriesMax = Integer.parseInt(value);
+			}
+			else {
+				secretRetriesMax = _SECRET_RETRIES_MAX_DEFAULT;
+			}
+		}
+		catch (IOException | NumberFormatException exception) {
+			secretRetriesMax = _SECRET_RETRIES_MAX_DEFAULT;
+		}
+
+		_secretRetriesMax = secretRetriesMax;
+
+		return _secretRetriesMax;
+	}
+
+	private static synchronized long _getSecretRetryPeriodSeconds() {
+		if (_secretRetryPeriodSeconds != null) {
+			return _secretRetryPeriodSeconds;
+		}
+
+		long secretRetryPeriodSeconds;
+
+		try {
+			String value = JenkinsResultsParserUtil.getBuildProperty(
+				"one.password.secret.retry.period.seconds");
+
+			if (JenkinsResultsParserUtil.isInteger(value)) {
+				secretRetryPeriodSeconds = Long.parseLong(value);
+			}
+			else {
+				secretRetryPeriodSeconds = _SECRET_RETRY_PERIOD_SECONDS_DEFAULT;
+			}
+		}
+		catch (IOException | NumberFormatException exception) {
+			secretRetryPeriodSeconds = _SECRET_RETRY_PERIOD_SECONDS_DEFAULT;
+		}
+
+		_secretRetryPeriodSeconds = secretRetryPeriodSeconds;
+
+		return _secretRetryPeriodSeconds;
+	}
+
+	private static synchronized String _getSecretsCacheURL() {
+		if (_secretsCacheURL != null) {
+			return _secretsCacheURL;
+		}
+
+		String secretsCacheURL;
+
+		try {
+			secretsCacheURL = JenkinsResultsParserUtil.getBuildProperty(
+				"one.password.cache.url");
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(secretsCacheURL)) {
+				secretsCacheURL = "";
+			}
+		}
+		catch (IOException ioException) {
+			secretsCacheURL = "";
+		}
+
+		_secretsCacheURL = secretsCacheURL;
+
+		return _secretsCacheURL;
+	}
+
 	private static boolean _isSecretsConfigured() {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(_getAccessToken()) ||
 			JenkinsResultsParserUtil.isNullOrEmpty(_getConnectURL())) {
@@ -195,6 +443,60 @@ public abstract class SecretsUtil {
 		}
 
 		return true;
+	}
+
+	private static synchronized void _loadCachedSecrets() {
+		_cachedSecretsLoaded = true;
+
+		String secretsCacheURL = _getSecretsCacheURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(secretsCacheURL)) {
+			return;
+		}
+
+		try {
+			String content;
+
+			String fileSuffix = "file://";
+
+			if (secretsCacheURL.startsWith(fileSuffix)) {
+				File file = new File(
+					secretsCacheURL.substring(fileSuffix.length()));
+
+				if (!file.exists()) {
+					return;
+				}
+
+				content = JenkinsResultsParserUtil.read(file);
+			}
+			else {
+				content = JenkinsResultsParserUtil.toString(
+					secretsCacheURL, false);
+			}
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(content)) {
+				return;
+			}
+
+			JSONObject jsonObject = new JSONObject(content);
+
+			_cachedSecrets = new HashMap<>();
+
+			for (String key : jsonObject.keySet()) {
+				String value = jsonObject.getString(key);
+
+				if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+					continue;
+				}
+
+				_cachedSecrets.put(key, value);
+
+				JenkinsResultsParserUtil.addRedactToken(value);
+			}
+		}
+		catch (Exception exception) {
+			_cachedSecrets = null;
+		}
 	}
 
 	private static JSONArray _toJSONArray(String path) {
@@ -251,11 +553,20 @@ public abstract class SecretsUtil {
 		}
 	}
 
+	private static final int _SECRET_RETRIES_MAX_DEFAULT = 3;
+
+	private static final long _SECRET_RETRY_PERIOD_SECONDS_DEFAULT = 5;
+
 	private static String _accessToken;
+	private static Map<String, String> _cachedSecrets;
+	private static boolean _cachedSecretsLoaded;
 	private static String _connectURL;
 	private static BearerHTTPAuthorization _httpAuthorization;
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
+	private static Integer _secretRetriesMax;
+	private static Long _secretRetryPeriodSeconds;
+	private static String _secretsCacheURL;
 
 	private static class Item {
 
@@ -307,6 +618,14 @@ public abstract class SecretsUtil {
 
 		public String getTitle() {
 			return _title;
+		}
+
+		public void refresh() {
+			synchronized (_vault) {
+				_itemFields = null;
+				_itemFiles = null;
+				_linkedItem = null;
+			}
 		}
 
 		private Item(String id, String title, Vault vault) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -457,11 +457,11 @@ public abstract class SecretsUtil {
 		try {
 			String content;
 
-			String fileSuffix = "file://";
+			String filePrefix = "file://";
 
-			if (secretsCacheURL.startsWith(fileSuffix)) {
+			if (secretsCacheURL.startsWith(filePrefix)) {
 				File file = new File(
-					secretsCacheURL.substring(fileSuffix.length()));
+					secretsCacheURL.substring(filePrefix.length()));
 
 				if (!file.exists()) {
 					return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -263,7 +263,7 @@ public abstract class SecretsUtil {
 					properties.load(new StringReader(content));
 				}
 			}
-			catch (IOException ioException) {
+			catch (IllegalArgumentException | IOException exception) {
 				continue;
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -178,14 +178,14 @@ public abstract class SecretsUtil {
 		String connectURL;
 
 		try {
-			String connectURLToken = JenkinsResultsParserUtil.getBuildProperty(
+			String connectURLKey = JenkinsResultsParserUtil.getBuildProperty(
 				"one.password.connect.url.key");
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(connectURLToken)) {
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(connectURLKey)) {
 				Process process = JenkinsResultsParserUtil.executeBashCommands(
 					new File("."), true, false, 60000,
 					JenkinsResultsParserUtil.combine(
-						"aws ssm get-parameter --name \"", connectURLToken,
+						"aws ssm get-parameter --name \"", connectURLKey,
 						"\" --with-decryption | jq -r .Parameter.Value"));
 
 				connectURL = JenkinsResultsParserUtil.readInputStream(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -12,7 +12,18 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 
+import java.nio.charset.StandardCharsets;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +34,12 @@ import java.util.TreeSet;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -53,8 +70,7 @@ public abstract class SecretsUtil {
 		String vaultName, String itemTitle, String fieldLabel) {
 
 		String cachedSecret = _getCachedSecret(
-			JenkinsResultsParserUtil.combine(
-				"op://", vaultName, "/", itemTitle, "/", fieldLabel));
+			_getSecretReference(vaultName, itemTitle, fieldLabel));
 
 		if (cachedSecret != null) {
 			return cachedSecret;
@@ -73,8 +89,8 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
-	public static void writeSecretsCache(
-			File cacheFile, File propertiesRootDirectory)
+	public static void writeCachedSecrets(
+			File cachedSecretsFile, File rootDirectory)
 		throws IOException {
 
 		if (!_isSecretsConfigured()) {
@@ -84,11 +100,19 @@ public abstract class SecretsUtil {
 			return;
 		}
 
+		PublicKey cachedSecretsPublicKey = _getCachedSecretsPublicKey();
+
+		if (cachedSecretsPublicKey == null) {
+			System.out.println(
+				"Cached secrets public key is not configured, unable to " +
+					"write encrypted 1Password cache");
+
+			return;
+		}
+
 		JSONObject jsonObject = new JSONObject();
 
-		for (String secretKey :
-				_getReferencedSecretKeys(propertiesRootDirectory)) {
-
+		for (String secretKey : _getReferencedSecretKeys(rootDirectory)) {
 			Matcher matcher = _secretReferencePattern.matcher(secretKey);
 
 			if (!matcher.matches()) {
@@ -107,12 +131,126 @@ public abstract class SecretsUtil {
 			}
 		}
 
-		JenkinsResultsParserUtil.write(cacheFile, jsonObject.toString());
+		String encryptedCache;
+
+		try {
+			encryptedCache = _encrypt(
+				jsonObject.toString(), cachedSecretsPublicKey);
+		}
+		catch (GeneralSecurityException generalSecurityException) {
+			throw new IOException(
+				"Unable to encrypt 1Password cache", generalSecurityException);
+		}
+
+		JenkinsResultsParserUtil.write(cachedSecretsFile, encryptedCache);
 
 		System.out.println(
 			JenkinsResultsParserUtil.combine(
-				"Wrote ", String.valueOf(jsonObject.length()), " secrets to ",
-				cacheFile.toString()));
+				"Wrote ", String.valueOf(jsonObject.length()),
+				" encrypted secrets to ", cachedSecretsFile.toString()));
+	}
+
+	private static byte[] _convertPEMToDER(String pem) {
+		String base64 = pem.replaceAll("-----BEGIN [^-]+-----", "");
+
+		base64 = base64.replaceAll("-----END [^-]+-----", "");
+
+		base64 = base64.replaceAll("\\s", "");
+
+		Base64.Decoder decoder = Base64.getDecoder();
+
+		return decoder.decode(base64);
+	}
+
+	private static String _decrypt(String content, PrivateKey privateKey)
+		throws GeneralSecurityException {
+
+		JSONObject envelopeJSONObject;
+
+		try {
+			envelopeJSONObject = new JSONObject(content);
+		}
+		catch (JSONException jsonException) {
+			return null;
+		}
+
+		if (!envelopeJSONObject.has("cipherText") ||
+			!envelopeJSONObject.has("encryptedKey") ||
+			!envelopeJSONObject.has("iv")) {
+
+			return null;
+		}
+
+		Base64.Decoder decoder = Base64.getDecoder();
+
+		Cipher rsaCipher = Cipher.getInstance(
+			"RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
+
+		rsaCipher.init(Cipher.DECRYPT_MODE, privateKey);
+
+		SecretKey secretKey = new SecretKeySpec(
+			rsaCipher.doFinal(
+				decoder.decode(envelopeJSONObject.getString("encryptedKey"))),
+			"AES");
+
+		byte[] iv = decoder.decode(envelopeJSONObject.getString("iv"));
+
+		Cipher aesCipher = Cipher.getInstance("AES/GCM/NoPadding");
+
+		aesCipher.init(
+			Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, iv));
+
+		byte[] plainText = aesCipher.doFinal(
+			decoder.decode(envelopeJSONObject.getString("cipherText")));
+
+		return new String(plainText, StandardCharsets.UTF_8);
+	}
+
+	private static String _encrypt(String plainText, PublicKey publicKey)
+		throws GeneralSecurityException {
+
+		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+
+		keyGenerator.init(256);
+
+		SecretKey secretKey = keyGenerator.generateKey();
+
+		byte[] iv = new byte[12];
+
+		SecureRandom secureRandom = new SecureRandom();
+
+		secureRandom.nextBytes(iv);
+
+		Cipher aesCipher = Cipher.getInstance("AES/GCM/NoPadding");
+
+		aesCipher.init(
+			Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(128, iv));
+
+		byte[] cipherText = aesCipher.doFinal(
+			plainText.getBytes(StandardCharsets.UTF_8));
+
+		Cipher rsaCipher = Cipher.getInstance(
+			"RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
+
+		rsaCipher.init(Cipher.ENCRYPT_MODE, publicKey);
+
+		byte[] encryptedKey = rsaCipher.doFinal(secretKey.getEncoded());
+
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		JSONObject envelopeJSONObject = new JSONObject();
+
+		envelopeJSONObject.put(
+			"cipher", _CACHE_CIPHER
+		).put(
+			"cipherText", encoder.encodeToString(cipherText)
+		).put(
+			"encryptedKey", encoder.encodeToString(encryptedKey)
+		).put(
+			"iv", encoder.encodeToString(iv)
+		);
+
+		return envelopeJSONObject.toString();
 	}
 
 	private static synchronized String _getAccessToken() {
@@ -127,19 +265,7 @@ public abstract class SecretsUtil {
 				"one.password.access.token.key");
 
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(accessTokenKey)) {
-				Process process = JenkinsResultsParserUtil.executeBashCommands(
-					new File("."), true, false, 60000,
-					JenkinsResultsParserUtil.combine(
-						"aws ssm get-parameter --name \"", accessTokenKey,
-						"\" --with-decryption | jq -r .Parameter.Value"));
-
-				accessToken = JenkinsResultsParserUtil.readInputStream(
-					process.getInputStream());
-
-				accessToken = accessToken.replace(
-					"Finished executing Bash commands.", "");
-
-				accessToken = accessToken.trim();
+				accessToken = _getSSMParameterValue(accessTokenKey);
 			}
 			else {
 				accessToken = "";
@@ -170,6 +296,211 @@ public abstract class SecretsUtil {
 		return _cachedSecrets.get(key);
 	}
 
+	private static synchronized String _getCachedSecretsContent()
+		throws IOException {
+
+		if (_cachedSecretsContent != null) {
+			return _cachedSecretsContent;
+		}
+
+		String cachedSecretsURL = _getCachedSecretsURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsURL)) {
+			_cachedSecretsContent = "";
+
+			return _cachedSecretsContent;
+		}
+
+		if (JenkinsResultsParserUtil.isURL(cachedSecretsURL)) {
+			_cachedSecretsContent = JenkinsResultsParserUtil.toString(
+				cachedSecretsURL, false);
+
+			return _cachedSecretsContent;
+		}
+
+		String filePrefix = "file://";
+
+		if (!cachedSecretsURL.startsWith(filePrefix)) {
+			_cachedSecretsContent = "";
+
+			return _cachedSecretsContent;
+		}
+
+		File file = new File(cachedSecretsURL.substring(filePrefix.length()));
+
+		if (!file.exists()) {
+			_cachedSecretsContent = "";
+
+			return _cachedSecretsContent;
+		}
+
+		_cachedSecretsContent = JenkinsResultsParserUtil.read(file);
+
+		return _cachedSecretsContent;
+	}
+
+	private static synchronized PrivateKey _getCachedSecretsPrivateKey() {
+		if (_cachedSecretsPrivateKeyInitialized) {
+			return _cachedSecretsPrivateKey;
+		}
+
+		_cachedSecretsPrivateKeyInitialized = true;
+
+		String cachedSecretsPrivateKeyPEM = _getCachedSecretsPrivateKeyPEM();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(
+				cachedSecretsPrivateKeyPEM)) {
+
+			return null;
+		}
+
+		try {
+			KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+
+			_cachedSecretsPrivateKey = keyFactory.generatePrivate(
+				new PKCS8EncodedKeySpec(
+					_convertPEMToDER(cachedSecretsPrivateKeyPEM)));
+		}
+		catch (GeneralSecurityException generalSecurityException) {
+			System.out.println(
+				"Unable to parse cache private key " +
+					generalSecurityException.getMessage());
+
+			_cachedSecretsPrivateKey = null;
+		}
+
+		return _cachedSecretsPrivateKey;
+	}
+
+	private static synchronized String _getCachedSecretsPrivateKeyPEM() {
+		if (_cachedSecretsPrivateKeyPEM != null) {
+			return _cachedSecretsPrivateKeyPEM;
+		}
+
+		String cachedSecretsPrivateKeyPEM;
+
+		try {
+			String cachedSecretsPrivateKeyPEMKey =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"one.password.cached.secrets.private.key.pem.key");
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(
+					cachedSecretsPrivateKeyPEMKey)) {
+
+				cachedSecretsPrivateKeyPEM = _getSSMParameterValue(
+					cachedSecretsPrivateKeyPEMKey);
+			}
+			else {
+				cachedSecretsPrivateKeyPEM = "";
+			}
+		}
+		catch (IOException | TimeoutException exception) {
+			cachedSecretsPrivateKeyPEM = "";
+		}
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				cachedSecretsPrivateKeyPEM)) {
+
+			JenkinsResultsParserUtil.addRedactToken(cachedSecretsPrivateKeyPEM);
+		}
+
+		_cachedSecretsPrivateKeyPEM = cachedSecretsPrivateKeyPEM;
+
+		return _cachedSecretsPrivateKeyPEM;
+	}
+
+	private static synchronized PublicKey _getCachedSecretsPublicKey() {
+		if (_cachedSecretsPublicKeyInitialized) {
+			return _cachedSecretsPublicKey;
+		}
+
+		_cachedSecretsPublicKeyInitialized = true;
+
+		String cachedSecretsPublicKeyPEM = _getCachedSecretsPublicKeyPEM();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsPublicKeyPEM)) {
+			return null;
+		}
+
+		try {
+			KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+
+			_cachedSecretsPublicKey = keyFactory.generatePublic(
+				new X509EncodedKeySpec(
+					_convertPEMToDER(cachedSecretsPublicKeyPEM)));
+		}
+		catch (GeneralSecurityException generalSecurityException) {
+			System.out.println(
+				"Unable to parse cache public key " +
+					generalSecurityException.getMessage());
+
+			_cachedSecretsPublicKey = null;
+		}
+
+		return _cachedSecretsPublicKey;
+	}
+
+	private static synchronized String _getCachedSecretsPublicKeyPEM() {
+		if (_cachedSecretsPublicKeyPEM != null) {
+			return _cachedSecretsPublicKeyPEM;
+		}
+
+		String cachedSecretsPublicKeyPEM;
+
+		try {
+			String cachedSecretsPublicKeyPEMKey =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"one.password.cached.secrets.public.key.pem.key");
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(
+					cachedSecretsPublicKeyPEMKey)) {
+
+				cachedSecretsPublicKeyPEM = _getSSMParameterValue(
+					cachedSecretsPublicKeyPEMKey);
+			}
+			else {
+				cachedSecretsPublicKeyPEM = "";
+			}
+		}
+		catch (IOException | TimeoutException exception) {
+			cachedSecretsPublicKeyPEM = "";
+		}
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				cachedSecretsPublicKeyPEM)) {
+
+			JenkinsResultsParserUtil.addRedactToken(cachedSecretsPublicKeyPEM);
+		}
+
+		_cachedSecretsPublicKeyPEM = cachedSecretsPublicKeyPEM;
+
+		return _cachedSecretsPublicKeyPEM;
+	}
+
+	private static synchronized String _getCachedSecretsURL() {
+		if (_cachedSecretsURL != null) {
+			return _cachedSecretsURL;
+		}
+
+		String cachedSecretsURL;
+
+		try {
+			cachedSecretsURL = JenkinsResultsParserUtil.getBuildProperty(
+				"one.password.cached.secrets.url");
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsURL)) {
+				cachedSecretsURL = "";
+			}
+		}
+		catch (IOException ioException) {
+			cachedSecretsURL = "";
+		}
+
+		_cachedSecretsURL = cachedSecretsURL;
+
+		return _cachedSecretsURL;
+	}
+
 	private static synchronized String _getConnectURL() {
 		if (_connectURL != null) {
 			return _connectURL;
@@ -182,19 +513,7 @@ public abstract class SecretsUtil {
 				"one.password.connect.url.key");
 
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(connectURLKey)) {
-				Process process = JenkinsResultsParserUtil.executeBashCommands(
-					new File("."), true, false, 60000,
-					JenkinsResultsParserUtil.combine(
-						"aws ssm get-parameter --name \"", connectURLKey,
-						"\" --with-decryption | jq -r .Parameter.Value"));
-
-				connectURL = JenkinsResultsParserUtil.readInputStream(
-					process.getInputStream());
-
-				connectURL = connectURL.replace(
-					"Finished executing Bash commands.", "");
-
-				connectURL = connectURL.trim();
+				connectURL = _getSSMParameterValue(connectURLKey);
 			}
 			else {
 				connectURL = "";
@@ -245,13 +564,11 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
-	private static Set<String> _getReferencedSecretKeys(
-		File propertiesRootDirectory) {
-
+	private static Set<String> _getReferencedSecretKeys(File rootDirectory) {
 		Set<String> secretKeys = new TreeSet<>();
 
 		List<File> propertiesFiles = JenkinsResultsParserUtil.findFiles(
-			propertiesRootDirectory, ".*\\.properties");
+			rootDirectory, ".*\\.properties");
 
 		for (File propertiesFile : propertiesFiles) {
 			Properties properties = new Properties();
@@ -289,7 +606,7 @@ public abstract class SecretsUtil {
 		Vault vault = Vault.getInstance(vaultName);
 
 		if (vault == null) {
-			System.out.println("Vault Not Found: " + vaultName);
+			System.out.println("Unable to find vault " + vaultName);
 
 			return null;
 		}
@@ -299,21 +616,22 @@ public abstract class SecretsUtil {
 		if (item == null) {
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
-					"Item Not Found: ", vaultName, "/", itemTitle));
+					"Unable to find item ", vaultName, "/", itemTitle));
 
 			return null;
+		}
+
+		String secretReference = _getSecretReference(
+			vaultName, itemTitle, fieldLabel);
+
+		if (_secrets.containsKey(secretReference)) {
+			return _secrets.get(secretReference);
 		}
 
 		int secretRetriesMax = _getSecretRetriesMax();
 
 		for (int i = 0; i <= secretRetriesMax; i++) {
 			if (i > 0) {
-				System.out.println(
-					JenkinsResultsParserUtil.combine(
-						"Retrying op://", vaultName, "/", itemTitle, "/",
-						fieldLabel, " (attempt ", String.valueOf(i + 1), " of ",
-						String.valueOf(secretRetriesMax + 1), ")"));
-
 				JenkinsResultsParserUtil.sleep(
 					_getSecretRetryPeriodSeconds() * 1000L);
 
@@ -327,6 +645,8 @@ public abstract class SecretsUtil {
 					String value = itemField.getValue();
 
 					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+						_secrets.put(secretReference, value);
+
 						return value;
 					}
 				}
@@ -337,24 +657,24 @@ public abstract class SecretsUtil {
 					String value = itemFile.getValue();
 
 					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+						_secrets.put(secretReference, value);
+
 						return value;
 					}
 				}
 			}
 			catch (Exception exception) {
-				System.out.println(
-					JenkinsResultsParserUtil.combine(
-						"Unable to resolve op://", vaultName, "/", itemTitle,
-						"/", fieldLabel, ": ", exception.getMessage()));
 			}
 		}
 
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Field Not Found: op://", vaultName, "/", itemTitle, "/",
-				fieldLabel));
+		return secretReference;
+	}
 
-		return null;
+	private static String _getSecretReference(
+		String vaultName, String itemTitle, String fieldLabel) {
+
+		return JenkinsResultsParserUtil.combine(
+			"op://", vaultName, "/", itemTitle, "/", fieldLabel);
 	}
 
 	private static synchronized int _getSecretRetriesMax() {
@@ -411,28 +731,21 @@ public abstract class SecretsUtil {
 		return _secretRetryPeriodSeconds;
 	}
 
-	private static synchronized String _getSecretsCacheURL() {
-		if (_secretsCacheURL != null) {
-			return _secretsCacheURL;
-		}
+	private static String _getSSMParameterValue(String parameterName)
+		throws IOException, TimeoutException {
 
-		String secretsCacheURL;
+		Process process = JenkinsResultsParserUtil.executeBashCommands(
+			new File("."), true, false, 60000,
+			JenkinsResultsParserUtil.combine(
+				"aws ssm get-parameter --name \"", parameterName,
+				"\" --with-decryption | jq -r .Parameter.Value"));
 
-		try {
-			secretsCacheURL = JenkinsResultsParserUtil.getBuildProperty(
-				"one.password.cache.url");
+		String value = JenkinsResultsParserUtil.readInputStream(
+			process.getInputStream());
 
-			if (JenkinsResultsParserUtil.isNullOrEmpty(secretsCacheURL)) {
-				secretsCacheURL = "";
-			}
-		}
-		catch (IOException ioException) {
-			secretsCacheURL = "";
-		}
+		value = value.replace("Finished executing Bash commands.", "");
 
-		_secretsCacheURL = secretsCacheURL;
-
-		return _secretsCacheURL;
+		return value.trim();
 	}
 
 	private static boolean _isSecretsConfigured() {
@@ -448,37 +761,27 @@ public abstract class SecretsUtil {
 	private static synchronized void _loadCachedSecrets() {
 		_cachedSecretsLoaded = true;
 
-		String secretsCacheURL = _getSecretsCacheURL();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(secretsCacheURL)) {
-			return;
-		}
-
 		try {
-			String content;
+			String cachedSecretsContent = _getCachedSecretsContent();
 
-			String filePrefix = "file://";
-
-			if (secretsCacheURL.startsWith(filePrefix)) {
-				File file = new File(
-					secretsCacheURL.substring(filePrefix.length()));
-
-				if (!file.exists()) {
-					return;
-				}
-
-				content = JenkinsResultsParserUtil.read(file);
-			}
-			else {
-				content = JenkinsResultsParserUtil.toString(
-					secretsCacheURL, false);
-			}
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(content)) {
+			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsContent)) {
 				return;
 			}
 
-			JSONObject jsonObject = new JSONObject(content);
+			PrivateKey cachedSecretsPrivateKey = _getCachedSecretsPrivateKey();
+
+			if (cachedSecretsPrivateKey == null) {
+				return;
+			}
+
+			cachedSecretsContent = _decrypt(
+				cachedSecretsContent, cachedSecretsPrivateKey);
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsContent)) {
+				return;
+			}
+
+			JSONObject jsonObject = new JSONObject(cachedSecretsContent);
 
 			_cachedSecrets = new HashMap<>();
 
@@ -553,20 +856,30 @@ public abstract class SecretsUtil {
 		}
 	}
 
+	private static final String _CACHE_CIPHER = "RSA-OAEP+AES-GCM";
+
 	private static final int _SECRET_RETRIES_MAX_DEFAULT = 3;
 
 	private static final long _SECRET_RETRY_PERIOD_SECONDS_DEFAULT = 5;
 
 	private static String _accessToken;
 	private static Map<String, String> _cachedSecrets;
+	private static String _cachedSecretsContent;
 	private static boolean _cachedSecretsLoaded;
+	private static PrivateKey _cachedSecretsPrivateKey;
+	private static boolean _cachedSecretsPrivateKeyInitialized;
+	private static String _cachedSecretsPrivateKeyPEM;
+	private static PublicKey _cachedSecretsPublicKey;
+	private static boolean _cachedSecretsPublicKeyInitialized;
+	private static String _cachedSecretsPublicKeyPEM;
+	private static String _cachedSecretsURL;
 	private static String _connectURL;
 	private static BearerHTTPAuthorization _httpAuthorization;
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
 	private static Integer _secretRetriesMax;
 	private static Long _secretRetryPeriodSeconds;
-	private static String _secretsCacheURL;
+	private static final Map<String, String> _secrets = new HashMap<>();
 
 	private static class Item {
 
@@ -575,13 +888,17 @@ public abstract class SecretsUtil {
 		}
 
 		public ItemField getItemField(String label) {
+			List<ItemField> itemFields;
+
 			synchronized (_vault) {
 				if (_itemFields == null) {
 					_init();
 				}
+
+				itemFields = _itemFields;
 			}
 
-			for (ItemField itemField : _itemFields) {
+			for (ItemField itemField : itemFields) {
 				if (Objects.equals(itemField.getId(), label) ||
 					Objects.equals(itemField.getLabel(), label)) {
 
@@ -597,13 +914,17 @@ public abstract class SecretsUtil {
 		}
 
 		public ItemFile getItemFile(String fileName) {
+			List<ItemFile> itemFiles;
+
 			synchronized (_vault) {
 				if (_itemFiles == null) {
 					_init();
 				}
+
+				itemFiles = _itemFiles;
 			}
 
-			for (ItemFile itemFile : _itemFiles) {
+			for (ItemFile itemFile : itemFiles) {
 				if (Objects.equals(itemFile.getName(), fileName)) {
 					return itemFile;
 				}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7786

## What Is Being Fixed

Every 1Password secret reference resolved through SecretsUtil made a live
call to OP Connect. Across a CI run the same references are read repeatedly
and by many parallel jobs, so Connect became a bottleneck and a point of
failure — a slow or unavailable Connect stalled or broke secret resolution.
Separately, a malformed properties file aborted secret-key discovery with an
unchecked IllegalArgumentException from Properties.load.

## How It Is Being Fixed

A caching layer backed by the mirrors shared drive is added. writeCachedSecrets
scans a root directory for every op:// reference in .properties files, resolves
each once from Connect, and writes the results as a single cache blob. Because
the cache holds live credentials, it is encrypted with a hybrid RSA-OAEP plus
AES-GCM scheme: an AES key encrypts the payload and the RSA public key wraps
the AES key. getSecret now consults the decrypted cache first — loaded once,
decrypted with the RSA private key, with each value registered as a redact
token — and only falls back to a direct Connect read on a miss. Connect reads
themselves gain bounded retries and SSM-backed Connect URL and access-token
lookups. Malformed properties files are skipped rather than aborting discovery.

## Why Are There No Tests?

SecretsUtil is Jenkins results-parser CI infrastructure that is not covered by
the standard unit or integration test harness.

## PR Check

**pr-check: PASS** — tested on `da060f4dbc5a257a83203fb2e002aaf1f4240853`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS (no `SecretsUtil` consumers) |
| Java Unit Tests | PASS (no `SecretsUtilTest` counterpart) |

<!-- pr-check {"result": "success", "sha": "da060f4dbc5a257a83203fb2e002aaf1f4240853"} -->
