### PR TITLE
LPD-92865 Grant SELECT_CATALOG_ROLE to lportal in Oracle legacy-import CI path (revised)

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15718,6 +15718,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 									connect sys/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
+									grant select_catalog_role to ${database.username};
 									exit
 									EOF
 								]]>
@@ -15933,7 +15934,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;grant select_catalog_role to lportal;&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -15934,7 +15934,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;grant select_catalog_role to ${database.username};&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to ${database.username};&#10;grant select on sys.v_$sql to ${database.username};&#10;grant select_catalog_role to ${database.username};&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -15934,7 +15934,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;grant select_catalog_role to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;grant select_catalog_role to ${database.username};&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -6380,6 +6380,8 @@ ${custom.upgrade.properties}</echo>
 												#!/bin/bash
 
 												sqlplus ${oracle.admin.user}/${oracle.admin.password} @/tmp/create.sql ${database.username} ${database.password}
+
+												echo "grant select_catalog_role to ${database.username};" | sqlplus sys/${oracle.admin.password} as sysdba
 											]]>
 										</echo>
 									</then>
@@ -6554,6 +6556,10 @@ ${custom.upgrade.properties}</echo>
 														<arg value="${database.password}" />
 													</exec>
 												</retry>
+
+												<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect sys/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select_catalog_role to ${database.username};&#10;exit&#10;">
+													<arg value="/nolog" />
+												</exec>
 											</else>
 										</if>
 									</then>


### PR DESCRIPTION
[LPD-92865](https://liferay.atlassian.net/browse/LPD-92865)

Revises [#1425](https://github.com/javalosjr96/liferay-portal/pull/1425) (opened by @javalosjr96) with the following follow-up commits:

- [3d436a8e2555](https://github.com/pyoo47/liferay-portal/commit/3d436a8e2555aed87287ba0501ff35759c15ff29) LPD-92865 Grant SELECT_CATALOG_ROLE to lportal in Oracle legacy-import CI path
- [a234ba586f0a](https://github.com/pyoo47/liferay-portal/commit/a234ba586f0a81e54de750d60fa6df98dda51403) LPD-92865 Use database.username instead of hardcoded lportal
- [a4f6d2f10b49](https://github.com/pyoo47/liferay-portal/commit/a4f6d2f10b49a0f7a0477ec0af28ebb546aff2f7) LPD-92865 Use database.username in the remaining v_$ grants
