### PR TITLE
LRCI-7815 Add monitoring module scaffolding and core abstractions

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/Check.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/Check.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+/**
+ * @author Brittney Nguyen
+ */
+public interface Check {
+
+	public CheckResult execute();
+
+	public CheckConfig getCheckConfig();
+
+	public String getId();
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckConfig.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckConfig {
+
+	public CheckConfig(
+		String id, String type, Severity severity, long cadence,
+		Map<String, String> parameters, Map<String, String> thresholds) {
+
+		_id = id;
+		_type = type;
+		_severity = severity;
+		_cadence = cadence;
+		_parameters = _newUnmodifiableMap(parameters);
+		_thresholds = _newUnmodifiableMap(thresholds);
+	}
+
+	public long getCadence() {
+		return _cadence;
+	}
+
+	public String getId() {
+		return _id;
+	}
+
+	public Map<String, String> getParameters() {
+		return _parameters;
+	}
+
+	public Severity getSeverity() {
+		return _severity;
+	}
+
+	public Map<String, String> getThresholds() {
+		return _thresholds;
+	}
+
+	public String getType() {
+		return _type;
+	}
+
+	public enum Severity {
+
+		HIGH, LOW, MEDIUM
+
+	}
+
+	private Map<String, String> _newUnmodifiableMap(Map<String, String> map) {
+		if (map == null) {
+			return Collections.emptyMap();
+		}
+
+		return Collections.unmodifiableMap(new LinkedHashMap<>(map));
+	}
+
+	private final long _cadence;
+	private final String _id;
+	private final Map<String, String> _parameters;
+	private final Severity _severity;
+	private final Map<String, String> _thresholds;
+	private final String _type;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckConfigLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckConfigLoader.java
@@ -1,0 +1,159 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckConfigLoader {
+
+	public static List<CheckConfig> getCheckConfigs() throws IOException {
+		return getCheckConfigs(JenkinsResultsParserUtil.getBuildProperties());
+	}
+
+	public static List<CheckConfig> getCheckConfigs(
+		Properties buildProperties) {
+
+		List<CheckConfig> checkConfigs = new ArrayList<>();
+
+		for (String id : _getIds(buildProperties)) {
+			checkConfigs.add(_getCheckConfig(buildProperties, id));
+		}
+
+		return checkConfigs;
+	}
+
+	private static long _getCadence(Properties buildProperties, String id) {
+		String cadenceString = JenkinsResultsParserUtil.getProperty(
+			buildProperties, _getKey(id, "cadence"));
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(cadenceString)) {
+			return 0;
+		}
+
+		try {
+			return Long.parseLong(cadenceString);
+		}
+		catch (NumberFormatException numberFormatException) {
+			throw new IllegalArgumentException(
+				"Invalid cadence for " + _getKey(id, "cadence") + ": " +
+					cadenceString,
+				numberFormatException);
+		}
+	}
+
+	private static CheckConfig _getCheckConfig(
+		Properties buildProperties, String id) {
+
+		String type = JenkinsResultsParserUtil.getProperty(
+			buildProperties, _getKey(id, "type"));
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(type)) {
+			throw new IllegalArgumentException(
+				"Missing required property " + _getKey(id, "type"));
+		}
+
+		return new CheckConfig(
+			id, type, _getSeverity(buildProperties, id),
+			_getCadence(buildProperties, id),
+			_getParameters(buildProperties, id),
+			_getThresholds(buildProperties, id));
+	}
+
+	private static TreeSet<String> _getIds(Properties buildProperties) {
+		TreeSet<String> ids = new TreeSet<>();
+
+		for (String propertyName : buildProperties.stringPropertyNames()) {
+			Matcher matcher = _checkPropertyPattern.matcher(propertyName);
+
+			if (matcher.matches()) {
+				ids.add(matcher.group("id"));
+			}
+		}
+
+		return ids;
+	}
+
+	private static Map<String, String> _getIndexedProperties(
+		Properties buildProperties, String id, String category) {
+
+		Map<String, String> indexedProperties = new LinkedHashMap<>();
+
+		for (String propertyName : buildProperties.stringPropertyNames()) {
+			Matcher matcher = _indexedPropertyPattern.matcher(propertyName);
+
+			if (matcher.matches() && id.equals(matcher.group("id")) &&
+				category.equals(matcher.group("category"))) {
+
+				indexedProperties.put(
+					matcher.group("name"),
+					JenkinsResultsParserUtil.getProperty(
+						buildProperties, propertyName));
+			}
+		}
+
+		return indexedProperties;
+	}
+
+	private static String _getKey(String id, String suffix) {
+		return "monitor.check[" + id + "]." + suffix;
+	}
+
+	private static Map<String, String> _getParameters(
+		Properties buildProperties, String id) {
+
+		return _getIndexedProperties(buildProperties, id, "parameter");
+	}
+
+	private static CheckConfig.Severity _getSeverity(
+		Properties buildProperties, String id) {
+
+		String severityString = JenkinsResultsParserUtil.getProperty(
+			buildProperties, _getKey(id, "severity"));
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(severityString)) {
+			return CheckConfig.Severity.MEDIUM;
+		}
+
+		try {
+			return CheckConfig.Severity.valueOf(
+				severityString.toUpperCase(Locale.ENGLISH));
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			throw new IllegalArgumentException(
+				"Invalid severity for " + _getKey(id, "severity") + ": " +
+					severityString,
+				illegalArgumentException);
+		}
+	}
+
+	private static Map<String, String> _getThresholds(
+		Properties buildProperties, String id) {
+
+		return _getIndexedProperties(buildProperties, id, "threshold");
+	}
+
+	private static final Pattern _checkPropertyPattern = Pattern.compile(
+		"monitor\\.check\\[(?<id>[^\\]]+)\\]\\..+");
+	private static final Pattern _indexedPropertyPattern = Pattern.compile(
+		"monitor\\.check\\[(?<id>[^\\]]+)\\]\\.(?<category>[^\\[]+)\\[" +
+			"(?<name>[^\\]]+)\\]");
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckFactory.java
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckFactory {
+
+	public static Check newCheck(CheckConfig checkConfig) {
+		throw new IllegalArgumentException(
+			"Unknown check type: " + checkConfig.getType());
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/CheckResult.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckResult {
+
+	public CheckResult(
+		Status status, String message, Map<String, String> metrics,
+		long timestamp) {
+
+		_status = status;
+		_message = message;
+		_timestamp = timestamp;
+
+		if (metrics == null) {
+			_metrics = Collections.emptyMap();
+		}
+		else {
+			_metrics = Collections.unmodifiableMap(
+				new LinkedHashMap<>(metrics));
+		}
+	}
+
+	public String getMessage() {
+		return _message;
+	}
+
+	public Map<String, String> getMetrics() {
+		return _metrics;
+	}
+
+	public Status getStatus() {
+		return _status;
+	}
+
+	public long getTimestamp() {
+		return _timestamp;
+	}
+
+	public enum Status {
+
+		CRITICAL(3), OK(0), UNKNOWN(1), WARN(2);
+
+		public static Status getMostSevere(Collection<Status> statuses) {
+			if (statuses.isEmpty()) {
+				return UNKNOWN;
+			}
+
+			Status mostSevereStatus = OK;
+
+			for (Status status : statuses) {
+				if (status._severityRank > mostSevereStatus._severityRank) {
+					mostSevereStatus = status;
+				}
+			}
+
+			return mostSevereStatus;
+		}
+
+		private Status(int severityRank) {
+			_severityRank = severityRank;
+		}
+
+		private final int _severityRank;
+
+	}
+
+	private final String _message;
+	private final Map<String, String> _metrics;
+	private final Status _status;
+	private final long _timestamp;
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckConfigLoaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckConfigLoaderTest.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckConfigLoaderTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetCheckConfigs() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"monitor.check[masters].type", "http-endpoint");
+		buildProperties.setProperty("monitor.check[masters].severity", "high");
+		buildProperties.setProperty("monitor.check[masters].cadence", "900");
+		buildProperties.setProperty(
+			"monitor.check[masters].parameter[target]",
+			"https://test-1-0.liferay.com/computer/api/json");
+		buildProperties.setProperty(
+			"monitor.check[masters].threshold[disk]", "85");
+
+		List<CheckConfig> checkConfigs = CheckConfigLoader.getCheckConfigs(
+			buildProperties);
+
+		Assert.assertEquals(checkConfigs.toString(), 1, checkConfigs.size());
+
+		CheckConfig checkConfig = checkConfigs.get(0);
+
+		Assert.assertEquals("masters", checkConfig.getId());
+		Assert.assertEquals("http-endpoint", checkConfig.getType());
+		Assert.assertEquals(
+			CheckConfig.Severity.HIGH, checkConfig.getSeverity());
+		Assert.assertEquals(900L, checkConfig.getCadence());
+
+		Map<String, String> parameters = checkConfig.getParameters();
+
+		Assert.assertEquals(
+			"https://test-1-0.liferay.com/computer/api/json",
+			parameters.get("target"));
+
+		Map<String, String> thresholds = checkConfig.getThresholds();
+
+		Assert.assertEquals("85", thresholds.get("disk"));
+	}
+
+	@Test
+	public void testGetCheckConfigsInvalidCadenceFailsLoud() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor.check[a].type", "http-endpoint");
+		buildProperties.setProperty("monitor.check[a].cadence", "not-a-number");
+
+		try {
+			CheckConfigLoader.getCheckConfigs(buildProperties);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	@Test
+	public void testGetCheckConfigsInvalidSeverityFailsLoud() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor.check[a].type", "http-endpoint");
+		buildProperties.setProperty("monitor.check[a].severity", "bogus");
+
+		try {
+			CheckConfigLoader.getCheckConfigs(buildProperties);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	@Test
+	public void testGetCheckConfigsMissingTypeFailsLoud() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor.check[a].severity", "high");
+
+		try {
+			CheckConfigLoader.getCheckConfigs(buildProperties);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckFactoryTest.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckFactoryTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testNewCheckUnknownTypeFailsLoud() {
+		CheckConfig checkConfig = new CheckConfig(
+			"a", "unknown-type", CheckConfig.Severity.MEDIUM, 0, null, null);
+
+		try {
+			CheckFactory.newCheck(checkConfig);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckResultTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckResultTest.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckResultTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetMetricsIsUnmodifiable() {
+		Map<String, String> metrics = Collections.singletonMap("disk", "88");
+
+		CheckResult checkResult = new CheckResult(
+			CheckResult.Status.WARN, "disk high", metrics, 1L);
+
+		Map<String, String> returnedMetrics = checkResult.getMetrics();
+
+		try {
+			returnedMetrics.put("cpu", "50");
+
+			Assert.fail("Expected UnsupportedOperationException");
+		}
+		catch (UnsupportedOperationException unsupportedOperationException) {
+		}
+	}
+
+	@Test
+	public void testGetMetricsNullYieldsEmpty() {
+		CheckResult checkResult = new CheckResult(
+			CheckResult.Status.OK, "ok", null, 1L);
+
+		Map<String, String> metrics = checkResult.getMetrics();
+
+		Assert.assertTrue(metrics.isEmpty());
+	}
+
+	@Test
+	public void testGetMostSevere() {
+		Assert.assertEquals(
+			CheckResult.Status.UNKNOWN,
+			CheckResult.Status.getMostSevere(
+				Collections.<CheckResult.Status>emptyList()));
+
+		Assert.assertEquals(
+			CheckResult.Status.OK,
+			CheckResult.Status.getMostSevere(
+				Arrays.asList(CheckResult.Status.OK, CheckResult.Status.OK)));
+
+		Assert.assertEquals(
+			CheckResult.Status.UNKNOWN,
+			CheckResult.Status.getMostSevere(
+				Arrays.asList(
+					CheckResult.Status.OK, CheckResult.Status.UNKNOWN)));
+
+		Assert.assertEquals(
+			CheckResult.Status.CRITICAL,
+			CheckResult.Status.getMostSevere(
+				Arrays.asList(
+					CheckResult.Status.OK, CheckResult.Status.WARN,
+					CheckResult.Status.CRITICAL)));
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/CheckTest.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CheckTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testExecute() {
+		CheckConfig checkConfig = new CheckConfig(
+			"masters", "http-endpoint", CheckConfig.Severity.HIGH, 900, null,
+			null);
+
+		CheckResult checkResult = new CheckResult(
+			CheckResult.Status.OK, "ok", null, 1L);
+
+		Check check = new Check() {
+
+			@Override
+			public CheckResult execute() {
+				return checkResult;
+			}
+
+			@Override
+			public CheckConfig getCheckConfig() {
+				return checkConfig;
+			}
+
+			@Override
+			public String getId() {
+				return checkConfig.getId();
+			}
+
+		};
+
+		Assert.assertSame(checkResult, check.execute());
+		Assert.assertEquals("masters", check.getId());
+		Assert.assertSame(checkConfig, check.getCheckConfig());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7815

## What Is Being Fixed

Liferay CI has no shared foundation for health monitoring. The monitoring
solution designed in LRCI-6038 needs a single extensibility contract before any
concrete check, the engine, the dashboard, or alerting can be built. Without it,
every check type would reinvent its own result, config, and registration shape.

## How It Is Being Fixed

Introduces a new `com.liferay.jenkins.results.parser.monitor` package with the
core abstractions every future check plugs into. `Check` is the one contract
(`execute()` returning an immutable `CheckResult`, plus `getId()` and
`getCheckConfig()`). `CheckResult` carries a `Status` (OK/WARN/CRITICAL/UNKNOWN,
ranked by an explicit severity so `getMostSevere` can roll many results into one)
and a defensive metrics map. `CheckConfig` holds a check's id, type, severity,
cadence, parameters, and thresholds, all immutable. `CheckConfigLoader` parses
`monitor.check[<id>].*` entries out of `build.properties` and fails loud on an
invalid cadence, an invalid severity, or a missing type. `CheckFactory` is the
type-to-instance seam that concrete check types register into (LRCI-7820 and
later).

The work is split into three dependency-ordered commits — contract and value
types, then the config loader, then the factory — so each one compiles and its
tests pass on its own. The code is lambda-free for the BeanShell and ECJ
consumers of the jar, and passes formatSource.

## PR Check

**pr-check: PASS** — tested on `c728e5179c8af71105048a26f556e7fd7a951cb4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c728e5179c8af71105048a26f556e7fd7a951cb4"} -->
