### PR TITLE
LRCI-7801 Ensure Testray-compatible failure messages for batch builds (revised)

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3414,7 +3414,9 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 								AntUtil.callTargetWithTimeout(projectDir, "build-common.xml", "gradle-execute-modules", parameters, timeout, true);
 							}
 							catch(Exception exception) {
-								throw new RuntimeException("Unable to run Gradle execute modules target.");
+								System.out.println("Unable to run Gradle execute modules target for " + entry.getKey());
+
+								exception.printStackTrace();
 							}
 						}
 					]]>

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -365,7 +365,8 @@ public class UrlReader {
 
 				Integer retryPeriodOverride = null;
 
-				if (exceptionMessage.matches(
+				if (gitHubAPICall &&
+					exceptionMessage.matches(
 						".*HTTP response code\\: 403 .*") &&
 					(urlConnection != null)) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ModulesJUnitBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ModulesJUnitBatchTestClassGroup.java
@@ -89,6 +89,24 @@ public class ModulesJUnitBatchTestClassGroup extends JUnitBatchTestClassGroup {
 	}
 
 	@Override
+	protected void addTestClass(TestClass testClass) {
+		String testClassFilePath = JenkinsResultsParserUtil.getCanonicalPath(
+			testClass.getTestClassFile());
+
+		File modulesDir = new File(
+			portalGitWorkingDirectory.getWorkingDirectory(), "modules");
+
+		String modulesDirPath = JenkinsResultsParserUtil.getCanonicalPath(
+			modulesDir);
+
+		if (!testClassFilePath.startsWith(modulesDirPath + "/")) {
+			return;
+		}
+
+		super.addTestClass(testClass);
+	}
+
+	@Override
 	protected List<JobProperty> getDefaultExcludesJobProperties() {
 		List<JobProperty> excludesJobProperties = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/AntTargetBatchBuildTestrayCaseResult.java
@@ -129,11 +129,7 @@ public class AntTargetBatchBuildTestrayCaseResult
 			errorMessage = buildReport.getFailureMessage();
 		}
 
-		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
-			return "Failed for unknown reason";
-		}
-
-		errorMessage = errorMessage.trim();
+		errorMessage = formatErrorMessage(errorMessage);
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
 			return "Failed for unknown reason";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -145,18 +145,8 @@ public class BatchBuildTestrayCaseResult
 			return buildReport.getJobName() + " timed out after 2 hours";
 		}
 
-		String errorMessage = buildReport.getFailureMessage();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
-			return "Failed for unknown reason";
-		}
-
-		if (errorMessage.contains("\n")) {
-			errorMessage = errorMessage.substring(
-				0, errorMessage.indexOf("\n"));
-		}
-
-		errorMessage = errorMessage.trim();
+		String errorMessage = formatErrorMessage(
+			buildReport.getFailureMessage());
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
 			return "Failed for unknown reason";
@@ -363,6 +353,49 @@ public class BatchBuildTestrayCaseResult
 		return null;
 	}
 
+	protected String formatErrorMessage(String errorMessage) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
+			return null;
+		}
+
+		errorMessage = errorMessage.replaceAll("</?pre>", "");
+
+		errorMessage = errorMessage.replace("&gt;", ">");
+		errorMessage = errorMessage.replace("&lt;", "<");
+		errorMessage = errorMessage.replace("&quot;", "\"");
+		errorMessage = errorMessage.replace("&amp;", "&");
+
+		StringBuilder sb = new StringBuilder();
+
+		for (String errorMessageLine : errorMessage.split("\n")) {
+			if (errorMessageLine.matches(
+					"(\\s*\\[exec\\])*\\s*at\\s+\\S+\\(.*\\)\\s*")) {
+
+				continue;
+			}
+
+			sb.append(errorMessageLine);
+			sb.append("\n");
+		}
+
+		errorMessage = sb.toString();
+
+		errorMessage = errorMessage.trim();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
+			return null;
+		}
+
+		int errorMessageMaxLength = _getErrorMessageMaxLength();
+
+		if (errorMessage.length() > errorMessageMaxLength) {
+			errorMessage =
+				errorMessage.substring(0, errorMessageMaxLength - 4) + "\n...";
+		}
+
+		return errorMessage;
+	}
+
 	protected AxisTestClassGroup getAxisTestClassGroup() {
 		return _axisTestClassGroup;
 	}
@@ -481,7 +514,8 @@ public class BatchBuildTestrayCaseResult
 				testResultErrors = "Unable to run test on CI";
 			}
 
-			String failureMessage = buildReport.getFailureMessage();
+			String failureMessage = formatErrorMessage(
+				buildReport.getFailureMessage());
 
 			if (JenkinsResultsParserUtil.isNullOrEmpty(failureMessage)) {
 				return testResultErrors;
@@ -504,16 +538,7 @@ public class BatchBuildTestrayCaseResult
 			testResultErrors = buildReport.getFailureMessage();
 		}
 
-		if (JenkinsResultsParserUtil.isNullOrEmpty(testResultErrors)) {
-			return "Failed for unknown reason";
-		}
-
-		if (testResultErrors.contains("\n")) {
-			testResultErrors = testResultErrors.substring(
-				0, testResultErrors.indexOf("\n"));
-		}
-
-		testResultErrors = testResultErrors.trim();
+		testResultErrors = formatErrorMessage(testResultErrors);
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(testResultErrors)) {
 			return "Failed for unknown reason";
@@ -663,6 +688,25 @@ public class BatchBuildTestrayCaseResult
 		}
 
 		return testrayAttachments;
+	}
+
+	private int _getErrorMessageMaxLength() {
+		try {
+			String errorMessageLengthMax =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"testray.case.result.error.message.max.length");
+
+			if ((errorMessageLengthMax != null) &&
+				errorMessageLengthMax.matches("\\d+")) {
+
+				return Integer.parseInt(errorMessageLengthMax);
+			}
+
+			return _ERROR_MESSAGE_MAX_LENGTH_DEFAULT;
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
 	}
 
 	private List<TestrayAttachment> _getGCLogsTestrayAttachments() {
@@ -828,6 +872,8 @@ public class BatchBuildTestrayCaseResult
 
 		return sb.toString();
 	}
+
+	private static final int _ERROR_MESSAGE_MAX_LENGTH_DEFAULT = 50000;
 
 	private static final Pattern _dockerLogsURLPattern = Pattern.compile(
 		"https?://.+/(?<key>docker-logs/(?<fileName>[^/]+.log).txt.gz)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -389,8 +389,10 @@ public class BatchBuildTestrayCaseResult
 		int errorMessageMaxLength = _getErrorMessageMaxLength();
 
 		if (errorMessage.length() > errorMessageMaxLength) {
-			errorMessage =
-				errorMessage.substring(0, errorMessageMaxLength - 4) + "\n...";
+			String truncatedErrorMessage = errorMessage.substring(
+				0, Math.max(0, errorMessageMaxLength - 4));
+
+			errorMessage = truncatedErrorMessage + "\n...";
 		}
 
 		return errorMessage;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BatchBuildTestrayCaseResult.java
@@ -692,14 +692,14 @@ public class BatchBuildTestrayCaseResult
 
 	private int _getErrorMessageMaxLength() {
 		try {
-			String errorMessageLengthMax =
+			String errorMessageMaxLength =
 				JenkinsResultsParserUtil.getBuildProperty(
 					"testray.case.result.error.message.max.length");
 
-			if ((errorMessageLengthMax != null) &&
-				errorMessageLengthMax.matches("\\d+")) {
+			if ((errorMessageMaxLength != null) &&
+				errorMessageMaxLength.matches("\\d+")) {
 
-				return Integer.parseInt(errorMessageLengthMax);
+				return Integer.parseInt(errorMessageMaxLength);
 			}
 
 			return _ERROR_MESSAGE_MAX_LENGTH_DEFAULT;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JSUnitBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JSUnitBatchBuildTestrayCaseResult.java
@@ -107,16 +107,7 @@ public class JSUnitBatchBuildTestrayCaseResult
 				errorMessage = buildReport.getFailureMessage();
 			}
 
-			if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
-				errorMessage = "Failed for unknown reason";
-			}
-
-			if (errorMessage.contains("\n")) {
-				errorMessage = errorMessage.substring(
-					0, errorMessage.indexOf("\n"));
-			}
-
-			errorMessage = errorMessage.trim();
+			errorMessage = formatErrorMessage(errorMessage);
 
 			if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
 				errorMessage = "Failed for unknown reason";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JUnitBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/JUnitBatchBuildTestrayCaseResult.java
@@ -113,16 +113,7 @@ public class JUnitBatchBuildTestrayCaseResult
 				errorMessage = null; //buildReport.getFailureMessage();
 			}
 
-			if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
-				errorMessage = "Failed for unknown reason";
-			}
-
-			if (errorMessage.contains("\n")) {
-				errorMessage = errorMessage.substring(
-					0, errorMessage.indexOf("\n"));
-			}
-
-			errorMessage = errorMessage.trim();
+			errorMessage = formatErrorMessage(errorMessage);
 
 			if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
 				errorMessage = "Failed for unknown reason";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/ModulesBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/ModulesBatchBuildTestrayCaseResult.java
@@ -109,11 +109,7 @@ public class ModulesBatchBuildTestrayCaseResult
 			errorMessage = buildReport.getFailureMessage();
 		}
 
-		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
-			return "Failed for unknown reason";
-		}
-
-		errorMessage = errorMessage.trim();
+		errorMessage = formatErrorMessage(errorMessage);
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(errorMessage)) {
 			return "Failed for unknown reason";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
@@ -94,7 +94,8 @@ public class PlaywrightBatchBuildTestrayCaseResult
 				errors = "Unable to run test on CI";
 			}
 
-			String failureMessage = buildReport.getFailureMessage();
+			String failureMessage = formatErrorMessage(
+				buildReport.getFailureMessage());
 
 			if (JenkinsResultsParserUtil.isNullOrEmpty(failureMessage)) {
 				return errors;
@@ -136,11 +137,7 @@ public class PlaywrightBatchBuildTestrayCaseResult
 			return stackTrace.substring(index, 500);
 		}
 
-		if (errors.contains("\n")) {
-			errors = errors.substring(0, errors.indexOf("\n"));
-		}
-
-		errors = errors.trim();
+		errors = formatErrorMessage(errors);
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(errors)) {
 			return "Failed for unknown reason";


### PR DESCRIPTION
[LRCI-7801](https://liferay.atlassian.net/browse/LRCI-7801)

Revises [#4412](https://github.com/pyoo47/liferay-portal/pull/4412) (opened by @michaelhashimoto) with the following follow-up commits:

- [8c41e812126b](https://github.com/pyoo47/liferay-portal/commit/8c41e812126bffe6b899542b37b68b1fc45b2568) LRCI-7801 Rename
- [5d20a4d0885e](https://github.com/pyoo47/liferay-portal/commit/5d20a4d0885e0736783559dd0ae788152f87f9b9) LRCI-7801 Guard error message truncation against small max lengths
