### PR TITLE
LRCI-7849 Make finding the first parentheses more resilient

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PlaywrightBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PlaywrightBatchTestClassGroup.java
@@ -711,14 +711,14 @@ public class PlaywrightBatchTestClassGroup extends BatchTestClassGroup {
 					playwrightBaseDir,
 					"npm run playwright test -- --list --reporter=json");
 
-				int index = result.indexOf("\n{");
+				Matcher matcher = _npmCommandOutputPattern.matcher(result);
 
-				if (index == -1) {
+				if (!matcher.find()) {
 					throw new RuntimeException(
 						"Invalid NPM command output: " + result);
 				}
 
-				result = result.substring(index);
+				result = result.substring(matcher.start(1));
 
 				result = result.replace(
 					"Finished executing Bash commands.", "");
@@ -947,6 +947,8 @@ public class PlaywrightBatchTestClassGroup extends BatchTestClassGroup {
 			"Playwright batch creation failure", "Liferay Playwright");
 	}
 
+	private static final Pattern _npmCommandOutputPattern = Pattern.compile(
+		"^\\s*(\\{)", Pattern.MULTILINE);
 	private static final Pattern _playwrightFileNamePattern = Pattern.compile(
 		"tests/(?<filePath>(?<projectName>.+)/[^/]*.spec.ts)");
 	private static JSONObject _playwrightJSONObject;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7849

## What Is Being Fixed

When parsing NPM command output in `PlaywrightBatchTestClassGroup`, the start of the JSON payload was located by searching for the literal `"\n{"`. Output where the opening brace is not at the very start of a line (for example, preceded by whitespace) or where the JSON begins on the first line fails the lookup and throws an "Invalid NPM command output" exception even though the payload is present.

## How It Is Being Fixed

The literal substring search is replaced with a precompiled multiline regular expression, `^\s*(\{)`, that finds the first line beginning with an opening brace regardless of leading whitespace. The substring extraction now starts at the brace capture group, so the parsed JSON is identical in the cases that already worked while the lookup tolerates the output variations that previously broke it.

## Why Are There No Tests?

This is CI-infrastructure tooling in `jenkins-results-parser`, validated by running it in CI; the module has no test harness for this parsing path.

## PR Check

**pr-check: PASS** — tested on `c7fb3f4ca4fcfbc51cbfbbca1b64bbbb4ff6b441`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

Java Unit Tests: the module's full suite ran as fallback (no parallel-name counterpart exists); the single failure, `PropertyValidatorTest`, is pre-existing on master (`SecretsUtil.java` build properties, untouched by this branch) and unrelated to this change.

<!-- pr-check {"result": "success", "sha": "c7fb3f4ca4fcfbc51cbfbbca1b64bbbb4ff6b441"} -->
