### PR TITLE
LRCI-7745 Set minimum RAM for oracle19 batches to 24 GB

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1633,10 +1633,10 @@
 
     test.batch.max.subgroup.size=5
 
-    test.batch.minimum.slave.ram[functional-upgrade-tomcat101-oracle193]=24
     test.batch.minimum.slave.ram[js-unit]=24
     test.batch.minimum.slave.ram[modules-integration*]=24
     test.batch.minimum.slave.ram[portal-license-smoke-mysql84]=24
+    test.batch.minimum.slave.ram[*oracle193*]=24
     test.batch.minimum.slave.ram[*playwright*]=24
     test.batch.minimum.slave.ram[*redhat9*]=24
     test.batch.minimum.slave.ram[*redhat10*]=24


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7745

## What Is Being Fixed

Only the `functional-upgrade-tomcat101-oracle193` batch had an elevated
24 GB minimum slave RAM entry. Other oracle19.3 batches had no such
minimum and could be scheduled onto slaves with insufficient memory.

## How It Is Being Fixed

Replace the single `functional-upgrade-tomcat101-oracle193` entry with a
`*oracle193*` wildcard so every oracle19.3 batch requires at least 24 GB
of slave RAM.

## Why Are There No Tests?

This change only adjusts CI batch RAM configuration in `test.properties`;
there is no application code path to cover with a test.

## PR Check

**pr-check: SKIPPED** — Running pr-check separately after creation and publishing the result via pr-check-publish.

<!-- pr-check {"reason": "Running pr-check separately after creation and publishing the result via pr-check-publish.", "result": "skipped", "sha": "ffe344fdc23284048dfdd94f5f6093053e039bec"} -->
