### PR TITLE
LRCI-7745 OracleDBTest confirmation run against oracle19c 1.0.4 image

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -7054,40 +7054,8 @@
     test.batch.dist.app.servers[upgrade]=tomcat
 
     test.batch.names[upgrade]=\
-        db-migration-container-db2111,\
-        db-migration-container-mariadb102,\
-        db-migration-container-mysql80,\
-        db-migration-container-mysql84,\
-        db-migration-container-oracle193,\
-        db-migration-container-sqlserver2019,\
-        functional-tomcat101-db2111,\
-        functional-tomcat101-mariadb102,\
-        functional-tomcat101-mysql80,\
-        functional-tomcat101-mysql84,\
-        functional-tomcat101-oracle193,\
-        functional-tomcat101-postgresql144,\
-        functional-tomcat101-postgresql153,\
-        functional-tomcat101-postgresql163,\
-        functional-tomcat101-sqlserver2019,\
-        functional-upgrade-tomcat101-db2111,\
-        functional-upgrade-tomcat101-mariadb102,\
-        functional-upgrade-tomcat101-mysql84,\
-        functional-upgrade-tomcat101-oracle193,\
-        functional-upgrade-tomcat101-postgresql144,\
-        functional-upgrade-tomcat101-postgresql153,\
-        functional-upgrade-tomcat101-postgresql163,\
-        functional-upgrade-tomcat101-sqlserver2019,\
-        modules-integration-db2111,\
-        modules-integration-mariadb102,\
-        modules-integration-mysql84,\
-        modules-integration-oracle193,\
-        modules-integration-postgresql144,\
-        modules-integration-postgresql153,\
-        modules-integration-postgresql163,\
-        modules-integration-sqlserver2019,\
-        modules-unit,\
-        playwright-js-tomcat101-postgresql163,\
-        unit
+        modules-integration-oracle193
+    test.batch.class.names.includes[modules-integration-oracle193]=**/portal-dao-test/**/OracleDBTest.java
 
     test.batch.run.property.query[functional-tomcat101-db2111][upgrade]=\
         (\


### PR DESCRIPTION
Throwaway PR to run OracleDBTest (modules-integration-oracle193) against the liferay-jenkins-ee branch charlottefrancis/LRCI-7745-v-grants (oracle19c image 1.0.4, v_$ grant baked in). Isolates the image PUBLIC grant: built off master, so no create.sql/LPD-89552 fix is present. Safe to close/delete after the run completes.