### PR TITLE
LRCI-7783 Add unit tests for workspace Git repository setup

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -70,8 +70,7 @@ public class PortalWorkspaceGitRepositoryTest
 			"The bundle version must be read from the " +
 				"PORTAL_LATEST_BUNDLE_VERSION environment variable",
 			"environment.value",
-			testProperties.getProperty(
-				"test.released.release.bundle.version"));
+			testProperties.getProperty("test.released.release.bundle.version"));
 
 		Assert.assertEquals(
 			"The bundle zip URL must be resolved from the " +

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -24,6 +26,60 @@ import org.mockito.Mockito;
  */
 public class PortalWorkspaceGitRepositoryTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetPortalTestPropertiesReadsBundleVersionFromEnvironment()
+		throws Exception {
+
+		Map<String, String> environmentValues = new HashMap<>();
+
+		environmentValues.put(
+			"PORTAL_LATEST_BUNDLE_VERSION", "environment.value");
+
+		mockEnvironment(environmentValues);
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"portal.bundle.tomcat[environment.value]", "dummy.value");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Properties portalTestProperties = new Properties();
+
+		portalTestProperties.setProperty(
+			"test.released.release.bundle.version", "property.value");
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doReturn(
+			portalTestProperties
+		).when(
+			portalWorkspaceGitRepository
+		).getProperties(
+			"portal.test.properties"
+		);
+
+		mockShell();
+
+		Properties testProperties = _getPortalTestProperties(
+			portalWorkspaceGitRepository);
+
+		Assert.assertEquals(
+			"The bundle version must be read from the " +
+				"PORTAL_LATEST_BUNDLE_VERSION environment variable",
+			"environment.value",
+			testProperties.getProperty(
+				"test.released.release.bundle.version"));
+
+		Assert.assertEquals(
+			"The bundle zip URL must be resolved from the " +
+				"portal.bundle.tomcat property keyed by the bundle version",
+			"dummy.value",
+			testProperties.getProperty(
+				"test.released.test.portal.bundle.zip.url"));
+	}
 
 	@Test
 	public void testPrepareGitWorkingDirectoryWithGitArchiveDisabled()
@@ -424,6 +480,18 @@ public class PortalWorkspaceGitRepositoryTest
 		).putWorkspaceGitRepository(
 			Mockito.anyString(), Mockito.any(WorkspaceGitRepository.class)
 		);
+	}
+
+	private Properties _getPortalTestProperties(
+			PortalWorkspaceGitRepository portalWorkspaceGitRepository)
+		throws Exception {
+
+		Method method = PortalWorkspaceGitRepository.class.getDeclaredMethod(
+			"_getPortalTestProperties");
+
+		method.setAccessible(true);
+
+		return (Properties)method.invoke(portalWorkspaceGitRepository);
 	}
 
 	private boolean _isCommand(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 /**
@@ -293,6 +294,87 @@ public class PortalWorkspaceGitRepositoryTest
 		Assert.assertFalse(
 			"The git archive must stay disabled when binaries cache is enabled",
 			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
+	@Test
+	public void testSetUpRunsStepsInOrderExactlyOnce() throws Exception {
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("git.archive.enabled", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		BuildDatabaseUtil.setBuildDatabase(buildDatabase);
+
+		mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isSetUp();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setSetUp(
+			Mockito.anyBoolean()
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUp();
+
+		Assert.assertFalse(
+			"The repository must not be set up before setUp() runs",
+			portalWorkspaceGitRepository.isSetUp());
+
+		portalWorkspaceGitRepository.setUp();
+
+		Assert.assertTrue(
+			"The repository must be set up after setUp() runs",
+			portalWorkspaceGitRepository.isSetUp());
+
+		InOrder inOrder = Mockito.inOrder(
+			buildDatabase, portalWorkspaceGitRepository);
+
+		inOrder.verify(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		inOrder.verify(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		inOrder.verify(
+			buildDatabase
+		).putWorkspaceGitRepository(
+			Mockito.anyString(), Mockito.any(WorkspaceGitRepository.class)
+		);
+
+		portalWorkspaceGitRepository.setUp();
+
+		Mockito.verify(
+			portalWorkspaceGitRepository, Mockito.times(1)
+		).prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			portalWorkspaceGitRepository, Mockito.times(1)
+		).setUpAdditionalCaches();
+
+		Mockito.verify(
+			buildDatabase, Mockito.times(1)
+		).putWorkspaceGitRepository(
+			Mockito.anyString(), Mockito.any(WorkspaceGitRepository.class)
+		);
 	}
 
 	private boolean _isCommand(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -11,8 +11,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -31,12 +29,9 @@ public class PortalWorkspaceGitRepositoryTest
 	public void testGetPortalTestPropertiesReadsBundleVersionFromEnvironment()
 		throws Exception {
 
-		Map<String, String> environmentValues = new HashMap<>();
-
-		environmentValues.put(
-			"PORTAL_LATEST_BUNDLE_VERSION", "environment.value");
-
-		mockEnvironment(environmentValues);
+		mockEnvironment(
+			Collections.singletonMap(
+				"PORTAL_LATEST_BUNDLE_VERSION", "environment.value"));
 
 		Properties buildProperties = new Properties();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser;
 
 import java.io.File;
+import java.io.IOException;
 
 import java.lang.reflect.Method;
 
@@ -294,6 +295,54 @@ public class PortalWorkspaceGitRepositoryTest
 		Assert.assertFalse(
 			"The git archive must stay disabled when binaries cache is enabled",
 			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
+	@Test
+	public void testSetUpFailureDoesNotMarkTheRepositorySetUp()
+		throws Exception {
+
+		mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isSetUp();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setSetUp(
+			Mockito.anyBoolean()
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUp();
+
+		IOException ioException = new IOException(
+			"The additional caches could not be set up");
+
+		Mockito.doThrow(
+			ioException
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		RuntimeException runtimeException = Assert.assertThrows(
+			RuntimeException.class, portalWorkspaceGitRepository::setUp);
+
+		Assert.assertSame(
+			"setUp() must rethrow the mid-sequence IOException as the " +
+				"RuntimeException cause",
+			ioException, runtimeException.getCause());
+
+		Assert.assertFalse(
+			"A failed setUp() must not mark the repository set up",
+			portalWorkspaceGitRepository.isSetUp());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -24,17 +24,109 @@ public class PortalWorkspaceGitRepositoryTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testPrepareGitWorkingDirectoryWithGitArchiveDisabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "true");
+		buildProperties.setProperty(
+			"cloud.ci.s3.bucket.dist.path", "s3://liferayci-dist/dist");
+		buildProperties.setProperty("git.archive.enabled", "false");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		portalWorkspaceGitRepository.prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			shell, Mockito.never()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "git-archives"))
+		);
+
+		Assert.assertTrue(
+			"The binaries cache must stay enabled when the git archive is " +
+				"disabled",
+			portalWorkspaceGitRepository.isBinariesCacheEnabled());
+	}
+
+	@Test
+	public void testPrepareGitWorkingDirectoryWithGitArchiveEnabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "false");
+		buildProperties.setProperty(
+			"cloud.ci.s3.bucket.dist.path", "s3://liferayci-dist/dist");
+		buildProperties.setProperty("git.archive.enabled", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		Mockito.doReturn(
+			new Shell.ExecutionResult(0, "", "")
+		).when(
+			shell
+		).doExecute(
+			Mockito.any(Shell.ExecutionRequest.class)
+		);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).prepareGitWorkingDirectory();
+
+		portalWorkspaceGitRepository.prepareGitWorkingDirectory();
+
+		Mockito.verify(
+			shell, Mockito.atLeastOnce()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "git-archives"))
+		);
+
+		Assert.assertFalse(
+			"The binaries cache must stay disabled when the git archive is " +
+				"enabled",
+			portalWorkspaceGitRepository.isBinariesCacheEnabled());
+	}
+
+	@Test
 	public void testSetUp() throws Exception {
-		File workingDirectory = File.createTempFile("portal-workspace-", null);
-
-		workingDirectory.delete();
-
-		workingDirectory.mkdir();
-
-		File gitDirectory = new File(workingDirectory, ".git");
-
-		gitDirectory.mkdir();
-
 		mockEnvironment(
 			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
 
@@ -60,49 +152,8 @@ public class PortalWorkspaceGitRepositoryTest
 			Mockito.any(Shell.ExecutionRequest.class)
 		);
 
-		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
-
-		Mockito.doReturn(
-			"1234567890123456789012345678901234567890"
-		).when(
-			localGitBranch
-		).getSHA();
-
-		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
-			GitWorkingDirectory.class);
-
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
-			Mockito.mock(PortalWorkspaceGitRepository.class);
-
-		Mockito.doReturn(
-			workingDirectory
-		).when(
-			portalWorkspaceGitRepository
-		).getDirectory();
-
-		Mockito.doReturn(
-			"liferay-portal"
-		).when(
-			portalWorkspaceGitRepository
-		).getDirectoryName();
-
-		Mockito.doReturn(
-			gitWorkingDirectory
-		).when(
-			portalWorkspaceGitRepository
-		).getGitWorkingDirectory();
-
-		Mockito.doReturn(
-			localGitBranch
-		).when(
-			portalWorkspaceGitRepository
-		).getLocalGitBranch();
-
-		Mockito.doReturn(
-			"master"
-		).when(
-			portalWorkspaceGitRepository
-		).getUpstreamBranchName();
+			_newPortalWorkspaceGitRepository();
 
 		Mockito.doReturn(
 			true
@@ -164,6 +215,16 @@ public class PortalWorkspaceGitRepositoryTest
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			_newPortalWorkspaceGitRepository();
 
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
 		portalWorkspaceGitRepository.setUpAdditionalCaches();
 
 		Mockito.verify(
@@ -208,6 +269,16 @@ public class PortalWorkspaceGitRepositoryTest
 
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			_newPortalWorkspaceGitRepository();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
 
 		portalWorkspaceGitRepository.setUpAdditionalCaches();
 
@@ -254,6 +325,22 @@ public class PortalWorkspaceGitRepositoryTest
 		return (Boolean)method.invoke(workspaceGitRepository);
 	}
 
+	private GitWorkingDirectory _newGitWorkingDirectory() {
+		return Mockito.mock(GitWorkingDirectory.class);
+	}
+
+	private LocalGitBranch _newLocalGitBranch() {
+		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
+
+		Mockito.doReturn(
+			"1234567890123456789012345678901234567890"
+		).when(
+			localGitBranch
+		).getSHA();
+
+		return localGitBranch;
+	}
+
 	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()
 		throws Exception {
 
@@ -263,8 +350,18 @@ public class PortalWorkspaceGitRepositoryTest
 
 		workingDirectory.mkdir();
 
+		File gitDirectory = new File(workingDirectory, ".git");
+
+		gitDirectory.mkdir();
+
 		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
 			Mockito.mock(PortalWorkspaceGitRepository.class);
+
+		Mockito.doReturn(
+			"1234567890123456789012345678901234567890"
+		).when(
+			portalWorkspaceGitRepository
+		).getBaseBranchSHA();
 
 		Mockito.doReturn(
 			workingDirectory
@@ -273,20 +370,34 @@ public class PortalWorkspaceGitRepositoryTest
 		).getDirectory();
 
 		Mockito.doReturn(
+			"liferay-portal"
+		).when(
+			portalWorkspaceGitRepository
+		).getDirectoryName();
+
+		Mockito.doReturn(
+			_newGitWorkingDirectory()
+		).when(
+			portalWorkspaceGitRepository
+		).getGitWorkingDirectory();
+
+		Mockito.doReturn(
+			_newLocalGitBranch()
+		).when(
+			portalWorkspaceGitRepository
+		).getLocalGitBranch();
+
+		Mockito.doReturn(
+			"0987654321098765432109876543210987654321"
+		).when(
+			portalWorkspaceGitRepository
+		).getSenderBranchSHA();
+
+		Mockito.doReturn(
 			"master"
 		).when(
 			portalWorkspaceGitRepository
 		).getUpstreamBranchName();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).isBinariesCacheEnabled();
-
-		Mockito.doCallRealMethod(
-		).when(
-			portalWorkspaceGitRepository
-		).setUpAdditionalCaches();
 
 		return portalWorkspaceGitRepository;
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -7,9 +7,12 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.lang.reflect.Method;
+
 import java.util.Collections;
 import java.util.Properties;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -142,6 +145,85 @@ public class PortalWorkspaceGitRepositoryTest
 		);
 	}
 
+	@Test
+	public void testSetUpAdditionalCachesWithBinariesCacheDisabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "false");
+		buildProperties.setProperty("git.archive.enabled", "true");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		portalWorkspaceGitRepository.setUpAdditionalCaches();
+
+		Mockito.verify(
+			shell, Mockito.never()
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
+		);
+
+		Assert.assertTrue(
+			"The git archive must stay enabled when binaries cache is disabled",
+			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
+	@Test
+	public void testSetUpAdditionalCachesWithBinariesCacheEnabled()
+		throws Exception {
+
+		mockEnvironment(
+			Collections.singletonMap("MASTER_NETWORK_NAME", "aws-network"));
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("binaries.cache.enabled", "true");
+		buildProperties.setProperty(
+			"binaries.cache.s3.path",
+			"s3://liferayci-file-propagator/binaries-cache/master.tar.gz");
+		buildProperties.setProperty("git.archive.enabled", "false");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		Shell shell = mockShell();
+
+		Mockito.doReturn(
+			new Shell.ExecutionResult(0, "", "")
+		).when(
+			shell
+		).doExecute(
+			Mockito.any(Shell.ExecutionRequest.class)
+		);
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			_newPortalWorkspaceGitRepository();
+
+		portalWorkspaceGitRepository.setUpAdditionalCaches();
+
+		Mockito.verify(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _isCommand(
+					executionRequest, "aws s3 cp", "binaries-cache.tar.gz"))
+		);
+
+		Assert.assertFalse(
+			"The git archive must stay disabled when binaries cache is enabled",
+			_isGitArchiveEnabled(portalWorkspaceGitRepository));
+	}
+
 	private boolean _isCommand(
 		Shell.ExecutionRequest executionRequest, String... substrings) {
 
@@ -158,6 +240,55 @@ public class PortalWorkspaceGitRepositoryTest
 		}
 
 		return true;
+	}
+
+	private boolean _isGitArchiveEnabled(
+			WorkspaceGitRepository workspaceGitRepository)
+		throws Exception {
+
+		Method method = BaseWorkspaceGitRepository.class.getDeclaredMethod(
+			"_isGitArchiveEnabled");
+
+		method.setAccessible(true);
+
+		return (Boolean)method.invoke(workspaceGitRepository);
+	}
+
+	private PortalWorkspaceGitRepository _newPortalWorkspaceGitRepository()
+		throws Exception {
+
+		File workingDirectory = File.createTempFile("portal-workspace-", null);
+
+		workingDirectory.delete();
+
+		workingDirectory.mkdir();
+
+		PortalWorkspaceGitRepository portalWorkspaceGitRepository =
+			Mockito.mock(PortalWorkspaceGitRepository.class);
+
+		Mockito.doReturn(
+			workingDirectory
+		).when(
+			portalWorkspaceGitRepository
+		).getDirectory();
+
+		Mockito.doReturn(
+			"master"
+		).when(
+			portalWorkspaceGitRepository
+		).getUpstreamBranchName();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).isBinariesCacheEnabled();
+
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpAdditionalCaches();
+
+		return portalWorkspaceGitRepository;
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -5,9 +5,12 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.File;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.InOrder;
@@ -18,6 +21,31 @@ import org.mockito.Mockito;
  */
 public class WorkspaceGitRepositoryTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testIsFullDotGitDirArchiveRequiredOnlyForEE62X()
+		throws Exception {
+
+		Assert.assertTrue(
+			"A full .git dir archive is required for ee-6.2.x working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-plugins-ee-6.2.x")));
+
+		Assert.assertTrue(
+			"A full .git dir archive is required for ee-6.2.x working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-portal-ee-6.2.x")));
+
+		Assert.assertFalse(
+			"A full .git dir archive is not required for master working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-portal")));
+
+		Assert.assertFalse(
+			"A full .git dir archive is not required for 7.0.x working dirs",
+			_isFullDotGitDirArchiveRequired(
+				_newWorkspaceGitRepository("liferay-portal-7.0.x")));
+	}
 
 	@Test
 	public void testValidateSHAInRemoteGitRefFetchesBeforeContainsCheck()
@@ -68,6 +96,42 @@ public class WorkspaceGitRepositoryTest
 		).refContainsSHA(
 			localGitBranch, sha
 		);
+	}
+
+	private boolean _isFullDotGitDirArchiveRequired(
+			WorkspaceGitRepository workspaceGitRepository)
+		throws Exception {
+
+		Method method = BaseWorkspaceGitRepository.class.getDeclaredMethod(
+			"_isFullDotGitDirArchiveRequired");
+
+		method.setAccessible(true);
+
+		return (Boolean)method.invoke(workspaceGitRepository);
+	}
+
+	private WorkspaceGitRepository _newWorkspaceGitRepository(
+		String workingDirectoryName) {
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		Mockito.when(
+			gitWorkingDirectory.getWorkingDirectory()
+		).thenReturn(
+			new File(workingDirectoryName)
+		);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			Mockito.mock(DefaultWorkspaceGitRepository.class);
+
+		Mockito.when(
+			defaultWorkspaceGitRepository.getGitWorkingDirectory()
+		).thenReturn(
+			gitWorkingDirectory
+		);
+
+		return defaultWorkspaceGitRepository;
 	}
 
 	private void _validateSHAInRemoteGitRef(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/WorkspaceGitRepositoryTest.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class WorkspaceGitRepositoryTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testValidateSHAInRemoteGitRefFetchesBeforeContainsCheck()
+		throws Exception {
+
+		GitWorkingDirectory gitWorkingDirectory = Mockito.mock(
+			GitWorkingDirectory.class);
+
+		LocalGitBranch localGitBranch = Mockito.mock(LocalGitBranch.class);
+		RemoteGitRef remoteGitRef = Mockito.mock(RemoteGitRef.class);
+
+		String sha = "0123456789012345678901234567890123456789";
+
+		Mockito.when(
+			gitWorkingDirectory.fetch(remoteGitRef)
+		).thenReturn(
+			localGitBranch
+		);
+
+		Mockito.when(
+			gitWorkingDirectory.refContainsSHA(localGitBranch, sha)
+		).thenReturn(
+			true
+		);
+
+		DefaultWorkspaceGitRepository defaultWorkspaceGitRepository =
+			Mockito.mock(DefaultWorkspaceGitRepository.class);
+
+		Mockito.when(
+			defaultWorkspaceGitRepository.getGitWorkingDirectory()
+		).thenReturn(
+			gitWorkingDirectory
+		);
+
+		_validateSHAInRemoteGitRef(
+			defaultWorkspaceGitRepository, "master", remoteGitRef, sha);
+
+		InOrder inOrder = Mockito.inOrder(gitWorkingDirectory);
+
+		inOrder.verify(
+			gitWorkingDirectory
+		).fetch(
+			remoteGitRef
+		);
+
+		inOrder.verify(
+			gitWorkingDirectory
+		).refContainsSHA(
+			localGitBranch, sha
+		);
+	}
+
+	private void _validateSHAInRemoteGitRef(
+			WorkspaceGitRepository workspaceGitRepository, String branchName,
+			RemoteGitRef remoteGitRef, String sha)
+		throws Exception {
+
+		Method method = BaseWorkspaceGitRepository.class.getDeclaredMethod(
+			"_validateSHAInRemoteGitRef", String.class, RemoteGitRef.class,
+			String.class);
+
+		method.setAccessible(true);
+
+		try {
+			method.invoke(
+				workspaceGitRepository, branchName, remoteGitRef, sha);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			Throwable throwable = invocationTargetException.getCause();
+
+			if (throwable instanceof RuntimeException) {
+				throw (RuntimeException)throwable;
+			}
+
+			throw invocationTargetException;
+		}
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7783

## What Is Being Fixed

The workspace Git repository setup flow in jenkins-results-parser — binaries cache, git archives, bundle version resolution, and SHA validation — had no unit coverage, so regressions in `setUp()` behavior could only surface in live CI runs.

## How It Is Being Fixed

Two Mockito-based unit test classes are added to `modules/test/jenkins-results-parser`. `PortalWorkspaceGitRepositoryTest` locks the bundle version read to the `PORTAL_LATEST_BUNDLE_VERSION` environment variable, ties the `git.archive.enabled` and `binaries.cache.enabled` toggles to only their respective paths, verifies the `setUp()` step order, verifies repeated `setUp()` calls do not rerun when cached, and verifies a failed `setUp()` does not mark the repository set up. `WorkspaceGitRepositoryTest` locks the SHA validation fetch-before-contains-check behavior and the ee-6.2.x-only full `.git` directory archive requirement.

## PR Check

**pr-check: PASS** — tested on `54ead09c697e1f4714d9f05c964b4bdfa69a2c57`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "54ead09c697e1f4714d9f05c964b4bdfa69a2c57"} -->
