### PR TITLE
LRCI-7850 Prevent OOM from unbounded git show output during teardown

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseLocalGitCommit.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseLocalGitCommit.java
@@ -61,12 +61,17 @@ public abstract class BaseLocalGitCommit
 		}
 
 		if (!_gitWorkingDirectory.localSHAExists(getSHA() + "^")) {
-			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"WARNING: Skipping patch for commit ", getSHA(),
-					" because its parent is absent from the shallow clone"));
+			_gitWorkingDirectory.fetchGitCommitParentFromUpstream(getSHA());
 
-			return null;
+			if (!_gitWorkingDirectory.localSHAExists(getSHA() + "^")) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"WARNING: Skipping patch for commit ", getSHA(),
+						" because its parent could not be fetched into the ",
+						"shallow clone"));
+
+				return null;
+			}
 		}
 
 		GitUtil.ExecutionResult executionResult =
@@ -96,13 +101,18 @@ public abstract class BaseLocalGitCommit
 	@Override
 	public boolean isFileChanged(File file) {
 		if (!_gitWorkingDirectory.localSHAExists(getSHA() + "^")) {
-			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"WARNING: Unable to determine if ", file.toString(),
-					" changed in commit ", getSHA(),
-					" because its parent is absent from the shallow clone"));
+			_gitWorkingDirectory.fetchGitCommitParentFromUpstream(getSHA());
 
-			return false;
+			if (!_gitWorkingDirectory.localSHAExists(getSHA() + "^")) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"WARNING: Unable to determine if ", file.toString(),
+						" changed in commit ", getSHA(),
+						" because its parent could not be fetched into the ",
+						"shallow clone"));
+
+				return false;
+			}
 		}
 
 		GitUtil.ExecutionResult executionResult =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseLocalGitCommit.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseLocalGitCommit.java
@@ -60,6 +60,15 @@ public abstract class BaseLocalGitCommit
 			return _patch;
 		}
 
+		if (!_gitWorkingDirectory.localSHAExists(getSHA() + "^")) {
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"WARNING: Skipping patch for commit ", getSHA(),
+					" because its parent is absent from the shallow clone"));
+
+			return null;
+		}
+
 		GitUtil.ExecutionResult executionResult =
 			_gitWorkingDirectory.executeBashCommands(
 				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
@@ -86,6 +95,16 @@ public abstract class BaseLocalGitCommit
 
 	@Override
 	public boolean isFileChanged(File file) {
+		if (!_gitWorkingDirectory.localSHAExists(getSHA() + "^")) {
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"WARNING: Unable to determine if ", file.toString(),
+					" changed in commit ", getSHA(),
+					" because its parent is absent from the shallow clone"));
+
+			return false;
+		}
+
 		GitUtil.ExecutionResult executionResult =
 			_gitWorkingDirectory.executeBashCommands(
 				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
@@ -37,6 +37,9 @@ public class BufferedProcess extends Process {
 	@Override
 	public void destroy() {
 		_process.destroy();
+
+		_standardErrorInputStreamBuffer._close();
+		_standardOutInputStreamBuffer._close();
 	}
 
 	@Override
@@ -104,6 +107,10 @@ public class BufferedProcess extends Process {
 		}
 
 		public synchronized InputStream toInputStream() {
+			if (_closed) {
+				return new ByteArrayInputStream(new byte[0]);
+			}
+
 			if (_overflowFile == null) {
 				return new ByteArrayInputStream(
 					_byteArrayOutputStream.toByteArray());
@@ -119,7 +126,31 @@ public class BufferedProcess extends Process {
 			}
 		}
 
+		private synchronized void _close() {
+			if (_closed) {
+				return;
+			}
+
+			_closed = true;
+
+			if (_overflowOutputStream != null) {
+				try {
+					_overflowOutputStream.close();
+				}
+				catch (IOException ioException) {
+				}
+			}
+
+			if (_overflowFile != null) {
+				_overflowFile.delete();
+			}
+		}
+
 		private synchronized void _write(byte[] bytes, int length) {
+			if (_closed) {
+				return;
+			}
+
 			try {
 				if (_overflowOutputStream != null) {
 					_overflowOutputStream.write(bytes, 0, length);
@@ -156,6 +187,7 @@ public class BufferedProcess extends Process {
 
 		private ByteArrayOutputStream _byteArrayOutputStream =
 			new ByteArrayOutputStream();
+		private boolean _closed;
 		private final InputStream _inputStream;
 		private File _overflowFile;
 		private OutputStream _overflowOutputStream;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
@@ -5,8 +5,12 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -66,6 +70,8 @@ public class BufferedProcess extends Process {
 		return _process.waitFor();
 	}
 
+	private static final int _MEMORY_THRESHOLD = 10 * 1024 * 1024;
+
 	private static final long _MILLIS_EXECUTION_TIME_MIN = 10;
 
 	private final Process _process;
@@ -88,9 +94,7 @@ public class BufferedProcess extends Process {
 					bytesRead = _inputStream.read(bytes);
 
 					if (bytesRead > 0) {
-						synchronized (_byteArrayOutputStream) {
-							_byteArrayOutputStream.write(bytes, 0, bytesRead);
-						}
+						_write(bytes, bytesRead);
 					}
 				}
 			}
@@ -99,14 +103,62 @@ public class BufferedProcess extends Process {
 			}
 		}
 
-		public InputStream toInputStream() {
-			return new ByteArrayInputStream(
-				_byteArrayOutputStream.toByteArray());
+		public synchronized InputStream toInputStream() {
+			if (_overflowFile == null) {
+				return new ByteArrayInputStream(
+					_byteArrayOutputStream.toByteArray());
+			}
+
+			try {
+				_overflowOutputStream.flush();
+
+				return new FileInputStream(_overflowFile);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
 		}
 
-		private final ByteArrayOutputStream _byteArrayOutputStream =
+		private synchronized void _write(byte[] bytes, int length) {
+			try {
+				if (_overflowOutputStream != null) {
+					_overflowOutputStream.write(bytes, 0, length);
+
+					return;
+				}
+
+				if ((_byteArrayOutputStream.size() + length) <=
+						_MEMORY_THRESHOLD) {
+
+					_byteArrayOutputStream.write(bytes, 0, length);
+
+					return;
+				}
+
+				_overflowFile = File.createTempFile(
+					"buffered-process-overflow-", ".tmp");
+
+				_overflowFile.deleteOnExit();
+
+				_overflowOutputStream = new BufferedOutputStream(
+					new FileOutputStream(_overflowFile));
+
+				_byteArrayOutputStream.writeTo(_overflowOutputStream);
+
+				_byteArrayOutputStream = null;
+
+				_overflowOutputStream.write(bytes, 0, length);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+		}
+
+		private ByteArrayOutputStream _byteArrayOutputStream =
 			new ByteArrayOutputStream();
 		private final InputStream _inputStream;
+		private File _overflowFile;
+		private OutputStream _overflowOutputStream;
 
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1109,6 +1109,20 @@ public class GitWorkingDirectory {
 			localGitBranch.getName(), true, localGitBranch.getSHA());
 	}
 
+	public void fetchGitCommitParentFromUpstream(String sha) {
+		GitRemote upstreamGitRemote = getUpstreamGitRemote();
+
+		if (upstreamGitRemote == null) {
+			return;
+		}
+
+		executeBashCommands(
+			3, GitUtil.MILLIS_RETRY_DELAY, 1000 * 60 * 15,
+			JenkinsResultsParserUtil.combine(
+				"git fetch -f --depth=2 ", upstreamGitRemote.getRemoteURL(),
+				" ", sha));
+	}
+
 	public Set<File> findFiles(String fileName, String fileContentSnippet) {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(fileContentSnippet)) {
 			return null;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
@@ -54,6 +54,43 @@ public class BaseLocalGitCommitTest
 		);
 	}
 
+	@Test
+	public void testIsFileChangedParentPresent() throws Exception {
+		Shell shell = _mockGitWorkingDirectoryShell();
+
+		setShellCommandOutput(
+			"git cat-file -t " + _SHA + "^", shell, "commit\n");
+		setShellCommandOutput("git show " + _SHA, shell, _PATCH);
+
+		LocalGitCommit localGitCommit = _newLocalGitCommit();
+
+		Assert.assertTrue(
+			localGitCommit.isFileChanged(
+				new File(temporaryFolder.getRoot(), "foo.txt")));
+	}
+
+	@Test
+	public void testIsFileChangedParentUnavailable() throws Exception {
+		Shell shell = _mockGitWorkingDirectoryShell();
+
+		_setShellExitValue(shell, "git cat-file -t " + _SHA + "^", 128);
+		setShellCommandOutput("git fetch -f --depth=2", shell, "");
+
+		LocalGitCommit localGitCommit = _newLocalGitCommit();
+
+		Assert.assertFalse(
+			localGitCommit.isFileChanged(
+				new File(temporaryFolder.getRoot(), "foo.txt")));
+
+		Mockito.verify(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> hasCommand(
+					executionRequest, "git fetch -f --depth=2", _SHA))
+		);
+	}
+
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
@@ -49,31 +49,13 @@ public class BaseLocalGitCommitTest
 			shell
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _hasCommand(
+				executionRequest -> hasCommand(
 					executionRequest, "git fetch -f --depth=2", _SHA))
 		);
 	}
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-	private boolean _hasCommand(
-		Shell.ExecutionRequest executionRequest, String... substrings) {
-
-		if (executionRequest == null) {
-			return false;
-		}
-
-		String command = executionRequest.getCommands()[0];
-
-		for (String substring : substrings) {
-			if (!command.contains(substring)) {
-				return false;
-			}
-		}
-
-		return true;
-	}
 
 	private Shell _mockGitWorkingDirectoryShell() throws Exception {
 		Shell shell = mockShell();
@@ -112,7 +94,7 @@ public class BaseLocalGitCommitTest
 			shell
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _hasCommand(executionRequest, command))
+				executionRequest -> hasCommand(executionRequest, command))
 		);
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseLocalGitCommitTest.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Peter Yoo
+ */
+public class BaseLocalGitCommitTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetPatchParentPresent() throws Exception {
+		Shell shell = _mockGitWorkingDirectoryShell();
+
+		setShellCommandOutput(
+			"git cat-file -t " + _SHA + "^", shell, "commit\n");
+		setShellCommandOutput(
+			"git show " + _SHA + " --patch --stat", shell, _PATCH);
+
+		LocalGitCommit localGitCommit = _newLocalGitCommit();
+
+		Assert.assertEquals(_PATCH, localGitCommit.getPatch());
+	}
+
+	@Test
+	public void testGetPatchParentUnavailable() throws Exception {
+		Shell shell = _mockGitWorkingDirectoryShell();
+
+		_setShellExitValue(shell, "git cat-file -t " + _SHA + "^", 128);
+		setShellCommandOutput("git fetch -f --depth=2", shell, "");
+
+		LocalGitCommit localGitCommit = _newLocalGitCommit();
+
+		Assert.assertNull(localGitCommit.getPatch());
+
+		Mockito.verify(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _hasCommand(
+					executionRequest, "git fetch -f --depth=2", _SHA))
+		);
+	}
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private boolean _hasCommand(
+		Shell.ExecutionRequest executionRequest, String... substrings) {
+
+		if (executionRequest == null) {
+			return false;
+		}
+
+		String command = executionRequest.getCommands()[0];
+
+		for (String substring : substrings) {
+			if (!command.contains(substring)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private Shell _mockGitWorkingDirectoryShell() throws Exception {
+		Shell shell = mockShell();
+
+		setShellCommandOutput(
+			"git remote -v", shell,
+			"upstream\tgit@github.com:liferay/liferay-portal.git (fetch)\n" +
+				"upstream\tgit@github.com:liferay/liferay-portal.git (push)\n");
+		setShellCommandOutput("git rev-parse master", shell, _SHA);
+
+		return shell;
+	}
+
+	private LocalGitCommit _newLocalGitCommit() {
+		File gitRepositoryDir = temporaryFolder.getRoot();
+
+		File gitDir = new File(gitRepositoryDir, ".git");
+
+		gitDir.mkdir();
+
+		GitWorkingDirectory gitWorkingDirectory =
+			GitWorkingDirectoryFactory.newGitWorkingDirectory(
+				"master", gitRepositoryDir, "liferay-portal");
+
+		return GitCommitFactory.newLocalGitCommit(
+			"test@liferay.com", gitWorkingDirectory, "LRCI-7850 Test commit",
+			_SHA, 0);
+	}
+
+	private void _setShellExitValue(Shell shell, String command, int exitValue)
+		throws Exception {
+
+		Mockito.doReturn(
+			new Shell.ExecutionResult(exitValue, "", "")
+		).when(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> _hasCommand(executionRequest, command))
+		);
+	}
+
+	private static final String _PATCH = "diff --git a/foo.txt b/foo.txt\n+bar";
+
+	private static final String _SHA =
+		"abcdef1234567890abcdef1234567890abcdef12";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BufferedProcessTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BufferedProcessTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BufferedProcessTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BufferedProcessTest.java
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Peter Yoo
+ */
+public class BufferedProcessTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testOutputOverThreshold() throws Exception {
+		byte[] standardOut = _newBytes(11 * 1024 * 1024);
+
+		Assert.assertArrayEquals(standardOut, _readStandardOut(standardOut));
+	}
+
+	@Test
+	public void testOutputUnderThreshold() throws Exception {
+		byte[] standardOut = _newBytes(1024);
+
+		Assert.assertArrayEquals(standardOut, _readStandardOut(standardOut));
+	}
+
+	private byte[] _newBytes(int size) {
+		byte[] bytes = new byte[size];
+
+		for (int i = 0; i < size; i++) {
+			bytes[i] = (byte)('a' + (i % 26));
+		}
+
+		return bytes;
+	}
+
+	private byte[] _readInputStream(InputStream inputStream) throws Exception {
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		byte[] bytes = new byte[8192];
+
+		int bytesRead = inputStream.read(bytes);
+
+		while (bytesRead != -1) {
+			byteArrayOutputStream.write(bytes, 0, bytesRead);
+
+			bytesRead = inputStream.read(bytes);
+		}
+
+		return byteArrayOutputStream.toByteArray();
+	}
+
+	private byte[] _readStandardOut(byte[] standardOut) throws Exception {
+		BufferedProcess bufferedProcess = new BufferedProcess(
+			new StubProcess(standardOut));
+
+		byte[] read = new byte[0];
+
+		for (int i = 0; i < 1000; i++) {
+			read = _readInputStream(bufferedProcess.getInputStream());
+
+			if (read.length >= standardOut.length) {
+				break;
+			}
+
+			JenkinsResultsParserUtil.sleep(10);
+		}
+
+		return read;
+	}
+
+	private static class StubProcess extends Process {
+
+		public StubProcess(byte[] standardOut) {
+			_standardOut = standardOut;
+		}
+
+		@Override
+		public void destroy() {
+		}
+
+		@Override
+		public int exitValue() {
+			return 0;
+		}
+
+		@Override
+		public InputStream getErrorStream() {
+			return new ByteArrayInputStream(new byte[0]);
+		}
+
+		@Override
+		public InputStream getInputStream() {
+			return new ByteArrayInputStream(_standardOut);
+		}
+
+		@Override
+		public OutputStream getOutputStream() {
+			return new ByteArrayOutputStream();
+		}
+
+		@Override
+		public int waitFor() {
+			return 0;
+		}
+
+		private final byte[] _standardOut;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BufferedProcessTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BufferedProcessTest.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -23,14 +24,28 @@ public class BufferedProcessTest
 	public void testOutputOverThreshold() throws Exception {
 		byte[] standardOut = _newBytes(11 * 1024 * 1024);
 
-		Assert.assertArrayEquals(standardOut, _readStandardOut(standardOut));
+		BufferedProcess bufferedProcess = new BufferedProcess(
+			new StubProcess(standardOut));
+
+		Assert.assertArrayEquals(
+			standardOut, _readStandardOut(bufferedProcess, standardOut.length));
+
+		Assert.assertTrue(
+			bufferedProcess.getInputStream() instanceof FileInputStream);
 	}
 
 	@Test
 	public void testOutputUnderThreshold() throws Exception {
 		byte[] standardOut = _newBytes(1024);
 
-		Assert.assertArrayEquals(standardOut, _readStandardOut(standardOut));
+		BufferedProcess bufferedProcess = new BufferedProcess(
+			new StubProcess(standardOut));
+
+		Assert.assertArrayEquals(
+			standardOut, _readStandardOut(bufferedProcess, standardOut.length));
+
+		Assert.assertTrue(
+			bufferedProcess.getInputStream() instanceof ByteArrayInputStream);
 	}
 
 	private byte[] _newBytes(int size) {
@@ -60,16 +75,16 @@ public class BufferedProcessTest
 		return byteArrayOutputStream.toByteArray();
 	}
 
-	private byte[] _readStandardOut(byte[] standardOut) throws Exception {
-		BufferedProcess bufferedProcess = new BufferedProcess(
-			new StubProcess(standardOut));
+	private byte[] _readStandardOut(
+			BufferedProcess bufferedProcess, int expectedLength)
+		throws Exception {
 
 		byte[] read = new byte[0];
 
 		for (int i = 0; i < 1000; i++) {
 			read = _readInputStream(bufferedProcess.getInputStream());
 
-			if (read.length >= standardOut.length) {
+			if (read.length >= expectedLength) {
 				break;
 			}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitWorkingDirectoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitWorkingDirectoryTest.java
@@ -12,11 +12,54 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import org.mockito.Mockito;
+
 /**
  * @author Kenji Heigel
  */
 public class GitWorkingDirectoryTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testFetchGitCommitParentFromUpstream() throws Exception {
+		File gitRepositoryDir = temporaryFolder.getRoot();
+
+		File gitDir = new File(gitRepositoryDir, ".git");
+
+		gitDir.mkdir();
+
+		Shell shell = mockShell();
+
+		setShellCommandOutput(
+			"git remote -v", shell,
+			"upstream\tgit@github.com:liferay/liferay-portal.git (fetch)\n" +
+				"upstream\tgit@github.com:liferay/liferay-portal.git (push)\n");
+
+		setShellCommandOutput("git rev-parse master", shell, _LOCAL_BRANCH_SHA);
+		setShellCommandOutput("git fetch -f --depth=2", shell, "");
+
+		GitWorkingDirectory gitWorkingDirectory =
+			GitWorkingDirectoryFactory.newGitWorkingDirectory(
+				"master", gitRepositoryDir, "liferay-portal");
+
+		gitWorkingDirectory.fetchGitCommitParentFromUpstream(_LOCAL_BRANCH_SHA);
+
+		Mockito.verify(
+			shell
+		).doExecute(
+			Mockito.argThat(
+				executionRequest -> {
+					if (executionRequest == null) {
+						return false;
+					}
+
+					String command = executionRequest.getCommands()[0];
+
+					return command.contains("git fetch -f --depth=2") &&
+						   command.contains(_LOCAL_BRANCH_SHA);
+				})
+		);
+	}
 
 	@Test
 	public void testGetLocalGitBranchSHA() throws Exception {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitWorkingDirectoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitWorkingDirectoryTest.java
@@ -48,16 +48,9 @@ public class GitWorkingDirectoryTest
 			shell
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> {
-					if (executionRequest == null) {
-						return false;
-					}
-
-					String command = executionRequest.getCommands()[0];
-
-					return command.contains("git fetch -f --depth=2") &&
-						   command.contains(_LOCAL_BRANCH_SHA);
-				})
+				executionRequest -> hasCommand(
+					executionRequest, "git fetch -f --depth=2",
+					_LOCAL_BRANCH_SHA))
 		);
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -304,6 +304,24 @@ public class Test {
 		return _simpleClassNames;
 	}
 
+	protected boolean hasCommand(
+		Shell.ExecutionRequest executionRequest, String... substrings) {
+
+		if (executionRequest == null) {
+			return false;
+		}
+
+		String command = executionRequest.getCommands()[0];
+
+		for (String substring : substrings) {
+			if (!command.contains(substring)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	protected Environment mockEnvironment(
 		Map<String, String> environmentValues) {
 
@@ -385,7 +403,7 @@ public class Test {
 			shell
 		).doExecute(
 			Mockito.argThat(
-				executionRequest -> _hasCommand(command, executionRequest))
+				executionRequest -> hasCommand(executionRequest, command))
 		);
 	}
 
@@ -449,18 +467,6 @@ public class Test {
 		getSimpleClassNames());
 	protected ExpectedMessageGenerator expectedMessageGenerator;
 	protected Map<String, TestSample> testSamples = new HashMap<>();
-
-	private boolean _hasCommand(
-		String command, Shell.ExecutionRequest executionRequest) {
-
-		if (executionRequest == null) {
-			return false;
-		}
-
-		String[] commands = executionRequest.getCommands();
-
-		return commands[0].contains(command);
-	}
 
 	private static final String[][] _XML_REPLACEMENTS = {
 		{"<pre>", "<pre><![CDATA["}, {"</pre>", "]]></pre>"},


### PR DESCRIPTION
- [LRCI-7850](https://liferay.atlassian.net/browse/LRCI-7850)

## What Is Being Fixed

During `stop-current-job` teardown, Jenkins Results Parser runs `git show <sha>`
and buffers the whole output in memory. CI shallow-clones the tested commit at
`--depth=1`, so at the shallow boundary its parent object is absent, `git show`
diffs against the empty tree, and emits the entire repository as one patch over
2 GB, exhausting the 8 GB heap. The failure is intermittent because each run
assembles its local history differently.

## How It Is Being Fixed

`BaseLocalGitCommit` checks for the parent object before running `git show`.
When it is missing, it fetches one commit deeper (`git fetch --depth=2`) to
recover the real diff, and skips the patch with a warning only if the parent
still cannot be fetched. Separately, `BufferedProcess` caps in-memory process
output at 10 MB and overflows to a temp file beyond that, so no single command
can exhaust the heap. The overflow file is deleted when the process is destroyed.

## PR Check

**pr-check: PASS** — tested on `1daeb254a300d7fb99d897bdbd9bddd001f6459c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

Scoped to the validations that fire for a jrp-only diff. One pre-existing,
unrelated failure (`PropertyValidatorTest`, `SecretsUtil` build properties) is
outside this diff.

<!-- pr-check {"result": "success", "sha": "1daeb254a300d7fb99d897bdbd9bddd001f6459c"} -->
