### PR TITLE
LRCI-7816 Add the monitor check engine (Phase 1)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -16,13 +16,15 @@ public class MonitorConfig {
 
 	public MonitorConfig(
 		long cadence, String id, Map<String, String> parameters,
-		Severity severity, Map<String, String> thresholds, String type) {
+		Severity severity, Map<String, String> thresholds, long timeout,
+		String type) {
 
 		_cadence = cadence;
 		_id = id;
 		_parameters = _newUnmodifiableMap(parameters);
 		_severity = severity;
 		_thresholds = _newUnmodifiableMap(thresholds);
+		_timeout = timeout;
 		_type = type;
 	}
 
@@ -44,6 +46,10 @@ public class MonitorConfig {
 
 	public Map<String, String> getThresholds() {
 		return _thresholds;
+	}
+
+	public long getTimeout() {
+		return _timeout;
 	}
 
 	public String getType() {
@@ -69,6 +75,7 @@ public class MonitorConfig {
 	private final Map<String, String> _parameters;
 	private final Severity _severity;
 	private final Map<String, String> _thresholds;
+	private final long _timeout;
 	private final String _type;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
@@ -40,26 +40,6 @@ public class MonitorConfigLoader {
 		return monitorConfigs;
 	}
 
-	private static long _getCadence(Properties buildProperties, String id) {
-		String cadenceString = JenkinsResultsParserUtil.getProperty(
-			buildProperties, _getKey(id, "cadence"));
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(cadenceString)) {
-			return 0;
-		}
-
-		try {
-			return Long.parseLong(cadenceString);
-		}
-		catch (NumberFormatException numberFormatException) {
-			throw new IllegalArgumentException(
-				JenkinsResultsParserUtil.combine(
-					"Invalid cadence for ", _getKey(id, "cadence"), ": ",
-					cadenceString),
-				numberFormatException);
-		}
-	}
-
 	private static TreeSet<String> _getIds(Properties buildProperties) {
 		TreeSet<String> ids = new TreeSet<>();
 
@@ -99,6 +79,29 @@ public class MonitorConfigLoader {
 		return JenkinsResultsParserUtil.combine("monitor[", id, "].", suffix);
 	}
 
+	private static long _getLong(
+		Properties buildProperties, long defaultValue, String id,
+		String suffix) {
+
+		String string = JenkinsResultsParserUtil.getProperty(
+			buildProperties, _getKey(id, suffix));
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(string)) {
+			return defaultValue;
+		}
+
+		try {
+			return Long.parseLong(string);
+		}
+		catch (NumberFormatException numberFormatException) {
+			throw new IllegalArgumentException(
+				JenkinsResultsParserUtil.combine(
+					"Invalid ", suffix, " for ", _getKey(id, suffix), ": ",
+					string),
+				numberFormatException);
+		}
+	}
+
 	private static MonitorConfig _getMonitorConfig(
 		Properties buildProperties, String id) {
 
@@ -111,10 +114,11 @@ public class MonitorConfigLoader {
 		}
 
 		return new MonitorConfig(
-			_getCadence(buildProperties, id), id,
+			_getLong(buildProperties, 0, id, "cadence"), id,
 			_getParameters(buildProperties, id),
 			_getSeverity(buildProperties, id),
-			_getThresholds(buildProperties, id), type);
+			_getThresholds(buildProperties, id),
+			_getLong(buildProperties, 60, id, "timeout"), type);
 	}
 
 	private static Map<String, String> _getParameters(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorEngine {
+
+	public MonitorEngine(
+		MonitorResultStore monitorResultStore, List<Monitor> monitors) {
+
+		_monitorResultStore = monitorResultStore;
+		_monitors = monitors;
+
+		_monitorScheduler = new MonitorScheduler(monitorResultStore);
+	}
+
+	public Map<Monitor, MonitorResult> runCycle(long timestamp) {
+		Map<Monitor, MonitorResult> monitorResultsMap = _monitorRunner.run(
+			_monitorScheduler.getDueMonitors(_monitors, timestamp), timestamp);
+
+		for (Map.Entry<Monitor, MonitorResult> entry :
+				monitorResultsMap.entrySet()) {
+
+			Monitor monitor = entry.getKey();
+
+			_monitorResultStore.store(monitor.getId(), entry.getValue());
+		}
+
+		return monitorResultsMap;
+	}
+
+	private final MonitorResultStore _monitorResultStore;
+	private final MonitorRunner _monitorRunner = new MonitorRunner();
+	private final List<Monitor> _monitors;
+	private final MonitorScheduler _monitorScheduler;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStore.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStore.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorResultStore {
+
+	public MonitorResultStore() {
+		this(100);
+	}
+
+	public MonitorResultStore(int maxMonitorResultCount) {
+		if (maxMonitorResultCount < 1) {
+			throw new IllegalArgumentException(
+				"Invalid max monitor result count: " + maxMonitorResultCount);
+		}
+
+		_maxMonitorResultCount = maxMonitorResultCount;
+	}
+
+	public MonitorResult getLatestMonitorResult(String id) {
+		List<MonitorResult> monitorResults = _monitorResultsMap.get(id);
+
+		if (monitorResults == null) {
+			return null;
+		}
+
+		return monitorResults.get(monitorResults.size() - 1);
+	}
+
+	public List<MonitorResult> getMonitorResults(String id) {
+		List<MonitorResult> monitorResults = _monitorResultsMap.get(id);
+
+		if (monitorResults == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.unmodifiableList(new ArrayList<>(monitorResults));
+	}
+
+	public void store(String id, MonitorResult monitorResult) {
+		List<MonitorResult> monitorResults = _monitorResultsMap.get(id);
+
+		if (monitorResults == null) {
+			monitorResults = new ArrayList<>();
+
+			_monitorResultsMap.put(id, monitorResults);
+		}
+
+		monitorResults.add(monitorResult);
+
+		while (monitorResults.size() > _maxMonitorResultCount) {
+			monitorResults.remove(0);
+		}
+	}
+
+	private final int _maxMonitorResultCount;
+	private final Map<String, List<MonitorResult>> _monitorResultsMap =
+		new HashMap<>();
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
@@ -1,0 +1,207 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorRunner {
+
+	public MonitorRunner() {
+		this(60 * 1000, 4);
+	}
+
+	public MonitorRunner(long defaultTimeoutMillis, int threadCount) {
+		if (defaultTimeoutMillis < 1) {
+			throw new IllegalArgumentException(
+				"Invalid default timeout: " + defaultTimeoutMillis);
+		}
+
+		if (threadCount < 1) {
+			throw new IllegalArgumentException(
+				"Invalid thread count: " + threadCount);
+		}
+
+		_defaultTimeoutMillis = defaultTimeoutMillis;
+		_threadCount = threadCount;
+	}
+
+	public Map<Monitor, MonitorResult> run(
+		Collection<Monitor> monitors, long timestamp) {
+
+		Map<Monitor, MonitorResult> monitorResultsMap = new LinkedHashMap<>();
+
+		if ((monitors == null) || monitors.isEmpty()) {
+			return monitorResultsMap;
+		}
+
+		ExecutorService executorService = _newExecutorService();
+
+		try {
+			long startTimestamp = System.currentTimeMillis();
+
+			Map<Monitor, Future<MonitorResult>> futuresMap =
+				new LinkedHashMap<>();
+
+			for (final Monitor monitor : monitors) {
+				futuresMap.put(
+					monitor,
+					executorService.submit(
+						new Callable<MonitorResult>() {
+
+							@Override
+							public MonitorResult call() {
+								return monitor.execute();
+							}
+
+						}));
+			}
+
+			for (Map.Entry<Monitor, Future<MonitorResult>> entry :
+					futuresMap.entrySet()) {
+
+				Monitor monitor = entry.getKey();
+
+				monitorResultsMap.put(
+					monitor,
+					_getMonitorResult(
+						entry.getValue(), monitor, startTimestamp, timestamp));
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+
+		return monitorResultsMap;
+	}
+
+	private MonitorResult _getMonitorResult(
+		Future<MonitorResult> future, Monitor monitor, long startTimestamp,
+		long timestamp) {
+
+		long timeoutMillis = _getTimeoutMillis(monitor);
+
+		long remainingMillis =
+			startTimestamp + timeoutMillis - System.currentTimeMillis();
+
+		if (remainingMillis < 0) {
+			remainingMillis = 0;
+		}
+
+		try {
+			MonitorResult monitorResult = future.get(
+				remainingMillis, TimeUnit.MILLISECONDS);
+
+			if (monitorResult == null) {
+				return _newUnknownMonitorResult(
+					JenkinsResultsParserUtil.combine(
+						"Monitor ", monitor.getId(), " returned no result"),
+					timestamp);
+			}
+
+			return new MonitorResult(
+				monitorResult.getMessage(), monitorResult.getMetrics(),
+				monitorResult.getStatus(), timestamp);
+		}
+		catch (ExecutionException executionException) {
+			Throwable throwable = executionException.getCause();
+
+			String message = throwable.getMessage();
+
+			if (message == null) {
+				Class<?> clazz = throwable.getClass();
+
+				message = clazz.getName();
+			}
+
+			return _newUnknownMonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Monitor ", monitor.getId(), " failed: ", message),
+				timestamp);
+		}
+		catch (InterruptedException interruptedException) {
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			future.cancel(true);
+
+			return _newUnknownMonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Monitor ", monitor.getId(), " was interrupted"),
+				timestamp);
+		}
+		catch (TimeoutException timeoutException) {
+			future.cancel(true);
+
+			return _newUnknownMonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Monitor ", monitor.getId(), " timed out after ",
+					String.valueOf(timeoutMillis), " ms"),
+				timestamp);
+		}
+	}
+
+	private long _getTimeoutMillis(Monitor monitor) {
+		MonitorConfig monitorConfig = monitor.getMonitorConfig();
+
+		long timeout = monitorConfig.getTimeout();
+
+		if (timeout <= 0) {
+			return _defaultTimeoutMillis;
+		}
+
+		return timeout * 1000;
+	}
+
+	private ExecutorService _newExecutorService() {
+		return Executors.newFixedThreadPool(
+			_threadCount,
+			new ThreadFactory() {
+
+				@Override
+				public Thread newThread(Runnable runnable) {
+					Thread thread = new Thread(
+						runnable,
+						"monitor-runner-" + _threadNumber.getAndIncrement());
+
+					thread.setDaemon(true);
+
+					return thread;
+				}
+
+				private final AtomicInteger _threadNumber = new AtomicInteger(
+					1);
+
+			});
+	}
+
+	private MonitorResult _newUnknownMonitorResult(
+		String message, long timestamp) {
+
+		return new MonitorResult(
+			message, null, MonitorResult.Status.UNKNOWN, timestamp);
+	}
+
+	private final long _defaultTimeoutMillis;
+	private final int _threadCount;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorScheduler {
+
+	public MonitorScheduler(MonitorResultStore monitorResultStore) {
+		_monitorResultStore = monitorResultStore;
+	}
+
+	public List<Monitor> getDueMonitors(
+		List<Monitor> monitors, long timestamp) {
+
+		List<Monitor> dueMonitors = new ArrayList<>();
+
+		for (Monitor monitor : monitors) {
+			if (_isDue(monitor, timestamp)) {
+				dueMonitors.add(monitor);
+			}
+		}
+
+		return dueMonitors;
+	}
+
+	private boolean _isDue(Monitor monitor, long timestamp) {
+		MonitorResult latestMonitorResult =
+			_monitorResultStore.getLatestMonitorResult(monitor.getId());
+
+		if (latestMonitorResult == null) {
+			return true;
+		}
+
+		MonitorConfig monitorConfig = monitor.getMonitorConfig();
+
+		if ((timestamp - latestMonitorResult.getTimestamp()) >=
+				(monitorConfig.getCadence() * 1000)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private final MonitorResultStore _monitorResultStore;
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
@@ -28,6 +28,7 @@ public class MonitorConfigLoaderTest
 			"https://test-1-0.liferay.com/computer/api/json");
 		buildProperties.setProperty("monitor[masters].severity", "high");
 		buildProperties.setProperty("monitor[masters].threshold[disk]", "85");
+		buildProperties.setProperty("monitor[masters].timeout", "30");
 		buildProperties.setProperty("monitor[masters].type", "http-endpoint");
 
 		List<MonitorConfig> monitorConfigs =
@@ -42,6 +43,7 @@ public class MonitorConfigLoaderTest
 		testEquals("http-endpoint", monitorConfig.getType());
 		testEquals(MonitorConfig.Severity.HIGH, monitorConfig.getSeverity());
 		testEquals(900L, monitorConfig.getCadence());
+		testEquals(30L, monitorConfig.getTimeout());
 
 		Map<String, String> parameters = monitorConfig.getParameters();
 
@@ -81,6 +83,30 @@ public class MonitorConfigLoaderTest
 		buildProperties.setProperty("monitor[a].type", "http-endpoint");
 
 		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
+	}
+
+	@Test
+	public void testGetMonitorConfigsTimeout() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].timeout", "not-a-number");
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
+	}
+
+	@Test
+	public void testGetMonitorConfigsTimeoutDefault() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(buildProperties);
+
+		MonitorConfig monitorConfig = monitorConfigs.get(0);
+
+		testEquals(60L, monitorConfig.getTimeout());
 	}
 
 	private void _testGetMonitorConfigsExpectedIllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test(timeout = 10000)
+	public void testRunCycle() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		TestMonitor hangingTestMonitor = new TestMonitor(
+			_newMonitorConfig("a", 1)) {
+
+			@Override
+			public MonitorResult execute() {
+				try {
+					Thread.sleep(10000);
+				}
+				catch (InterruptedException interruptedException) {
+					Thread thread = Thread.currentThread();
+
+					thread.interrupt();
+				}
+
+				return null;
+			}
+
+		};
+
+		TestMonitor okTestMonitor = new TestMonitor(_newMonitorConfig("b", 0));
+
+		TestMonitor throwingTestMonitor = new TestMonitor(
+			_newMonitorConfig("c", 0)) {
+
+			@Override
+			public MonitorResult execute() {
+				throw new RuntimeException("boom");
+			}
+
+		};
+
+		MonitorEngine monitorEngine = new MonitorEngine(
+			monitorResultStore,
+			Arrays.<Monitor>asList(
+				hangingTestMonitor, okTestMonitor, throwingTestMonitor));
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorEngine.runCycle(
+			1000000L);
+
+		testEquals(3, monitorResultsMap.size());
+
+		MonitorResult latestMonitorResult =
+			monitorResultStore.getLatestMonitorResult("a");
+
+		testEquals(
+			MonitorResult.Status.UNKNOWN, latestMonitorResult.getStatus());
+		testEquals(
+			"Monitor a timed out after 1000 ms",
+			latestMonitorResult.getMessage());
+		testEquals(1000000L, latestMonitorResult.getTimestamp());
+
+		latestMonitorResult = monitorResultStore.getLatestMonitorResult("b");
+
+		testEquals(MonitorResult.Status.OK, latestMonitorResult.getStatus());
+		testEquals(1000000L, latestMonitorResult.getTimestamp());
+
+		latestMonitorResult = monitorResultStore.getLatestMonitorResult("c");
+
+		testEquals(
+			MonitorResult.Status.UNKNOWN, latestMonitorResult.getStatus());
+		testEquals("Monitor c failed: boom", latestMonitorResult.getMessage());
+
+		monitorResultsMap = monitorEngine.runCycle(1000000L);
+
+		testEquals(0, monitorResultsMap.size());
+
+		List<MonitorResult> monitorResults =
+			monitorResultStore.getMonitorResults("b");
+
+		testEquals(1, monitorResults.size());
+
+		monitorResultsMap = monitorEngine.runCycle(1900000L);
+
+		testEquals(3, monitorResultsMap.size());
+
+		monitorResults = monitorResultStore.getMonitorResults("b");
+
+		testEquals(2, monitorResults.size());
+	}
+
+	private MonitorConfig _newMonitorConfig(String id, long timeout) {
+		return new MonitorConfig(
+			900, id, null, MonitorConfig.Severity.MEDIUM, null, timeout,
+			"test");
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -17,7 +17,8 @@ public class MonitorFactoryTest
 	@Test
 	public void testNewMonitorUnknownType() {
 		MonitorConfig monitorConfig = new MonitorConfig(
-			0, "a", null, MonitorConfig.Severity.MEDIUM, null, "unknown-type");
+			0, "a", null, MonitorConfig.Severity.MEDIUM, null, 60,
+			"unknown-type");
 
 		try {
 			MonitorFactory.newMonitor(monitorConfig);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStoreTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStoreTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorResultStoreTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetLatestMonitorResult() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		testSame(null, monitorResultStore.getLatestMonitorResult("a"));
+
+		MonitorResult monitorResult1 = _newMonitorResult(1L);
+		MonitorResult monitorResult2 = _newMonitorResult(2L);
+
+		monitorResultStore.store("a", monitorResult1);
+		monitorResultStore.store("a", monitorResult2);
+
+		testSame(
+			monitorResult2, monitorResultStore.getLatestMonitorResult("a"));
+	}
+
+	@Test
+	public void testGetMonitorResults() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		List<MonitorResult> monitorResults =
+			monitorResultStore.getMonitorResults("a");
+
+		Assert.assertTrue(monitorResults.isEmpty());
+
+		MonitorResult monitorResult1 = _newMonitorResult(1L);
+		MonitorResult monitorResult2 = _newMonitorResult(2L);
+
+		monitorResultStore.store("a", monitorResult1);
+		monitorResultStore.store("a", monitorResult2);
+
+		monitorResults = monitorResultStore.getMonitorResults("a");
+
+		testEquals(2, monitorResults.size());
+		testSame(monitorResult1, monitorResults.get(0));
+		testSame(monitorResult2, monitorResults.get(1));
+	}
+
+	@Test
+	public void testGetMonitorResultsIsUnmodifiable() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store("a", _newMonitorResult(1L));
+
+		List<MonitorResult> monitorResults =
+			monitorResultStore.getMonitorResults("a");
+
+		try {
+			monitorResults.add(_newMonitorResult(2L));
+
+			Assert.fail("Expected UnsupportedOperationException");
+		}
+		catch (UnsupportedOperationException unsupportedOperationException) {
+		}
+	}
+
+	@Test
+	public void testStoreRetention() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore(2);
+
+		MonitorResult monitorResult1 = _newMonitorResult(1L);
+		MonitorResult monitorResult2 = _newMonitorResult(2L);
+		MonitorResult monitorResult3 = _newMonitorResult(3L);
+
+		monitorResultStore.store("a", monitorResult1);
+		monitorResultStore.store("a", monitorResult2);
+		monitorResultStore.store("a", monitorResult3);
+
+		List<MonitorResult> monitorResults =
+			monitorResultStore.getMonitorResults("a");
+
+		testEquals(2, monitorResults.size());
+		testSame(monitorResult2, monitorResults.get(0));
+		testSame(monitorResult3, monitorResults.get(1));
+	}
+
+	private MonitorResult _newMonitorResult(long timestamp) {
+		return new MonitorResult(
+			"ok", null, MonitorResult.Status.OK, timestamp);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
@@ -1,0 +1,350 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorRunnerTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test(timeout = 5000)
+	public void testRun() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor1 = new TestMonitor(_newMonitorConfig("a"));
+		TestMonitor testMonitor2 = new TestMonitor(_newMonitorConfig("b"));
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			testMonitor1, testMonitor2);
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			monitors, 1L);
+
+		testEquals(monitors, new ArrayList<>(monitorResultsMap.keySet()));
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(1L, monitorResult.getTimestamp());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(1L, monitorResult.getTimestamp());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunCancelsHangingMonitor() throws Exception {
+		MonitorRunner monitorRunner = new MonitorRunner(100, 1);
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		monitorRunner.run(
+			Collections.<Monitor>singletonList(
+				new HangingTestMonitor(countDownLatch, _newMonitorConfig("a"))),
+			1L);
+
+		Assert.assertTrue(countDownLatch.await(1, TimeUnit.SECONDS));
+	}
+
+	@Test(timeout = 5000)
+	public void testRunConcurrentMonitors() {
+		MonitorRunner monitorRunner = new MonitorRunner(60 * 1000, 2);
+
+		CountDownLatch countDownLatch = new CountDownLatch(2);
+
+		TestMonitor testMonitor1 = new ConcurrentTestMonitor(
+			countDownLatch, _newMonitorConfig("a"));
+		TestMonitor testMonitor2 = new ConcurrentTestMonitor(
+			countDownLatch, _newMonitorConfig("b"));
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(testMonitor1, testMonitor2), 1L);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunDuplicateIds() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(
+				new TestMonitor(_newMonitorConfig("a")),
+				new TestMonitor(_newMonitorConfig("a"))),
+			1L);
+
+		testEquals(2, monitorResultsMap.size());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunEmpty() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>emptyList(), 1L);
+
+		Assert.assertTrue(monitorResultsMap.isEmpty());
+
+		monitorResultsMap = monitorRunner.run(null, 1L);
+
+		Assert.assertTrue(monitorResultsMap.isEmpty());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunHangingMonitor() {
+		MonitorRunner monitorRunner = new MonitorRunner(100, 2);
+
+		TestMonitor testMonitor = new HangingTestMonitor(
+			null, _newMonitorConfig("a"));
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor), 1L);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Monitor a timed out after 100 ms", monitorResult.getMessage());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunHangingMonitorDoesNotBlockOthers() {
+		MonitorRunner monitorRunner = new MonitorRunner(100, 2);
+
+		TestMonitor testMonitor1 = new HangingTestMonitor(
+			null, _newMonitorConfig("a"));
+		TestMonitor testMonitor2 = new TestMonitor(_newMonitorConfig("b"));
+		TestMonitor testMonitor3 = new TestMonitor(_newMonitorConfig("c"));
+
+		long startTimestamp = System.currentTimeMillis();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(testMonitor1, testMonitor2, testMonitor3),
+			1L);
+
+		Assert.assertTrue((System.currentTimeMillis() - startTimestamp) < 2000);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+
+		monitorResult = monitorResultsMap.get(testMonitor3);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunMultipleHangingMonitors() {
+		MonitorRunner monitorRunner = new MonitorRunner(200, 4);
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			new HangingTestMonitor(null, _newMonitorConfig("a")),
+			new HangingTestMonitor(null, _newMonitorConfig("b")),
+			new HangingTestMonitor(null, _newMonitorConfig("c")),
+			new HangingTestMonitor(null, _newMonitorConfig("d")));
+
+		long startTimestamp = System.currentTimeMillis();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			monitors, 1L);
+
+		Assert.assertTrue((System.currentTimeMillis() - startTimestamp) < 600);
+
+		for (MonitorResult monitorResult : monitorResultsMap.values()) {
+			testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		}
+	}
+
+	@Test(timeout = 5000)
+	public void testRunNullMessageThrowingMonitor() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor = new TestMonitor(_newMonitorConfig("a")) {
+
+			@Override
+			public MonitorResult execute() {
+				throw new RuntimeException();
+			}
+
+		};
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor), 1L);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Monitor a failed: java.lang.RuntimeException",
+			monitorResult.getMessage());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunNullResultMonitor() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor = new TestMonitor(_newMonitorConfig("a")) {
+
+			@Override
+			public MonitorResult execute() {
+				return null;
+			}
+
+		};
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor), 1L);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals("Monitor a returned no result", monitorResult.getMessage());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunThrowingMonitor() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor1 = new TestMonitor(_newMonitorConfig("a")) {
+
+			@Override
+			public MonitorResult execute() {
+				throw new RuntimeException("boom");
+			}
+
+		};
+
+		TestMonitor testMonitor2 = new TestMonitor(_newMonitorConfig("b"));
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(testMonitor1, testMonitor2), 1L);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals("Monitor a failed: boom", monitorResult.getMessage());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunTimeoutFromMonitorConfig() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor = new HangingTestMonitor(
+			null, _newMonitorConfig("a", 1));
+
+		long startTimestamp = System.currentTimeMillis();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor), 1L);
+
+		Assert.assertTrue((System.currentTimeMillis() - startTimestamp) < 3000);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Monitor a timed out after 1000 ms", monitorResult.getMessage());
+	}
+
+	private MonitorConfig _newMonitorConfig(String id) {
+		return _newMonitorConfig(id, 0);
+	}
+
+	private MonitorConfig _newMonitorConfig(String id, long timeout) {
+		return new MonitorConfig(
+			0, id, null, MonitorConfig.Severity.MEDIUM, null, timeout, "test");
+	}
+
+	private static class ConcurrentTestMonitor extends TestMonitor {
+
+		public ConcurrentTestMonitor(
+			CountDownLatch countDownLatch, MonitorConfig monitorConfig) {
+
+			super(monitorConfig);
+
+			_countDownLatch = countDownLatch;
+		}
+
+		@Override
+		public MonitorResult execute() {
+			_countDownLatch.countDown();
+
+			try {
+				if (!_countDownLatch.await(2, TimeUnit.SECONDS)) {
+					throw new IllegalStateException(
+						"Monitors did not run concurrently");
+				}
+			}
+			catch (InterruptedException interruptedException) {
+				throw new RuntimeException(interruptedException);
+			}
+
+			return super.execute();
+		}
+
+		private final CountDownLatch _countDownLatch;
+
+	}
+
+	private static class HangingTestMonitor extends TestMonitor {
+
+		public HangingTestMonitor(
+			CountDownLatch countDownLatch, MonitorConfig monitorConfig) {
+
+			super(monitorConfig);
+
+			_countDownLatch = countDownLatch;
+		}
+
+		@Override
+		public MonitorResult execute() {
+			try {
+				Thread.sleep(10000);
+			}
+			catch (InterruptedException interruptedException) {
+				if (_countDownLatch != null) {
+					_countDownLatch.countDown();
+				}
+
+				Thread thread = Thread.currentThread();
+
+				thread.interrupt();
+			}
+
+			return null;
+		}
+
+		private final CountDownLatch _countDownLatch;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorSchedulerTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetDueMonitors() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		MonitorScheduler monitorScheduler = new MonitorScheduler(
+			monitorResultStore);
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			new TestMonitor(_newMonitorConfig(900, "a")));
+
+		testEquals(
+			monitors, monitorScheduler.getDueMonitors(monitors, 1000000L));
+
+		monitorResultStore.store("a", _newMonitorResult(1000000L));
+
+		testEquals(
+			Collections.emptyList(),
+			monitorScheduler.getDueMonitors(monitors, 1899000L));
+		testEquals(
+			monitors, monitorScheduler.getDueMonitors(monitors, 1900000L));
+	}
+
+	@Test
+	public void testGetDueMonitorsZeroCadence() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		MonitorScheduler monitorScheduler = new MonitorScheduler(
+			monitorResultStore);
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			new TestMonitor(_newMonitorConfig(0, "a")));
+
+		monitorResultStore.store("a", _newMonitorResult(1000000L));
+
+		testEquals(
+			monitors, monitorScheduler.getDueMonitors(monitors, 1000000L));
+	}
+
+	private MonitorConfig _newMonitorConfig(long cadence, String id) {
+		return new MonitorConfig(
+			cadence, id, null, MonitorConfig.Severity.MEDIUM, null, 60, "test");
+	}
+
+	private MonitorResult _newMonitorResult(long timestamp) {
+		return new MonitorResult(
+			"ok", null, MonitorResult.Status.OK, timestamp);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/TestMonitor.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/TestMonitor.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class TestMonitor implements Monitor {
+
+	public TestMonitor(MonitorConfig monitorConfig) {
+		_monitorConfig = monitorConfig;
+	}
+
+	@Override
+	public MonitorResult execute() {
+		return new MonitorResult(
+			"ok", null, MonitorResult.Status.OK, System.currentTimeMillis());
+	}
+
+	@Override
+	public String getId() {
+		return _monitorConfig.getId();
+	}
+
+	@Override
+	public MonitorConfig getMonitorConfig() {
+		return _monitorConfig;
+	}
+
+	private final MonitorConfig _monitorConfig;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7816

## What Is Being Fixed

The monitoring effort has module scaffolding from LRCI-7815 (the Monitor contract, value types, config loader, and factory) but nothing that actually runs checks: no execution with timeouts, no cadence-based scheduling, and no state for the future dashboard and alerting phases to read.

## How It Is Being Fixed

MonitorRunner executes a cycle's due monitors on a small fixed pool of named daemon threads, with a per-monitor timeout enforced through deadlines anchored at submission, so several hanging checks cost max(timeout) rather than the sum. A check that times out, throws, or returns null yields a synthesized UNKNOWN result instead of failing the cycle. The runner is also the single timestamp authority: every stored result carries the cycle timestamp, so scheduling math and history stay on one clock. MonitorScheduler resolves dueness from the store's latest result against the per-monitor cadence (cadence 0 runs every tick). MonitorResultStore keeps the latest result plus a rolling, size-capped history per monitor id. MonitorEngine ties the three together in runCycle. A new monitor[<id>].timeout property (seconds, default 60) rides MonitorConfig and MonitorConfigLoader, with the cadence/timeout parsing consolidated into one _getLong helper.

Design notes for review:

- Timeout is a wait bound, not a strict SLA: a check whose result arrived before its collection turn is recorded with its real status even if it ran past its timeout, because a real observation beats a synthesized UNKNOWN. Documented in a comment on LRCI-7816.
- Deadlines start at submission, so queue time counts against a check's budget; the pool should be sized at or above the typical due-check count (default 4).
- MonitorResultStore is intentionally not thread-safe; the Phase 2 dashboard reader must stay on the cycle thread or add synchronization then.
- The 60-second timeout default appears in both MonitorConfigLoader (seconds) and the MonitorRunner default constructor (millis); a shared constant felt like more coupling than the drift risk warrants.
- MonitorFactory still throws for every type, so nothing invokes this engine yet — the jar change is inert until Phase 2 adds check types and the Jenkins job wiring.

## PR Check

**pr-check: PASS** — tested on `0139ab6ba2583d62735037887154a08b53c208a2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0139ab6ba2583d62735037887154a08b53c208a2"} -->
