### PR TITLE
LRCI-7786 Print where op connect entries are received from in CI

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -695,6 +695,10 @@ public abstract class SecretsUtil {
 			}
 			catch (Exception exception) {
 			}
+
+			System.out.println(
+				"Loaded " + _secrets.size() + " secrets from " +
+					_getConnectURL());
 		}
 
 		return null;
@@ -826,6 +830,10 @@ public abstract class SecretsUtil {
 
 				JenkinsResultsParserUtil.addRedactToken(value);
 			}
+
+			System.out.println(
+				"Loaded " + _cachedSecrets.size() + " secrets from " +
+					_getCachedSecretsURL());
 		}
 		catch (Exception exception) {
 			_cachedSecrets = null;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7786

## What Is Being Fixed

When CI loads secrets through op connect, the logs give no visibility into which op connect endpoint served the entries, making it hard to diagnose where secrets were actually loaded from.

## How It Is Being Fixed

SecretsUtil now prints how many secrets were loaded and the URL they came from, both when loading from an op connect URL and when loading from the cached secrets URL.

## Why Are There No Tests?

This change only adds System.out.println diagnostic output for CI; there is no behavior to test.

## PR Check

**pr-check: PASS** — tested on `93706b40537224025d4e585cb33e0aa03f9145f3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "93706b40537224025d4e585cb33e0aa03f9145f3"} -->
