### PR TITLE
LRCI-7816 Add the monitor check engine (Phase 1) (revised 2)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -15,12 +15,12 @@ import java.util.Map;
 public class MonitorConfig {
 
 	public MonitorConfig(
-		long intervalSeconds, String id, Map<String, String> parameters,
+		String id, long intervalSeconds, Map<String, String> parameters,
 		Severity severity, Map<String, String> thresholds, long timeout,
 		String type) {
 
-		_intervalSeconds = intervalSeconds;
 		_id = id;
+		_intervalSeconds = intervalSeconds;
 		_parameters = _newUnmodifiableMap(parameters);
 		_severity = severity;
 		_thresholds = _newUnmodifiableMap(thresholds);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -32,7 +32,7 @@ public class MonitorConfig {
 		return _id;
 	}
 
-	public long getInterval() {
+	public long getIntervalSeconds() {
 		return _intervalSeconds;
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -16,7 +16,7 @@ public class MonitorConfig {
 
 	public MonitorConfig(
 		String id, long intervalSeconds, Map<String, String> parameters,
-		Severity severity, Map<String, String> thresholds, long timeout,
+		Severity severity, Map<String, String> thresholds, long timeoutSeconds,
 		String type) {
 
 		_id = id;
@@ -24,7 +24,7 @@ public class MonitorConfig {
 		_parameters = _newUnmodifiableMap(parameters);
 		_severity = severity;
 		_thresholds = _newUnmodifiableMap(thresholds);
-		_timeout = timeout;
+		_timeoutSeconds = timeoutSeconds;
 		_type = type;
 	}
 
@@ -48,8 +48,8 @@ public class MonitorConfig {
 		return _thresholds;
 	}
 
-	public long getTimeout() {
-		return _timeout;
+	public long getTimeoutSeconds() {
+		return _timeoutSeconds;
 	}
 
 	public String getType() {
@@ -75,7 +75,7 @@ public class MonitorConfig {
 	private final Map<String, String> _parameters;
 	private final Severity _severity;
 	private final Map<String, String> _thresholds;
-	private final long _timeout;
+	private final long _timeoutSeconds;
 	private final String _type;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -15,11 +15,11 @@ import java.util.Map;
 public class MonitorConfig {
 
 	public MonitorConfig(
-		long interval, String id, Map<String, String> parameters,
+		long intervalSeconds, String id, Map<String, String> parameters,
 		Severity severity, Map<String, String> thresholds, long timeout,
 		String type) {
 
-		_interval = interval;
+		_intervalSeconds = intervalSeconds;
 		_id = id;
 		_parameters = _newUnmodifiableMap(parameters);
 		_severity = severity;
@@ -33,7 +33,7 @@ public class MonitorConfig {
 	}
 
 	public long getInterval() {
-		return _interval;
+		return _intervalSeconds;
 	}
 
 	public Map<String, String> getParameters() {
@@ -71,7 +71,7 @@ public class MonitorConfig {
 	}
 
 	private final String _id;
-	private final long _interval;
+	private final long _intervalSeconds;
 	private final Map<String, String> _parameters;
 	private final Severity _severity;
 	private final Map<String, String> _thresholds;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -16,13 +16,15 @@ public class MonitorConfig {
 
 	public MonitorConfig(
 		long cadence, String id, Map<String, String> parameters,
-		Severity severity, Map<String, String> thresholds, String type) {
+		Severity severity, Map<String, String> thresholds, long timeout,
+		String type) {
 
 		_cadence = cadence;
 		_id = id;
 		_parameters = _newUnmodifiableMap(parameters);
 		_severity = severity;
 		_thresholds = _newUnmodifiableMap(thresholds);
+		_timeout = timeout;
 		_type = type;
 	}
 
@@ -44,6 +46,10 @@ public class MonitorConfig {
 
 	public Map<String, String> getThresholds() {
 		return _thresholds;
+	}
+
+	public long getTimeout() {
+		return _timeout;
 	}
 
 	public String getType() {
@@ -69,6 +75,7 @@ public class MonitorConfig {
 	private final Map<String, String> _parameters;
 	private final Severity _severity;
 	private final Map<String, String> _thresholds;
+	private final long _timeout;
 	private final String _type;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -15,11 +15,11 @@ import java.util.Map;
 public class MonitorConfig {
 
 	public MonitorConfig(
-		long cadence, String id, Map<String, String> parameters,
+		long interval, String id, Map<String, String> parameters,
 		Severity severity, Map<String, String> thresholds, long timeout,
 		String type) {
 
-		_cadence = cadence;
+		_interval = interval;
 		_id = id;
 		_parameters = _newUnmodifiableMap(parameters);
 		_severity = severity;
@@ -28,12 +28,12 @@ public class MonitorConfig {
 		_type = type;
 	}
 
-	public long getCadence() {
-		return _cadence;
-	}
-
 	public String getId() {
 		return _id;
+	}
+
+	public long getInterval() {
+		return _interval;
 	}
 
 	public Map<String, String> getParameters() {
@@ -70,8 +70,8 @@ public class MonitorConfig {
 		return Collections.unmodifiableMap(new LinkedHashMap<>(map));
 	}
 
-	private final long _cadence;
 	private final String _id;
+	private final long _interval;
 	private final Map<String, String> _parameters;
 	private final Severity _severity;
 	private final Map<String, String> _thresholds;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
@@ -125,7 +125,7 @@ public class MonitorConfigLoader {
 		}
 
 		return new MonitorConfig(
-			_getLongProperty(buildProperties, 0, id, "interval"), id,
+			id, _getLongProperty(buildProperties, 0, id, "interval"),
 			_getParameters(buildProperties, id),
 			_getSeverity(buildProperties, id),
 			_getThresholds(buildProperties, id),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
@@ -40,26 +40,6 @@ public class MonitorConfigLoader {
 		return monitorConfigs;
 	}
 
-	private static long _getCadence(Properties buildProperties, String id) {
-		String cadenceString = JenkinsResultsParserUtil.getProperty(
-			buildProperties, _getKey(id, "cadence"));
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(cadenceString)) {
-			return 0;
-		}
-
-		try {
-			return Long.parseLong(cadenceString);
-		}
-		catch (NumberFormatException numberFormatException) {
-			throw new IllegalArgumentException(
-				JenkinsResultsParserUtil.combine(
-					"Invalid cadence for ", _getKey(id, "cadence"), ": ",
-					cadenceString),
-				numberFormatException);
-		}
-	}
-
 	private static TreeSet<String> _getIds(Properties buildProperties) {
 		TreeSet<String> ids = new TreeSet<>();
 
@@ -99,6 +79,40 @@ public class MonitorConfigLoader {
 		return JenkinsResultsParserUtil.combine("monitor[", id, "].", suffix);
 	}
 
+	private static long _getLongProperty(
+		Properties buildProperties, long defaultValue, String id,
+		String suffix) {
+
+		String propertyValue = JenkinsResultsParserUtil.getProperty(
+			buildProperties, _getKey(id, suffix));
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(propertyValue)) {
+			return defaultValue;
+		}
+
+		long value;
+
+		try {
+			value = Long.parseLong(propertyValue);
+		}
+		catch (NumberFormatException numberFormatException) {
+			throw new IllegalArgumentException(
+				JenkinsResultsParserUtil.combine(
+					"Invalid ", suffix, " for ", _getKey(id, suffix), ": ",
+					propertyValue),
+				numberFormatException);
+		}
+
+		if (value < 0) {
+			throw new IllegalArgumentException(
+				JenkinsResultsParserUtil.combine(
+					"Invalid ", suffix, " for ", _getKey(id, suffix), ": ",
+					propertyValue));
+		}
+
+		return value;
+	}
+
 	private static MonitorConfig _getMonitorConfig(
 		Properties buildProperties, String id) {
 
@@ -111,10 +125,11 @@ public class MonitorConfigLoader {
 		}
 
 		return new MonitorConfig(
-			_getCadence(buildProperties, id), id,
+			_getLongProperty(buildProperties, 0, id, "cadence"), id,
 			_getParameters(buildProperties, id),
 			_getSeverity(buildProperties, id),
-			_getThresholds(buildProperties, id), type);
+			_getThresholds(buildProperties, id),
+			_getLongProperty(buildProperties, 60, id, "timeout"), type);
 	}
 
 	private static Map<String, String> _getParameters(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
@@ -125,7 +125,7 @@ public class MonitorConfigLoader {
 		}
 
 		return new MonitorConfig(
-			_getLongProperty(buildProperties, 0, id, "cadence"), id,
+			_getLongProperty(buildProperties, 0, id, "interval"), id,
 			_getParameters(buildProperties, id),
 			_getSeverity(buildProperties, id),
 			_getThresholds(buildProperties, id),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorEngine {
+
+	public MonitorEngine(
+		MonitorResultStore monitorResultStore, List<Monitor> monitors) {
+
+		_monitorResultStore = monitorResultStore;
+		_monitors = monitors;
+
+		_monitorScheduler = new MonitorScheduler(monitorResultStore);
+	}
+
+	public Map<Monitor, MonitorResult> runCycle() {
+		Map<Monitor, MonitorResult> monitorResultsMap = _monitorRunner.run(
+			_monitorScheduler.getDueMonitors(_monitors));
+
+		long currentTimeMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		for (Map.Entry<Monitor, MonitorResult> entry :
+				monitorResultsMap.entrySet()) {
+
+			Monitor monitor = entry.getKey();
+
+			MonitorResult monitorResult = entry.getValue();
+
+			monitorResult = new MonitorResult(
+				monitorResult.getMessage(), monitorResult.getMetrics(),
+				monitorResult.getStatus(), currentTimeMillis);
+
+			entry.setValue(monitorResult);
+
+			_monitorResultStore.store(monitor.getId(), monitorResult);
+		}
+
+		return monitorResultsMap;
+	}
+
+	private final MonitorResultStore _monitorResultStore;
+	private final MonitorRunner _monitorRunner = new MonitorRunner();
+	private final List<Monitor> _monitors;
+	private final MonitorScheduler _monitorScheduler;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStore.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStore.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorResultStore {
+
+	public MonitorResultStore() {
+		this(100);
+	}
+
+	public MonitorResultStore(int maxMonitorResultCount) {
+		if (maxMonitorResultCount < 1) {
+			throw new IllegalArgumentException(
+				"Invalid max monitor result count: " + maxMonitorResultCount);
+		}
+
+		_maxMonitorResultCount = maxMonitorResultCount;
+	}
+
+	public MonitorResult getLatestMonitorResult(String id) {
+		List<MonitorResult> monitorResults = _monitorResultsMap.get(id);
+
+		if (monitorResults == null) {
+			return null;
+		}
+
+		return monitorResults.get(monitorResults.size() - 1);
+	}
+
+	public List<MonitorResult> getMonitorResults(String id) {
+		List<MonitorResult> monitorResults = _monitorResultsMap.get(id);
+
+		if (monitorResults == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.unmodifiableList(new ArrayList<>(monitorResults));
+	}
+
+	public void store(String id, MonitorResult monitorResult) {
+		List<MonitorResult> monitorResults = _monitorResultsMap.get(id);
+
+		if (monitorResults == null) {
+			monitorResults = new ArrayList<>();
+
+			_monitorResultsMap.put(id, monitorResults);
+		}
+
+		monitorResults.add(monitorResult);
+
+		while (monitorResults.size() > _maxMonitorResultCount) {
+			monitorResults.remove(0);
+		}
+	}
+
+	private final int _maxMonitorResultCount;
+	private final Map<String, List<MonitorResult>> _monitorResultsMap =
+		new HashMap<>();
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
@@ -88,13 +88,13 @@ public class MonitorRunner {
 	private long _getTimeoutMillis(Monitor monitor) {
 		MonitorConfig monitorConfig = monitor.getMonitorConfig();
 
-		long timeout = monitorConfig.getTimeout();
+		long timeoutSeconds = monitorConfig.getTimeoutSeconds();
 
-		if (timeout <= 0) {
+		if (timeoutSeconds <= 0) {
 			return _defaultTimeoutMillis;
 		}
 
-		return timeout * 1000;
+		return timeoutSeconds * 1000;
 	}
 
 	private ExecutorService _newExecutorService(int threadCount) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorRunner {
+
+	public MonitorRunner() {
+		this(60 * 1000);
+	}
+
+	public MonitorRunner(long defaultTimeoutMillis) {
+		if (defaultTimeoutMillis < 1) {
+			throw new IllegalArgumentException(
+				"Invalid default timeout: " + defaultTimeoutMillis);
+		}
+
+		_defaultTimeoutMillis = defaultTimeoutMillis;
+	}
+
+	public Map<Monitor, MonitorResult> run(Collection<Monitor> monitors) {
+		Map<Monitor, MonitorResult> monitorResultsMap = new LinkedHashMap<>();
+
+		if ((monitors == null) || monitors.isEmpty()) {
+			return monitorResultsMap;
+		}
+
+		ExecutorService executorService = _newExecutorService(monitors.size());
+
+		try {
+			long startTimestamp = System.currentTimeMillis();
+
+			Map<Monitor, Future<MonitorResult>> futuresMap =
+				new LinkedHashMap<>();
+
+			for (final Monitor monitor : monitors) {
+				futuresMap.put(
+					monitor,
+					executorService.submit(
+						new Callable<MonitorResult>() {
+
+							@Override
+							public MonitorResult call() {
+								return monitor.execute();
+							}
+
+						}));
+			}
+
+			for (Map.Entry<Monitor, Future<MonitorResult>> entry :
+					futuresMap.entrySet()) {
+
+				Monitor monitor = entry.getKey();
+
+				monitorResultsMap.put(
+					monitor,
+					_resolveMonitorResult(
+						entry.getValue(), monitor, startTimestamp));
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+
+		return monitorResultsMap;
+	}
+
+	private long _getTimeoutMillis(Monitor monitor) {
+		MonitorConfig monitorConfig = monitor.getMonitorConfig();
+
+		long timeout = monitorConfig.getTimeout();
+
+		if (timeout <= 0) {
+			return _defaultTimeoutMillis;
+		}
+
+		return timeout * 1000;
+	}
+
+	private ExecutorService _newExecutorService(int threadCount) {
+		return Executors.newFixedThreadPool(
+			threadCount,
+			new ThreadFactory() {
+
+				@Override
+				public Thread newThread(Runnable runnable) {
+					Thread thread = new Thread(
+						runnable,
+						"monitor-runner-" + _threadNumber.getAndIncrement());
+
+					thread.setDaemon(true);
+
+					return thread;
+				}
+
+				private final AtomicInteger _threadNumber = new AtomicInteger(
+					1);
+
+			});
+	}
+
+	private MonitorResult _newUnknownMonitorResult(String message) {
+		return new MonitorResult(
+			message, null, MonitorResult.Status.UNKNOWN,
+			System.currentTimeMillis());
+	}
+
+	private MonitorResult _resolveMonitorResult(
+		Future<MonitorResult> future, Monitor monitor, long startTimestamp) {
+
+		long timeoutMillis = _getTimeoutMillis(monitor);
+
+		long remainingMillis =
+			startTimestamp + timeoutMillis - System.currentTimeMillis();
+
+		if (remainingMillis < 0) {
+			remainingMillis = 0;
+		}
+
+		try {
+			MonitorResult monitorResult = future.get(
+				remainingMillis, TimeUnit.MILLISECONDS);
+
+			if (monitorResult == null) {
+				return _newUnknownMonitorResult(
+					JenkinsResultsParserUtil.combine(
+						"Monitor ", monitor.getId(), " returned no result"));
+			}
+
+			return monitorResult;
+		}
+		catch (ExecutionException executionException) {
+			Throwable throwable = executionException.getCause();
+
+			String message = throwable.getMessage();
+
+			if (message == null) {
+				Class<?> clazz = throwable.getClass();
+
+				message = clazz.getName();
+			}
+
+			return _newUnknownMonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Monitor ", monitor.getId(), " failed: ", message));
+		}
+		catch (InterruptedException interruptedException) {
+			Thread thread = Thread.currentThread();
+
+			thread.interrupt();
+
+			future.cancel(true);
+
+			return _newUnknownMonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Monitor ", monitor.getId(), " was interrupted"));
+		}
+		catch (TimeoutException timeoutException) {
+			future.cancel(true);
+
+			return _newUnknownMonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Monitor ", monitor.getId(), " timed out after ",
+					String.valueOf(timeoutMillis), " ms"));
+		}
+	}
+
+	private final long _defaultTimeoutMillis;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
@@ -45,7 +45,7 @@ public class MonitorScheduler {
 		MonitorConfig monitorConfig = monitor.getMonitorConfig();
 
 		if ((currentTimeMillis - latestMonitorResult.getTimestamp()) >=
-				(monitorConfig.getInterval() * 1000)) {
+				(monitorConfig.getIntervalSeconds() * 1000)) {
 
 			return true;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorScheduler {
+
+	public MonitorScheduler(MonitorResultStore monitorResultStore) {
+		_monitorResultStore = monitorResultStore;
+	}
+
+	public List<Monitor> getDueMonitors(List<Monitor> monitors) {
+		List<Monitor> dueMonitors = new ArrayList<>();
+
+		long currentTimeMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		for (Monitor monitor : monitors) {
+			if (_isDue(currentTimeMillis, monitor)) {
+				dueMonitors.add(monitor);
+			}
+		}
+
+		return dueMonitors;
+	}
+
+	private boolean _isDue(long currentTimeMillis, Monitor monitor) {
+		MonitorResult latestMonitorResult =
+			_monitorResultStore.getLatestMonitorResult(monitor.getId());
+
+		if (latestMonitorResult == null) {
+			return true;
+		}
+
+		MonitorConfig monitorConfig = monitor.getMonitorConfig();
+
+		if ((currentTimeMillis - latestMonitorResult.getTimestamp()) >=
+				(monitorConfig.getCadence() * 1000)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private final MonitorResultStore _monitorResultStore;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorScheduler.java
@@ -45,7 +45,7 @@ public class MonitorScheduler {
 		MonitorConfig monitorConfig = monitor.getMonitorConfig();
 
 		if ((currentTimeMillis - latestMonitorResult.getTimestamp()) >=
-				(monitorConfig.getCadence() * 1000)) {
+				(monitorConfig.getInterval() * 1000)) {
 
 			return true;
 		}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
@@ -17,6 +17,10 @@ public class RandomTestUtil {
 		return _random.nextDouble();
 	}
 
+	public static long randomLong() {
+		return _random.nextLong();
+	}
+
 	public static String randomString() {
 		UUID uuid = UUID.randomUUID();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
@@ -43,7 +43,7 @@ public class MonitorConfigLoaderTest
 		testEquals("http-endpoint", monitorConfig.getType());
 		testEquals(MonitorConfig.Severity.HIGH, monitorConfig.getSeverity());
 		testEquals(900L, monitorConfig.getIntervalSeconds());
-		testEquals(30L, monitorConfig.getTimeout());
+		testEquals(30L, monitorConfig.getTimeoutSeconds());
 
 		Map<String, String> parameters = monitorConfig.getParameters();
 
@@ -81,7 +81,7 @@ public class MonitorConfigLoaderTest
 
 		MonitorConfig monitorConfig = monitorConfigs.get(0);
 
-		testEquals(60L, monitorConfig.getTimeout());
+		testEquals(60L, monitorConfig.getTimeoutSeconds());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
@@ -22,7 +22,7 @@ public class MonitorConfigLoaderTest
 	public void testGetMonitorConfigs() {
 		Properties buildProperties = new Properties();
 
-		buildProperties.setProperty("monitor[masters].cadence", "900");
+		buildProperties.setProperty("monitor[masters].interval", "900");
 		buildProperties.setProperty(
 			"monitor[masters].parameter[target]",
 			"https://test-1-0.liferay.com/computer/api/json");
@@ -42,7 +42,7 @@ public class MonitorConfigLoaderTest
 		testEquals("masters", monitorConfig.getId());
 		testEquals("http-endpoint", monitorConfig.getType());
 		testEquals(MonitorConfig.Severity.HIGH, monitorConfig.getSeverity());
-		testEquals(900L, monitorConfig.getCadence());
+		testEquals(900L, monitorConfig.getInterval());
 		testEquals(30L, monitorConfig.getTimeout());
 
 		Map<String, String> parameters = monitorConfig.getParameters();
@@ -54,16 +54,6 @@ public class MonitorConfigLoaderTest
 		Map<String, String> thresholds = monitorConfig.getThresholds();
 
 		testEquals("85", thresholds.get("disk"));
-	}
-
-	@Test
-	public void testGetMonitorConfigsCadence() {
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty("monitor[a].cadence", "not-a-number");
-		buildProperties.setProperty("monitor[a].type", "http-endpoint");
-
-		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
 	}
 
 	@Test
@@ -95,6 +85,16 @@ public class MonitorConfigLoaderTest
 	}
 
 	@Test
+	public void testGetMonitorConfigsInterval() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].interval", "not-a-number");
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
+	}
+
+	@Test
 	public void testGetMonitorConfigsMissingType() {
 		Properties buildProperties = new Properties();
 
@@ -104,10 +104,10 @@ public class MonitorConfigLoaderTest
 	}
 
 	@Test
-	public void testGetMonitorConfigsNegativeCadence() {
+	public void testGetMonitorConfigsNegativeInterval() {
 		Properties buildProperties = new Properties();
 
-		buildProperties.setProperty("monitor[a].cadence", "-1");
+		buildProperties.setProperty("monitor[a].interval", "-1");
 		buildProperties.setProperty("monitor[a].type", "http-endpoint");
 
 		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
@@ -144,10 +144,10 @@ public class MonitorConfigLoaderTest
 	}
 
 	@Test
-	public void testGetMonitorConfigsZeroCadence() {
+	public void testGetMonitorConfigsZeroInterval() {
 		Properties buildProperties = new Properties();
 
-		buildProperties.setProperty("monitor[a].cadence", "0");
+		buildProperties.setProperty("monitor[a].interval", "0");
 		buildProperties.setProperty("monitor[a].type", "http-endpoint");
 
 		List<MonitorConfig> monitorConfigs =
@@ -155,7 +155,7 @@ public class MonitorConfigLoaderTest
 
 		MonitorConfig monitorConfig = monitorConfigs.get(0);
 
-		testEquals(0L, monitorConfig.getCadence());
+		testEquals(0L, monitorConfig.getInterval());
 	}
 
 	private void _testGetMonitorConfigsExpectedIllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
@@ -42,7 +42,7 @@ public class MonitorConfigLoaderTest
 		testEquals("masters", monitorConfig.getId());
 		testEquals("http-endpoint", monitorConfig.getType());
 		testEquals(MonitorConfig.Severity.HIGH, monitorConfig.getSeverity());
-		testEquals(900L, monitorConfig.getInterval());
+		testEquals(900L, monitorConfig.getIntervalSeconds());
 		testEquals(30L, monitorConfig.getTimeout());
 
 		Map<String, String> parameters = monitorConfig.getParameters();
@@ -155,7 +155,7 @@ public class MonitorConfigLoaderTest
 
 		MonitorConfig monitorConfig = monitorConfigs.get(0);
 
-		testEquals(0L, monitorConfig.getInterval());
+		testEquals(0L, monitorConfig.getIntervalSeconds());
 	}
 
 	private void _testGetMonitorConfigsExpectedIllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoaderTest.java
@@ -28,6 +28,7 @@ public class MonitorConfigLoaderTest
 			"https://test-1-0.liferay.com/computer/api/json");
 		buildProperties.setProperty("monitor[masters].severity", "high");
 		buildProperties.setProperty("monitor[masters].threshold[disk]", "85");
+		buildProperties.setProperty("monitor[masters].timeout", "30");
 		buildProperties.setProperty("monitor[masters].type", "http-endpoint");
 
 		List<MonitorConfig> monitorConfigs =
@@ -42,6 +43,7 @@ public class MonitorConfigLoaderTest
 		testEquals("http-endpoint", monitorConfig.getType());
 		testEquals(MonitorConfig.Severity.HIGH, monitorConfig.getSeverity());
 		testEquals(900L, monitorConfig.getCadence());
+		testEquals(30L, monitorConfig.getTimeout());
 
 		Map<String, String> parameters = monitorConfig.getParameters();
 
@@ -65,10 +67,58 @@ public class MonitorConfigLoaderTest
 	}
 
 	@Test
+	public void testGetMonitorConfigsDefaultSeverity() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(buildProperties);
+
+		MonitorConfig monitorConfig = monitorConfigs.get(0);
+
+		testEquals(MonitorConfig.Severity.MEDIUM, monitorConfig.getSeverity());
+	}
+
+	@Test
+	public void testGetMonitorConfigsDefaultTimeout() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(buildProperties);
+
+		MonitorConfig monitorConfig = monitorConfigs.get(0);
+
+		testEquals(60L, monitorConfig.getTimeout());
+	}
+
+	@Test
 	public void testGetMonitorConfigsMissingType() {
 		Properties buildProperties = new Properties();
 
 		buildProperties.setProperty("monitor[a].severity", "high");
+
+		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
+	}
+
+	@Test
+	public void testGetMonitorConfigsNegativeCadence() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].cadence", "-1");
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
+	}
+
+	@Test
+	public void testGetMonitorConfigsNegativeTimeout() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].timeout", "-1");
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
 
 		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
 	}
@@ -81,6 +131,31 @@ public class MonitorConfigLoaderTest
 		buildProperties.setProperty("monitor[a].type", "http-endpoint");
 
 		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
+	}
+
+	@Test
+	public void testGetMonitorConfigsTimeout() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].timeout", "not-a-number");
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		_testGetMonitorConfigsExpectedIllegalArgumentException(buildProperties);
+	}
+
+	@Test
+	public void testGetMonitorConfigsZeroCadence() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("monitor[a].cadence", "0");
+		buildProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(buildProperties);
+
+		MonitorConfig monitorConfig = monitorConfigs.get(0);
+
+		testEquals(0L, monitorConfig.getCadence());
 	}
 
 	private void _testGetMonitorConfigsExpectedIllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -26,10 +26,10 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 	public void testRunCycle() {
 		MonitorResultStore monitorResultStore = new MonitorResultStore();
 
-		long cadenceMillis = 1000L * 10L;
+		long intervalMillis = 1000L * 10L;
 
 		TestMonitor hangingTestMonitor = new TestMonitor(
-			_newMonitorConfig(cadenceMillis / 1000, "a", 1)) {
+			_newMonitorConfig(intervalMillis / 1000, "a", 1)) {
 
 			@Override
 			public MonitorResult execute() {
@@ -48,10 +48,10 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 		};
 
 		TestMonitor passingTestMonitor = new TestMonitor(
-			_newMonitorConfig(cadenceMillis / 1000, "b", 0));
+			_newMonitorConfig(intervalMillis / 1000, "b", 0));
 
 		TestMonitor throwingTestMonitor = new TestMonitor(
-			_newMonitorConfig(cadenceMillis / 1000, "c", 0)) {
+			_newMonitorConfig(intervalMillis / 1000, "c", 0)) {
 
 			@Override
 			public MonitorResult execute() {
@@ -84,7 +84,7 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 				}
 			);
 
-			long virtualCurrentTime = cadenceMillis + 1L;
+			long virtualCurrentTime = intervalMillis + 1L;
 
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
@@ -134,7 +134,7 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 
 			testEquals(1, monitorResults.size());
 
-			virtualCurrentTime += cadenceMillis;
+			virtualCurrentTime += intervalMillis;
 
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
@@ -154,10 +154,10 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	private MonitorConfig _newMonitorConfig(
-		long cadence, String id, long timeout) {
+		long interval, String id, long timeout) {
 
 		return new MonitorConfig(
-			cadence, id, null, MonitorConfig.Severity.MEDIUM, null, timeout,
+			interval, id, null, MonitorConfig.Severity.MEDIUM, null, timeout,
 			RandomTestUtil.randomString());
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -26,8 +26,10 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 	public void testRunCycle() {
 		MonitorResultStore monitorResultStore = new MonitorResultStore();
 
+		long cadenceMillis = 1000L * 10L;
+
 		TestMonitor hangingTestMonitor = new TestMonitor(
-			_newMonitorConfig("a", 1)) {
+			_newMonitorConfig(cadenceMillis / 1000, "a", 1)) {
 
 			@Override
 			public MonitorResult execute() {
@@ -46,10 +48,10 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 		};
 
 		TestMonitor passingTestMonitor = new TestMonitor(
-			_newMonitorConfig("b", 0));
+			_newMonitorConfig(cadenceMillis / 1000, "b", 0));
 
 		TestMonitor throwingTestMonitor = new TestMonitor(
-			_newMonitorConfig("c", 0)) {
+			_newMonitorConfig(cadenceMillis / 1000, "c", 0)) {
 
 			@Override
 			public MonitorResult execute() {
@@ -82,10 +84,12 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 				}
 			);
 
+			long virtualCurrentTime = cadenceMillis + 1L;
+
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
 			).thenReturn(
-				1000000L
+				virtualCurrentTime
 			);
 
 			Map<Monitor, MonitorResult> monitorResultsMap =
@@ -102,14 +106,14 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 			testEquals(
 				"Monitor a timed out after 1000 ms",
 				latestMonitorResult.getMessage());
-			testEquals(1000000L, latestMonitorResult.getTimestamp());
+			testEquals(virtualCurrentTime, latestMonitorResult.getTimestamp());
 
 			latestMonitorResult = monitorResultStore.getLatestMonitorResult(
 				passingTestMonitor.getId());
 
 			testEquals(
 				MonitorResult.Status.OK, latestMonitorResult.getStatus());
-			testEquals(1000000L, latestMonitorResult.getTimestamp());
+			testEquals(virtualCurrentTime, latestMonitorResult.getTimestamp());
 
 			latestMonitorResult = monitorResultStore.getLatestMonitorResult(
 				throwingTestMonitor.getId());
@@ -130,10 +134,12 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 
 			testEquals(1, monitorResults.size());
 
+			virtualCurrentTime += cadenceMillis;
+
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
 			).thenReturn(
-				1900000L
+				virtualCurrentTime
 			);
 
 			monitorResultsMap = monitorEngine.runCycle();
@@ -147,9 +153,11 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 		}
 	}
 
-	private MonitorConfig _newMonitorConfig(String id, long timeout) {
+	private MonitorConfig _newMonitorConfig(
+		long cadence, String id, long timeout) {
+
 		return new MonitorConfig(
-			900, id, null, MonitorConfig.Severity.MEDIUM, null, timeout,
+			cadence, id, null, MonitorConfig.Severity.MEDIUM, null, timeout,
 			RandomTestUtil.randomString());
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -154,11 +154,11 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	private MonitorConfig _newMonitorConfig(
-		String id, long intervalSeconds, long timeout) {
+		String id, long intervalSeconds, long timeoutSeconds) {
 
 		return new MonitorConfig(
 			id, intervalSeconds, null, MonitorConfig.Severity.MEDIUM, null,
-			timeout, RandomTestUtil.randomString());
+			timeoutSeconds, RandomTestUtil.randomString());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -29,7 +29,7 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 		long intervalMillis = 1000L * 10L;
 
 		TestMonitor hangingTestMonitor = new TestMonitor(
-			_newMonitorConfig(intervalMillis / 1000, "a", 1)) {
+			_newMonitorConfig("a", intervalMillis / 1000, 1)) {
 
 			@Override
 			public MonitorResult execute() {
@@ -48,10 +48,10 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 		};
 
 		TestMonitor passingTestMonitor = new TestMonitor(
-			_newMonitorConfig(intervalMillis / 1000, "b", 0));
+			_newMonitorConfig("b", intervalMillis / 1000, 0));
 
 		TestMonitor throwingTestMonitor = new TestMonitor(
-			_newMonitorConfig(intervalMillis / 1000, "c", 0)) {
+			_newMonitorConfig("c", intervalMillis / 1000, 0)) {
 
 			@Override
 			public MonitorResult execute() {
@@ -154,11 +154,11 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	private MonitorConfig _newMonitorConfig(
-		long interval, String id, long timeout) {
+		String id, long intervalSeconds, long timeout) {
 
 		return new MonitorConfig(
-			interval, id, null, MonitorConfig.Severity.MEDIUM, null, timeout,
-			RandomTestUtil.randomString());
+			id, intervalSeconds, null, MonitorConfig.Severity.MEDIUM, null,
+			timeout, RandomTestUtil.randomString());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test(timeout = 10000)
+	public void testRunCycle() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		TestMonitor hangingTestMonitor = new TestMonitor(
+			_newMonitorConfig("a", 1)) {
+
+			@Override
+			public MonitorResult execute() {
+				try {
+					Thread.sleep(10000);
+				}
+				catch (InterruptedException interruptedException) {
+					Thread thread = Thread.currentThread();
+
+					thread.interrupt();
+				}
+
+				return null;
+			}
+
+		};
+
+		TestMonitor passingTestMonitor = new TestMonitor(
+			_newMonitorConfig("b", 0));
+
+		TestMonitor throwingTestMonitor = new TestMonitor(
+			_newMonitorConfig("c", 0)) {
+
+			@Override
+			public MonitorResult execute() {
+				throw new RuntimeException("Unable to execute the monitor");
+			}
+
+		};
+
+		MonitorEngine monitorEngine = new MonitorEngine(
+			monitorResultStore,
+			Arrays.<Monitor>asList(
+				hangingTestMonitor, passingTestMonitor, throwingTestMonitor));
+
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
+					JenkinsResultsParserUtil.class,
+					Mockito.CALLS_REAL_METHODS)) {
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				() -> JenkinsResultsParserUtil.combine(Mockito.<String[]>any())
+			).thenAnswer(
+				invocation -> {
+					StringBuilder sb = new StringBuilder();
+
+					for (Object argument : invocation.getArguments()) {
+						sb.append(argument);
+					}
+
+					return sb.toString();
+				}
+			);
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1000000L
+			);
+
+			Map<Monitor, MonitorResult> monitorResultsMap =
+				monitorEngine.runCycle();
+
+			testEquals(3, monitorResultsMap.size());
+
+			MonitorResult latestMonitorResult =
+				monitorResultStore.getLatestMonitorResult(
+					hangingTestMonitor.getId());
+
+			testEquals(
+				MonitorResult.Status.UNKNOWN, latestMonitorResult.getStatus());
+			testEquals(
+				"Monitor a timed out after 1000 ms",
+				latestMonitorResult.getMessage());
+			testEquals(1000000L, latestMonitorResult.getTimestamp());
+
+			latestMonitorResult = monitorResultStore.getLatestMonitorResult(
+				passingTestMonitor.getId());
+
+			testEquals(
+				MonitorResult.Status.OK, latestMonitorResult.getStatus());
+			testEquals(1000000L, latestMonitorResult.getTimestamp());
+
+			latestMonitorResult = monitorResultStore.getLatestMonitorResult(
+				throwingTestMonitor.getId());
+
+			testEquals(
+				MonitorResult.Status.UNKNOWN, latestMonitorResult.getStatus());
+			testEquals(
+				"Monitor c failed: Unable to execute the monitor",
+				latestMonitorResult.getMessage());
+
+			monitorResultsMap = monitorEngine.runCycle();
+
+			testEquals(0, monitorResultsMap.size());
+
+			List<MonitorResult> monitorResults =
+				monitorResultStore.getMonitorResults(
+					passingTestMonitor.getId());
+
+			testEquals(1, monitorResults.size());
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1900000L
+			);
+
+			monitorResultsMap = monitorEngine.runCycle();
+
+			testEquals(3, monitorResultsMap.size());
+
+			monitorResults = monitorResultStore.getMonitorResults(
+				passingTestMonitor.getId());
+
+			testEquals(2, monitorResults.size());
+		}
+	}
+
+	private MonitorConfig _newMonitorConfig(String id, long timeout) {
+		return new MonitorConfig(
+			900, id, null, MonitorConfig.Severity.MEDIUM, null, timeout,
+			RandomTestUtil.randomString());
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -17,7 +17,7 @@ public class MonitorFactoryTest
 	@Test
 	public void testNewMonitorUnknownType() {
 		MonitorConfig monitorConfig = new MonitorConfig(
-			0, "a", null, MonitorConfig.Severity.MEDIUM, null, 60,
+			"a", 0, null, MonitorConfig.Severity.MEDIUM, null, 60,
 			"unknown-type");
 
 		try {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -17,7 +17,8 @@ public class MonitorFactoryTest
 	@Test
 	public void testNewMonitorUnknownType() {
 		MonitorConfig monitorConfig = new MonitorConfig(
-			0, "a", null, MonitorConfig.Severity.MEDIUM, null, "unknown-type");
+			0, "a", null, MonitorConfig.Severity.MEDIUM, null, 60,
+			"unknown-type");
 
 		try {
 			MonitorFactory.newMonitor(monitorConfig);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStoreTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultStoreTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorResultStoreTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetLatestMonitorResult() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		testSame(null, monitorResultStore.getLatestMonitorResult("a"));
+
+		MonitorResult monitorResult1 = _newMonitorResult();
+		MonitorResult monitorResult2 = _newMonitorResult();
+
+		monitorResultStore.store("a", monitorResult1);
+		monitorResultStore.store("a", monitorResult2);
+
+		testSame(
+			monitorResult2, monitorResultStore.getLatestMonitorResult("a"));
+	}
+
+	@Test
+	public void testGetMonitorResults() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		List<MonitorResult> monitorResults =
+			monitorResultStore.getMonitorResults("a");
+
+		Assert.assertTrue(monitorResults.isEmpty());
+
+		MonitorResult monitorResult1 = _newMonitorResult();
+		MonitorResult monitorResult2 = _newMonitorResult();
+
+		monitorResultStore.store("a", monitorResult1);
+		monitorResultStore.store("a", monitorResult2);
+
+		monitorResults = monitorResultStore.getMonitorResults("a");
+
+		testEquals(2, monitorResults.size());
+		testSame(monitorResult1, monitorResults.get(0));
+		testSame(monitorResult2, monitorResults.get(1));
+	}
+
+	@Test
+	public void testGetMonitorResultsIsUnmodifiable() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store("a", _newMonitorResult());
+
+		List<MonitorResult> monitorResults =
+			monitorResultStore.getMonitorResults("a");
+
+		try {
+			monitorResults.add(_newMonitorResult());
+
+			Assert.fail("Expected UnsupportedOperationException");
+		}
+		catch (UnsupportedOperationException unsupportedOperationException) {
+		}
+	}
+
+	@Test
+	public void testMonitorResultStoreMaxMonitorResultCount() {
+		new MonitorResultStore(1);
+
+		try {
+			new MonitorResultStore(0);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	@Test
+	public void testStoreMaxMonitorResultCount() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore(2);
+
+		MonitorResult monitorResult1 = _newMonitorResult();
+		MonitorResult monitorResult2 = _newMonitorResult();
+		MonitorResult monitorResult3 = _newMonitorResult();
+
+		monitorResultStore.store("a", monitorResult1);
+		monitorResultStore.store("a", monitorResult2);
+		monitorResultStore.store("a", monitorResult3);
+
+		List<MonitorResult> monitorResults =
+			monitorResultStore.getMonitorResults("a");
+
+		testEquals(2, monitorResults.size());
+		testSame(monitorResult2, monitorResults.get(0));
+		testSame(monitorResult3, monitorResults.get(1));
+	}
+
+	private MonitorResult _newMonitorResult() {
+		return new MonitorResult(
+			RandomTestUtil.randomString(), null, MonitorResult.Status.OK,
+			RandomTestUtil.randomLong());
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
@@ -338,10 +338,10 @@ public class MonitorRunnerTest extends com.liferay.jenkins.results.parser.Test {
 		return _newMonitorConfig(id, 0);
 	}
 
-	private MonitorConfig _newMonitorConfig(String id, long timeout) {
+	private MonitorConfig _newMonitorConfig(String id, long timeoutSeconds) {
 		return new MonitorConfig(
 			id, RandomTestUtil.randomLong(), null,
-			MonitorConfig.Severity.MEDIUM, null, timeout,
+			MonitorConfig.Severity.MEDIUM, null, timeoutSeconds,
 			RandomTestUtil.randomString());
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
@@ -340,7 +340,7 @@ public class MonitorRunnerTest extends com.liferay.jenkins.results.parser.Test {
 
 	private MonitorConfig _newMonitorConfig(String id, long timeout) {
 		return new MonitorConfig(
-			RandomTestUtil.randomLong(), id, null,
+			id, RandomTestUtil.randomLong(), null,
 			MonitorConfig.Severity.MEDIUM, null, timeout,
 			RandomTestUtil.randomString());
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorRunnerTest.java
@@ -1,0 +1,380 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorRunnerTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testMonitorRunnerDefaultTimeoutMillis() {
+		new MonitorRunner(1);
+
+		try {
+			new MonitorRunner(0);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	@Test(timeout = 5000)
+	public void testRun() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor1 = new TestMonitor(_newMonitorConfig("a"));
+		TestMonitor testMonitor2 = new TestMonitor(_newMonitorConfig("b"));
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			testMonitor1, testMonitor2);
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			monitors);
+
+		testEquals(monitors, new ArrayList<>(monitorResultsMap.keySet()));
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunConcurrentMonitors() {
+		MonitorRunner monitorRunner = new MonitorRunner(60 * 1000);
+
+		CountDownLatch countDownLatch = new CountDownLatch(2);
+
+		TestMonitor testMonitor1 = _newConcurrentTestMonitor(
+			countDownLatch, _newMonitorConfig("a"));
+		TestMonitor testMonitor2 = _newConcurrentTestMonitor(
+			countDownLatch, _newMonitorConfig("b"));
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(testMonitor1, testMonitor2));
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunDuplicateIds() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(
+				new TestMonitor(_newMonitorConfig("a")),
+				new TestMonitor(_newMonitorConfig("a"))));
+
+		testEquals(2, monitorResultsMap.size());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunEmpty() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>emptyList());
+
+		Assert.assertTrue(monitorResultsMap.isEmpty());
+
+		monitorResultsMap = monitorRunner.run(null);
+
+		Assert.assertTrue(monitorResultsMap.isEmpty());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunHangingMonitor() {
+		MonitorRunner monitorRunner = new MonitorRunner(100);
+
+		TestMonitor testMonitor = new HangingTestMonitor(
+			null, _newMonitorConfig("a"));
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor));
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Monitor a timed out after 100 ms", monitorResult.getMessage());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunHangingMonitorCancellation() throws Exception {
+		MonitorRunner monitorRunner = new MonitorRunner(100);
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		monitorRunner.run(
+			Collections.<Monitor>singletonList(
+				new HangingTestMonitor(
+					countDownLatch, _newMonitorConfig("a"))));
+
+		Assert.assertTrue(countDownLatch.await(1, TimeUnit.SECONDS));
+	}
+
+	@Test(timeout = 5000)
+	public void testRunHangingMonitorWithPassingMonitors() {
+		MonitorRunner monitorRunner = new MonitorRunner(100);
+
+		TestMonitor testMonitor1 = new HangingTestMonitor(
+			null, _newMonitorConfig("a"));
+		TestMonitor testMonitor2 = new TestMonitor(_newMonitorConfig("b"));
+		TestMonitor testMonitor3 = new TestMonitor(_newMonitorConfig("c"));
+
+		long startTimestamp = System.currentTimeMillis();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(testMonitor1, testMonitor2, testMonitor3));
+
+		Assert.assertTrue((System.currentTimeMillis() - startTimestamp) < 2000);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+
+		monitorResult = monitorResultsMap.get(testMonitor3);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunInterrupted() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor = new TestMonitor(_newMonitorConfig("a"));
+
+		Thread thread = Thread.currentThread();
+
+		thread.interrupt();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor));
+
+		Assert.assertTrue(Thread.interrupted());
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals("Monitor a was interrupted", monitorResult.getMessage());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunMonitorConfigTimeout() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor = new HangingTestMonitor(
+			null, _newMonitorConfig("a", 1));
+
+		long startTimestamp = System.currentTimeMillis();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor));
+
+		Assert.assertTrue((System.currentTimeMillis() - startTimestamp) < 3000);
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Monitor a timed out after 1000 ms", monitorResult.getMessage());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunMultipleHangingMonitors() {
+		MonitorRunner monitorRunner = new MonitorRunner(200);
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			new HangingTestMonitor(null, _newMonitorConfig("a")),
+			new HangingTestMonitor(null, _newMonitorConfig("b")),
+			new HangingTestMonitor(null, _newMonitorConfig("c")),
+			new HangingTestMonitor(null, _newMonitorConfig("d")));
+
+		long startTimestamp = System.currentTimeMillis();
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			monitors);
+
+		Assert.assertTrue((System.currentTimeMillis() - startTimestamp) < 600);
+
+		for (MonitorResult monitorResult : monitorResultsMap.values()) {
+			testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		}
+	}
+
+	@Test(timeout = 5000)
+	public void testRunNullResultMonitor() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor = new TestMonitor(_newMonitorConfig("a")) {
+
+			@Override
+			public MonitorResult execute() {
+				return null;
+			}
+
+		};
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor));
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals("Monitor a returned no result", monitorResult.getMessage());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunThrowingMonitor() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor1 = new TestMonitor(_newMonitorConfig("a")) {
+
+			@Override
+			public MonitorResult execute() {
+				throw new RuntimeException("Unable to execute the monitor");
+			}
+
+		};
+
+		TestMonitor testMonitor2 = new TestMonitor(_newMonitorConfig("b"));
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Arrays.<Monitor>asList(testMonitor1, testMonitor2));
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor1);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Monitor a failed: Unable to execute the monitor",
+			monitorResult.getMessage());
+
+		monitorResult = monitorResultsMap.get(testMonitor2);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test(timeout = 5000)
+	public void testRunThrowingMonitorWithoutMessage() {
+		MonitorRunner monitorRunner = new MonitorRunner();
+
+		TestMonitor testMonitor = new TestMonitor(_newMonitorConfig("a")) {
+
+			@Override
+			public MonitorResult execute() {
+				throw new RuntimeException();
+			}
+
+		};
+
+		Map<Monitor, MonitorResult> monitorResultsMap = monitorRunner.run(
+			Collections.<Monitor>singletonList(testMonitor));
+
+		MonitorResult monitorResult = monitorResultsMap.get(testMonitor);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Monitor a failed: java.lang.RuntimeException",
+			monitorResult.getMessage());
+	}
+
+	private TestMonitor _newConcurrentTestMonitor(
+		CountDownLatch countDownLatch, MonitorConfig monitorConfig) {
+
+		return new TestMonitor(monitorConfig) {
+
+			@Override
+			public MonitorResult execute() {
+				countDownLatch.countDown();
+
+				try {
+					if (!countDownLatch.await(2, TimeUnit.SECONDS)) {
+						throw new IllegalStateException(
+							"Monitors did not run concurrently");
+					}
+				}
+				catch (InterruptedException interruptedException) {
+					throw new RuntimeException(interruptedException);
+				}
+
+				return super.execute();
+			}
+
+		};
+	}
+
+	private MonitorConfig _newMonitorConfig(String id) {
+		return _newMonitorConfig(id, 0);
+	}
+
+	private MonitorConfig _newMonitorConfig(String id, long timeout) {
+		return new MonitorConfig(
+			RandomTestUtil.randomLong(), id, null,
+			MonitorConfig.Severity.MEDIUM, null, timeout,
+			RandomTestUtil.randomString());
+	}
+
+	private static class HangingTestMonitor extends TestMonitor {
+
+		public HangingTestMonitor(
+			CountDownLatch countDownLatch, MonitorConfig monitorConfig) {
+
+			super(monitorConfig);
+
+			_countDownLatch = countDownLatch;
+		}
+
+		@Override
+		public MonitorResult execute() {
+			try {
+				Thread.sleep(10000);
+			}
+			catch (InterruptedException interruptedException) {
+				if (_countDownLatch != null) {
+					_countDownLatch.countDown();
+				}
+
+				Thread thread = Thread.currentThread();
+
+				thread.interrupt();
+			}
+
+			return null;
+		}
+
+		private final CountDownLatch _countDownLatch;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorSchedulerTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetDueMonitors() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		MonitorScheduler monitorScheduler = new MonitorScheduler(
+			monitorResultStore);
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			new TestMonitor(_newMonitorConfig(900, "a")));
+
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
+					JenkinsResultsParserUtil.class,
+					Mockito.CALLS_REAL_METHODS)) {
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1000000L
+			);
+
+			testEquals(monitors, monitorScheduler.getDueMonitors(monitors));
+
+			monitorResultStore.store("a", _newMonitorResult(1000000L));
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1899000L
+			);
+
+			testEquals(
+				Collections.emptyList(),
+				monitorScheduler.getDueMonitors(monitors));
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1900000L
+			);
+
+			testEquals(monitors, monitorScheduler.getDueMonitors(monitors));
+		}
+	}
+
+	@Test
+	public void testGetDueMonitorsZeroCadence() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		MonitorScheduler monitorScheduler = new MonitorScheduler(
+			monitorResultStore);
+
+		List<Monitor> monitors = Arrays.<Monitor>asList(
+			new TestMonitor(_newMonitorConfig(0, "a")));
+
+		monitorResultStore.store("a", _newMonitorResult(1000000L));
+
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
+					JenkinsResultsParserUtil.class,
+					Mockito.CALLS_REAL_METHODS)) {
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1000000L
+			);
+
+			testEquals(monitors, monitorScheduler.getDueMonitors(monitors));
+		}
+	}
+
+	private MonitorConfig _newMonitorConfig(long cadence, String id) {
+		return new MonitorConfig(
+			cadence, id, null, MonitorConfig.Severity.MEDIUM, null,
+			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
+	}
+
+	private MonitorResult _newMonitorResult(long timestamp) {
+		return new MonitorResult(
+			RandomTestUtil.randomString(), null, MonitorResult.Status.OK,
+			timestamp);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
@@ -30,17 +30,17 @@ public class MonitorSchedulerTest
 		MonitorScheduler monitorScheduler = new MonitorScheduler(
 			monitorResultStore);
 
-		long cadenceMillis = 1000L * 10L;
+		long intervalMillis = 1000L * 10L;
 
 		List<Monitor> monitors = Arrays.<Monitor>asList(
-			new TestMonitor(_newMonitorConfig(cadenceMillis / 1000, "a")));
+			new TestMonitor(_newMonitorConfig(intervalMillis / 1000, "a")));
 
 		try (MockedStatic<JenkinsResultsParserUtil>
 				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
 					JenkinsResultsParserUtil.class,
 					Mockito.CALLS_REAL_METHODS)) {
 
-			long virtualCurrentTime = cadenceMillis + 1L;
+			long virtualCurrentTime = intervalMillis + 1L;
 
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
@@ -53,7 +53,7 @@ public class MonitorSchedulerTest
 			monitorResultStore.store(
 				"a", _newMonitorResult(virtualCurrentTime));
 
-			virtualCurrentTime += cadenceMillis - 1L;
+			virtualCurrentTime += intervalMillis - 1L;
 
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
@@ -78,7 +78,7 @@ public class MonitorSchedulerTest
 	}
 
 	@Test
-	public void testGetDueMonitorsZeroCadence() {
+	public void testGetDueMonitorsZeroInterval() {
 		MonitorResultStore monitorResultStore = new MonitorResultStore();
 
 		MonitorScheduler monitorScheduler = new MonitorScheduler(
@@ -104,9 +104,9 @@ public class MonitorSchedulerTest
 		}
 	}
 
-	private MonitorConfig _newMonitorConfig(long cadence, String id) {
+	private MonitorConfig _newMonitorConfig(long interval, String id) {
 		return new MonitorConfig(
-			cadence, id, null, MonitorConfig.Severity.MEDIUM, null,
+			interval, id, null, MonitorConfig.Severity.MEDIUM, null,
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
@@ -65,7 +65,7 @@ public class MonitorSchedulerTest
 				Collections.emptyList(),
 				monitorScheduler.getDueMonitors(monitors));
 
-			virtualCurrentTime += 2L;
+			virtualCurrentTime += 1L;
 
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
@@ -33,7 +33,7 @@ public class MonitorSchedulerTest
 		long intervalMillis = 1000L * 10L;
 
 		List<Monitor> monitors = Arrays.<Monitor>asList(
-			new TestMonitor(_newMonitorConfig(intervalMillis / 1000, "a")));
+			new TestMonitor(_newMonitorConfig("a", intervalMillis / 1000)));
 
 		try (MockedStatic<JenkinsResultsParserUtil>
 				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
@@ -85,7 +85,7 @@ public class MonitorSchedulerTest
 			monitorResultStore);
 
 		List<Monitor> monitors = Arrays.<Monitor>asList(
-			new TestMonitor(_newMonitorConfig(0, "a")));
+			new TestMonitor(_newMonitorConfig("a", 0)));
 
 		monitorResultStore.store("a", _newMonitorResult(1000000L));
 
@@ -104,9 +104,9 @@ public class MonitorSchedulerTest
 		}
 	}
 
-	private MonitorConfig _newMonitorConfig(long interval, String id) {
+	private MonitorConfig _newMonitorConfig(String id, long intervalSeconds) {
 		return new MonitorConfig(
-			interval, id, null, MonitorConfig.Severity.MEDIUM, null,
+			id, intervalSeconds, null, MonitorConfig.Severity.MEDIUM, null,
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString());
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorSchedulerTest.java
@@ -30,38 +30,47 @@ public class MonitorSchedulerTest
 		MonitorScheduler monitorScheduler = new MonitorScheduler(
 			monitorResultStore);
 
+		long cadenceMillis = 1000L * 10L;
+
 		List<Monitor> monitors = Arrays.<Monitor>asList(
-			new TestMonitor(_newMonitorConfig(900, "a")));
+			new TestMonitor(_newMonitorConfig(cadenceMillis / 1000, "a")));
 
 		try (MockedStatic<JenkinsResultsParserUtil>
 				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
 					JenkinsResultsParserUtil.class,
 					Mockito.CALLS_REAL_METHODS)) {
 
+			long virtualCurrentTime = cadenceMillis + 1L;
+
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
 			).thenReturn(
-				1000000L
+				virtualCurrentTime
 			);
 
 			testEquals(monitors, monitorScheduler.getDueMonitors(monitors));
 
-			monitorResultStore.store("a", _newMonitorResult(1000000L));
+			monitorResultStore.store(
+				"a", _newMonitorResult(virtualCurrentTime));
+
+			virtualCurrentTime += cadenceMillis - 1L;
 
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
 			).thenReturn(
-				1899000L
+				virtualCurrentTime
 			);
 
 			testEquals(
 				Collections.emptyList(),
 				monitorScheduler.getDueMonitors(monitors));
 
+			virtualCurrentTime += 2L;
+
 			jenkinsResultsParserUtilMockedStatic.when(
 				JenkinsResultsParserUtil::getCurrentTimeMillis
 			).thenReturn(
-				1900000L
+				virtualCurrentTime
 			);
 
 			testEquals(monitors, monitorScheduler.getDueMonitors(monitors));

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/TestMonitor.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/TestMonitor.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class TestMonitor implements Monitor {
+
+	public TestMonitor(MonitorConfig monitorConfig) {
+		_monitorConfig = monitorConfig;
+	}
+
+	@Override
+	public MonitorResult execute() {
+		return new MonitorResult(
+			RandomTestUtil.randomString(), null, MonitorResult.Status.OK,
+			System.currentTimeMillis());
+	}
+
+	@Override
+	public String getId() {
+		return _monitorConfig.getId();
+	}
+
+	@Override
+	public MonitorConfig getMonitorConfig() {
+		return _monitorConfig;
+	}
+
+	private final MonitorConfig _monitorConfig;
+
+}


### PR DESCRIPTION
Revises #4431 (opened by @pyoo47) with the following follow-up commits:

- LRCI-7816 Rename getTimeout to getTimeoutSeconds
- LRCI-7816 Rename getTimeout to getTimeoutSeconds in the monitor tests
- LRCI-7816 Test the exact interval boundary in the monitor scheduler test

`getTimeoutSeconds` completes the `intervalSeconds` unit suffix convention from #4431 for the other seconds-valued `MonitorConfig` field. The `monitor[<id>].timeout` property key stays as is, matching `monitor[<id>].interval`. The scheduler test now advances the virtual time to an elapsed time exactly equal to the interval, pinning the `>=` comparison.

**pr-check: PASS** — tested on `1b3219982d455eb792c653d13c57894eed27236d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |