### PR TITLE
LRCI-7528 Relevant test suite job selection for the jenkins-ee PR tester

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsGitRepositoryJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsGitRepositoryJob.java
@@ -8,9 +8,21 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 import java.io.IOException;
 
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.json.JSONObject;
 
@@ -32,6 +44,58 @@ public class JenkinsGitRepositoryJob extends GitRepositoryJob {
 	@Override
 	public GitWorkingDirectory getGitWorkingDirectory() {
 		return gitWorkingDirectory;
+	}
+
+	public List<String> getInvokedJobNames() {
+		List<String> modifiedFileNames = _getModifiedFileNames();
+
+		List<String> modifiedJarEntryNames = new ArrayList<>();
+
+		if (modifiedFileNames.contains(_JAR_FILE_NAME)) {
+			try {
+				modifiedJarEntryNames = _getModifiedEntryNames(
+					_getUpstreamJarFile(), _getJarFile());
+
+				modifiedFileNames.remove(_JAR_FILE_NAME);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+		}
+
+		Properties buildProperties = _getBuildProperties();
+
+		Set<String> invokedJobNames = new TreeSet<>();
+
+		for (String propertyName : buildProperties.stringPropertyNames()) {
+			if (!propertyName.startsWith("jenkins.pull.request.jobs[")) {
+				continue;
+			}
+
+			List<String> propertyOptions =
+				JenkinsResultsParserUtil.getPropertyOptions(propertyName);
+
+			if ((propertyOptions.size() != 2) ||
+				!Objects.equals(propertyOptions.get(1), getTestSuiteName()) ||
+				!_matchesRule(
+					buildProperties, modifiedFileNames, modifiedJarEntryNames,
+					propertyOptions.get(0))) {
+
+				continue;
+			}
+
+			invokedJobNames.addAll(_getInvokedJobNames(propertyName));
+		}
+
+		if (invokedJobNames.isEmpty()) {
+			invokedJobNames.addAll(
+				_getInvokedJobNames(
+					JenkinsResultsParserUtil.combine(
+						"jenkins.pull.request.jobs[", getTestSuiteName(),
+						"]")));
+		}
+
+		return new ArrayList<>(invokedJobNames);
 	}
 
 	@Override
@@ -80,15 +144,53 @@ public class JenkinsGitRepositoryJob extends GitRepositoryJob {
 		_initialize();
 	}
 
-	private File _getJenkinsGitRepositoryDir() {
-		Properties buildProperties = null;
-
+	private Properties _getBuildProperties() {
 		try {
-			buildProperties = JenkinsResultsParserUtil.getBuildProperties();
+			return JenkinsResultsParserUtil.getBuildProperties();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
+	}
+
+	private Map<String, Long> _getEntryChecksumMap(File jarFile)
+		throws IOException {
+
+		Map<String, Long> entryChecksumMap = new HashMap<>();
+
+		try (ZipFile zipFile = new ZipFile(jarFile)) {
+			Enumeration<? extends ZipEntry> enumeration = zipFile.entries();
+
+			while (enumeration.hasMoreElements()) {
+				ZipEntry zipEntry = enumeration.nextElement();
+
+				if (zipEntry.isDirectory()) {
+					continue;
+				}
+
+				entryChecksumMap.put(zipEntry.getName(), zipEntry.getCrc());
+			}
+		}
+
+		return entryChecksumMap;
+	}
+
+	private List<String> _getInvokedJobNames(String propertyName) {
+		try {
+			return JenkinsResultsParserUtil.getBuildPropertyAsList(
+				true, propertyName);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+	private File _getJarFile() {
+		return new File(gitRepositoryDir, _JAR_FILE_NAME);
+	}
+
+	private File _getJenkinsGitRepositoryDir() {
+		Properties buildProperties = _getBuildProperties();
 
 		String jenkinsDirPath = JenkinsResultsParserUtil.getProperty(
 			buildProperties, "jenkins.dir", getBranchName());
@@ -113,6 +215,74 @@ public class JenkinsGitRepositoryJob extends GitRepositoryJob {
 		return jenkinsDir;
 	}
 
+	private List<String> _getModifiedEntryNames(File jarFile1, File jarFile2)
+		throws IOException {
+
+		Map<String, Long> entryChecksumMap1 = _getEntryChecksumMap(jarFile1);
+		Map<String, Long> entryChecksumMap2 = _getEntryChecksumMap(jarFile2);
+
+		Set<String> entryNames = new HashSet<>(entryChecksumMap1.keySet());
+
+		entryNames.addAll(entryChecksumMap2.keySet());
+
+		Set<String> modifiedEntryNames = new TreeSet<>();
+
+		for (String entryName : entryNames) {
+			if (entryName.startsWith("META-INF/") ||
+				Objects.equals(
+					entryChecksumMap1.get(entryName),
+					entryChecksumMap2.get(entryName))) {
+
+				continue;
+			}
+
+			modifiedEntryNames.add(
+				entryName.replaceAll("\\$[^/]*\\.class", ".class"));
+		}
+
+		return new ArrayList<>(modifiedEntryNames);
+	}
+
+	private List<String> _getModifiedFileNames() {
+		List<String> modifiedFileNames = new ArrayList<>();
+
+		for (File modifiedFile : gitWorkingDirectory.getModifiedFilesList()) {
+			modifiedFileNames.add(
+				JenkinsResultsParserUtil.getPathRelativeTo(
+					modifiedFile, gitRepositoryDir));
+		}
+
+		return modifiedFileNames;
+	}
+
+	private File _getUpstreamJarFile() throws IOException {
+		String upstreamBranchName = Environment.get(
+			"GITHUB_UPSTREAM_BRANCH_NAME");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(upstreamBranchName)) {
+			throw new IOException("Please set GITHUB_UPSTREAM_BRANCH_NAME");
+		}
+
+		File upstreamJarFile = File.createTempFile("upstream-", ".jar");
+
+		upstreamJarFile.deleteOnExit();
+
+		GitUtil.ExecutionResult executionResult =
+			gitWorkingDirectory.executeBashCommands(
+				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+				GitUtil.MILLIS_TIMEOUT,
+				JenkinsResultsParserUtil.combine(
+					"git show ", upstreamBranchName, ":", _JAR_FILE_NAME, " > ",
+					JenkinsResultsParserUtil.getCanonicalPath(
+						upstreamJarFile)));
+
+		if (executionResult.getExitValue() != 0) {
+			throw new IOException(executionResult.getStandardError());
+		}
+
+		return upstreamJarFile;
+	}
+
 	private void _initialize() {
 		gitWorkingDirectory = GitWorkingDirectoryFactory.newGitWorkingDirectory(
 			getBranchName(), _getJenkinsGitRepositoryDir(),
@@ -124,6 +294,53 @@ public class JenkinsGitRepositoryJob extends GitRepositoryJob {
 
 		jobPropertiesFiles.add(new File(gitRepositoryDir, "test.properties"));
 	}
+
+	private boolean _matchesModifiedFileNames(
+		List<String> modifiedFileNames, String propertyValue) {
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(propertyValue)) {
+			return false;
+		}
+
+		for (PathMatcher pathMatcher :
+				JenkinsResultsParserUtil.toPathMatchers(
+					"",
+					JenkinsResultsParserUtil.getGlobsFromProperty(
+						propertyValue))) {
+
+			for (String modifiedFileName : modifiedFileNames) {
+				if (pathMatcher.matches(Paths.get(modifiedFileName))) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _matchesRule(
+		Properties buildProperties, List<String> modifiedFileNames,
+		List<String> modifiedJarEntryNames, String ruleName) {
+
+		if (_matchesModifiedFileNames(
+				modifiedFileNames,
+				JenkinsResultsParserUtil.getProperty(
+					buildProperties, "modified.files.includes", false, ruleName,
+					getTestSuiteName())) ||
+			_matchesModifiedFileNames(
+				modifiedJarEntryNames,
+				JenkinsResultsParserUtil.getProperty(
+					buildProperties, "modified.jar.entries.includes", false,
+					ruleName, getTestSuiteName()))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String _JAR_FILE_NAME =
+		"lib/jenkins/com.liferay.jenkins.results.parser.jar";
 
 	private final String _testSuiteName;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobFactory.java
@@ -264,6 +264,14 @@ public class JobFactory {
 			testSuiteName, upstreamBranchName);
 	}
 
+	public static Job newJob(
+		Job.BuildProfile buildProfile, String jobName, String testSuiteName) {
+
+		return _newJob(
+			buildProfile, jobName, null, null, null, null, null, null,
+			testSuiteName, null);
+	}
+
 	public static Job newJob(JSONObject jsonObject) {
 		return _newJob(
 			null, null, jsonObject, null, null, null, null, null, null, null);

--- a/test.properties
+++ b/test.properties
@@ -3744,6 +3744,8 @@
     # Dummy
     #
 
+    playwright.projects.includes[playwright-js-tomcat101-postgresql163][dummy]=smoke.main
+
     test.batch.class.names.includes[modules-integration-*][dummy]=**/jenkins-results-parser/**/DummyIntegrationTest.java
     test.batch.class.names.includes[modules-unit][dummy]=**/jenkins-results-parser/**/DummyUnitTest.java
 
@@ -3752,7 +3754,8 @@
     test.batch.names[dummy]=\
         functional-tomcat101-mysql84,\
         modules-integration-postgresql163,\
-        modules-unit
+        modules-unit,\
+        playwright-js-tomcat101-postgresql163
 
     test.batch.run.property.query[functional-tomcat101-mysql84][dummy]=\
         portal.smoke == "dummy"


### PR DESCRIPTION
This is the liferay-portal half of LRCI-7528 (subtask LRCI-7894). It adds the job selection logic behind the new relevant test suite on the jenkins-ee PR tester.

The class keeps its JenkinsGitRepositoryJob name for now. Renaming it to JenkinsAcceptancePullRequestJob to match its siblings is deferred to a separate follow-up PR.

The first commit adds the selection. getInvokedJobNames reads rule properties from jenkins-ee build-shared.properties in the portal relevant rule style. Each rule pairs modified.files.includes patterns for repository paths with modified.jar.entries.includes patterns for files inside the committed parser jar, and contributes its jenkins.pull.request.jobs list when it matches. All matching rules contribute and the bare jenkins.pull.request.jobs list is the fallback when none match. When the diff touches the committed parser jar, the jar is compared entry by entry against the upstream branch copy by CRC so a version bump selects jobs from the classes that actually changed, and a failed comparison fails the build. JobFactory gains a three argument newJob overload carrying the test suite name.

The second commit adds a playwright smoke batch to the dummy suite so a relevant run can exercise a playwright batch.

The consuming jenkins-ee change is on kenjiheigel/liferay-jenkins-ee branch LRCI-7528-test.


**pr-check: PASS** — tested on `1ae103fc6dcac6cef96b6bb40ebbb906fcc6603d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "1ae103fc6dcac6cef96b6bb40ebbb906fcc6603d"} -->
