### PR TITLE
LRCI-7822 Add the Spot Interruption rate report

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -2,6 +2,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
+	api group: "com.amazonaws", name: "aws-java-sdk-cloudtrail", version: "1.12.719"
 	api group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
 	api group: "com.amazonaws", name: "aws-java-sdk-ec2", version: "1.12.719"
 	api group: "com.amazonaws", name: "aws-java-sdk-rds", version: "1.12.719"

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsBuildRunner.java
@@ -5,8 +5,10 @@
 
 package com.liferay.jenkins.results.parser;
 
+import com.liferay.jenkins.results.parser.aws.CloudTrailEventCrawler;
 import com.liferay.jenkins.results.parser.metrics.BuildHistoryProcessor;
 import com.liferay.jenkins.results.parser.metrics.BuildHistoryReport;
+import com.liferay.jenkins.results.parser.metrics.SpotInterruptionReport;
 import com.liferay.jenkins.results.parser.testray.TestrayCloudBucket;
 import com.liferay.jenkins.results.parser.testray.TestrayCloudObject;
 
@@ -21,12 +23,14 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +101,7 @@ public class GenerateReportsBuildRunner extends BaseBuildRunner<BuildData> {
 		FLAKY_TEST_MASTER("Flaky Test master"),
 		PULL_REQUEST_HISTORY("Pull Request History"),
 		RELEASE_HISTORY("Release History"),
+		SPOT_INTERRUPTION("Spot Interruption"),
 		UPSTREAM_HISTORY("Upstream History"), UTILIZATION("Utilization");
 
 		public String getDirName() {
@@ -595,6 +600,10 @@ public class GenerateReportsBuildRunner extends BaseBuildRunner<BuildData> {
 					_generateReleaseReport(reportName);
 				}
 
+				if (reportName.equals(Report.SPOT_INTERRUPTION.toString())) {
+					_generateSpotInterruptionReport(reportName);
+				}
+
 				if (reportName.equals(Report.UPSTREAM_HISTORY.toString())) {
 					_generateUpstreamReport(reportName);
 				}
@@ -635,6 +644,30 @@ public class GenerateReportsBuildRunner extends BaseBuildRunner<BuildData> {
 		buildData.setBuildDescription(sb.toString());
 
 		updateBuildDescription();
+	}
+
+	private void _generateSpotInterruptionReport(String reportName)
+		throws IOException {
+
+		System.out.println("Generating the " + reportName + " report");
+
+		File dailyDataDir = new File(
+			_TMP_BASE_DIR_PATH, "spot-interruption-data");
+
+		long reportDurationDays = _getReportDurationDays(reportName);
+
+		_updateSpotInterruptionDataFiles(dailyDataDir, reportDurationDays);
+
+		String filePath = _getReportFilePath(reportName);
+
+		SpotInterruptionReport spotInterruptionReport =
+			SpotInterruptionReport.newSpotInterruptionReport(
+				dailyDataDir, reportDurationDays, new File(filePath),
+				_getStartDateString(reportDurationDays - 1));
+
+		spotInterruptionReport.write();
+
+		_updateReport(filePath);
 	}
 
 	private void _generateUpstreamReport(String reportName) throws IOException {
@@ -951,6 +984,52 @@ public class GenerateReportsBuildRunner extends BaseBuildRunner<BuildData> {
 		}
 	}
 
+	private void _updateSpotInterruptionDataFiles(
+			File dailyDataDir, long reportDurationDays)
+		throws IOException {
+
+		LocalDate startLocalDate = LocalDate.parse(
+			_getStartDateString(reportDurationDays - 1), _dateTimeFormatter);
+
+		ZonedDateTime startZonedDateTime = startLocalDate.atStartOfDay(
+			ZoneOffset.UTC);
+
+		Date endDate = new Date();
+		Date startDate = Date.from(startZonedDateTime.toInstant());
+
+		String regionName = _getBuildProperty("aws.cloudtrail.region");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(regionName)) {
+			regionName = "us-east-1";
+		}
+
+		CloudTrailEventCrawler cloudTrailEventCrawler =
+			new CloudTrailEventCrawler(regionName);
+
+		List<JSONObject> bidEvictedEventJSONObjects =
+			cloudTrailEventCrawler.getEventJSONObjects(
+				endDate, "BidEvictedEvent", startDate);
+		List<JSONObject> runInstancesEventJSONObjects =
+			cloudTrailEventCrawler.getEventJSONObjects(
+				endDate, "RunInstances", startDate);
+
+		for (String dateString :
+				JenkinsResultsParserUtil.getDateStrings(
+					reportDurationDays, startLocalDate)) {
+
+			File dailyDataFile = new File(
+				dailyDataDir, dateString + "/spot-interruption.json");
+
+			JSONObject dailyDataJSONObject =
+				SpotInterruptionReport.newDailyDataJSONObject(
+					bidEvictedEventJSONObjects, dateString,
+					runInstancesEventJSONObjects);
+
+			JenkinsResultsParserUtil.write(
+				dailyDataFile, dailyDataJSONObject.toString());
+		}
+	}
+
 	private void _validateBuildParameters() {
 		String[] reportNames = _getReportNames();
 
@@ -1016,6 +1095,9 @@ public class GenerateReportsBuildRunner extends BaseBuildRunner<BuildData> {
 					Report.PULL_REQUEST_HISTORY.toString(),
 					"pull-request-report");
 				put(Report.RELEASE_HISTORY.toString(), "release-report");
+				put(
+					Report.SPOT_INTERRUPTION.toString(),
+					"spot-interruption-report");
 				put(Report.UPSTREAM_HISTORY.toString(), "upstream-report");
 				put(Report.UTILIZATION.toString(), "utilization-report");
 			}
@@ -1029,8 +1111,8 @@ public class GenerateReportsBuildRunner extends BaseBuildRunner<BuildData> {
 		Report.FLAKY_TEST_7_2_x.toString(), Report.FLAKY_TEST_7_3_x.toString(),
 		Report.FLAKY_TEST_MASTER.toString(),
 		Report.PULL_REQUEST_HISTORY.toString(),
-		Report.RELEASE_HISTORY.toString(), Report.UPSTREAM_HISTORY.toString(),
-		Report.UTILIZATION.toString());
+		Report.RELEASE_HISTORY.toString(), Report.SPOT_INTERRUPTION.toString(),
+		Report.UPSTREAM_HISTORY.toString(), Report.UTILIZATION.toString());
 
 	static {
 		Instant instant = Instant.now();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
@@ -67,15 +67,13 @@ public class GenerateReportsControllerBuildRunner
 
 		for (String reportName : reportNames) {
 			if (reportName.startsWith("Flaky Test")) {
-				Map<String, String> invocationParameters = new HashMap<>();
+				_invoke(jenkinsGitHubURL, reportName, "slave");
 
-				invocationParameters.put(
-					"JENKINS_GITHUB_URL", jenkinsGitHubURL);
+				continue;
+			}
 
-				invocationParameters.put("REPORT_NAMES", reportName);
-				invocationParameters.put("SLAVE_LABEL", "slave");
-
-				_invoke(invocationParameters);
+			if (reportName.equals("Spot Interruption")) {
+				_invoke(jenkinsGitHubURL, reportName, "slave-pco");
 
 				continue;
 			}
@@ -84,14 +82,8 @@ public class GenerateReportsControllerBuildRunner
 		}
 
 		if (!groupedReportNames.isEmpty()) {
-			Map<String, String> invocationParameters = new HashMap<>();
-
-			invocationParameters.put("JENKINS_GITHUB_URL", jenkinsGitHubURL);
-
-			invocationParameters.put(
-				"REPORT_NAMES", String.join(",", groupedReportNames));
-
-			_invoke(invocationParameters);
+			_invoke(
+				jenkinsGitHubURL, String.join(",", groupedReportNames), null);
 		}
 
 		_updateBuildDescription(reportNames);
@@ -290,6 +282,18 @@ public class GenerateReportsControllerBuildRunner
 
 			ioException.printStackTrace();
 		}
+	}
+
+	private void _invoke(
+		String jenkinsGitHubURL, String reportNames, String slaveLabel) {
+
+		Map<String, String> invocationParameters = new HashMap<>();
+
+		invocationParameters.put("JENKINS_GITHUB_URL", jenkinsGitHubURL);
+		invocationParameters.put("REPORT_NAMES", reportNames);
+		invocationParameters.put("SLAVE_LABEL", slaveLabel);
+
+		_invoke(invocationParameters);
 	}
 
 	private void _updateBuildDescription(List<String> reportNames) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/aws/CloudTrailEventCrawler.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/aws/CloudTrailEventCrawler.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.aws;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.retry.RetryMode;
+import com.amazonaws.services.cloudtrail.AWSCloudTrail;
+import com.amazonaws.services.cloudtrail.AWSCloudTrailClientBuilder;
+import com.amazonaws.services.cloudtrail.model.Event;
+import com.amazonaws.services.cloudtrail.model.LookupAttribute;
+import com.amazonaws.services.cloudtrail.model.LookupAttributeKey;
+import com.amazonaws.services.cloudtrail.model.LookupEventsRequest;
+import com.amazonaws.services.cloudtrail.model.LookupEventsResult;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.json.JSONObject;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class CloudTrailEventCrawler {
+
+	public CloudTrailEventCrawler(String regionName) {
+		ClientConfiguration clientConfiguration = new ClientConfiguration();
+
+		clientConfiguration.setMaxErrorRetry(9);
+		clientConfiguration.setRetryMode(RetryMode.ADAPTIVE);
+
+		AWSCloudTrailClientBuilder awsCloudTrailClientBuilder =
+			AWSCloudTrailClientBuilder.standard();
+
+		awsCloudTrailClientBuilder.withClientConfiguration(clientConfiguration);
+		awsCloudTrailClientBuilder.withRegion(regionName);
+
+		_awsCloudTrail = awsCloudTrailClientBuilder.build();
+	}
+
+	public List<JSONObject> getEventJSONObjects(
+		Date endDate, String eventName, Date startDate) {
+
+		List<JSONObject> eventJSONObjects = new ArrayList<>();
+
+		LookupAttribute lookupAttribute = new LookupAttribute();
+
+		lookupAttribute.withAttributeKey(LookupAttributeKey.EventName);
+		lookupAttribute.withAttributeValue(eventName);
+
+		LookupEventsRequest lookupEventsRequest = new LookupEventsRequest();
+
+		lookupEventsRequest.withEndTime(endDate);
+		lookupEventsRequest.withLookupAttributes(lookupAttribute);
+		lookupEventsRequest.withMaxResults(50);
+		lookupEventsRequest.withStartTime(startDate);
+
+		int lookupCount = 0;
+
+		while (true) {
+			LookupEventsResult lookupEventsResult = _awsCloudTrail.lookupEvents(
+				lookupEventsRequest);
+
+			for (Event event : lookupEventsResult.getEvents()) {
+				eventJSONObjects.add(
+					new JSONObject(event.getCloudTrailEvent()));
+			}
+
+			lookupCount++;
+
+			if ((lookupCount % 10) == 0) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"Retrieved ", String.valueOf(eventJSONObjects.size()),
+						" ", eventName, " events"));
+			}
+
+			String nextToken = lookupEventsResult.getNextToken();
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(nextToken)) {
+				break;
+			}
+
+			lookupEventsRequest.withNextToken(nextToken);
+
+			JenkinsResultsParserUtil.sleep(300);
+		}
+
+		return eventJSONObjects;
+	}
+
+	private final AWSCloudTrail _awsCloudTrail;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BaseReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BaseReport.java
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.metrics;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+
+/**
+ * @author Brittney Nguyen
+ */
+public abstract class BaseReport {
+
+	public void addFile(String fileContent, String fileName) {
+		_fileMap.put(new File(_outputDir, fileName), fileContent);
+	}
+
+	public void addFilesFromResource(
+		String resourceDirPath, String... fileNames) {
+
+		for (String fileName : fileNames) {
+			try {
+				addFile(
+					JenkinsResultsParserUtil.getResourceFileContent(
+						resourceDirPath + fileName),
+					fileName);
+			}
+			catch (IOException ioException) {
+				System.out.println(
+					"Unable to get file content from resource: " +
+						resourceDirPath + fileName);
+			}
+		}
+	}
+
+	public void write() throws IOException {
+		FileUtils.deleteDirectory(_outputDir);
+
+		for (Map.Entry<File, String> entry : _fileMap.entrySet()) {
+			File file = entry.getKey();
+
+			String filePath = file.getCanonicalPath();
+
+			if (filePath.contains(".html")) {
+				System.out.println("Report created at: file://" + filePath);
+			}
+
+			JenkinsResultsParserUtil.write(file, entry.getValue());
+		}
+	}
+
+	protected BaseReport(File outputDir) {
+		_outputDir = outputDir;
+	}
+
+	private final Map<File, String> _fileMap = new HashMap<>();
+	private final File _outputDir;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/BuildHistoryReport.java
@@ -23,13 +23,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
-import org.apache.commons.io.FileUtils;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -37,7 +34,7 @@ import org.json.JSONObject;
 /**
  * @author Kenji Heigel
  */
-public class BuildHistoryReport {
+public class BuildHistoryReport extends BaseReport {
 
 	public static BuildHistoryReport newAggregateReport(
 		long durationDays, File outputDir, String startDateString) {
@@ -287,45 +284,7 @@ public class BuildHistoryReport {
 	}
 
 	public BuildHistoryReport(File outputDir) {
-		_outputDir = outputDir;
-	}
-
-	public void addFile(String fileContent, String fileName) {
-		_fileMap.put(new File(_outputDir, fileName), fileContent);
-	}
-
-	public void addFilesFromResource(
-		String resourceDirPath, String... fileNames) {
-
-		for (String fileName : fileNames) {
-			try {
-				addFile(
-					JenkinsResultsParserUtil.getResourceFileContent(
-						resourceDirPath + fileName),
-					fileName);
-			}
-			catch (IOException ioException) {
-				System.out.println(
-					"Unable to get file content from resource: " +
-						resourceDirPath + fileName);
-			}
-		}
-	}
-
-	public void write() throws IOException {
-		FileUtils.deleteDirectory(_outputDir);
-
-		for (Map.Entry<File, String> entry : _fileMap.entrySet()) {
-			File file = entry.getKey();
-
-			String filePath = file.getCanonicalPath();
-
-			if (filePath.contains(".html")) {
-				System.out.println("Report created at: file://" + filePath);
-			}
-
-			JenkinsResultsParserUtil.write(entry.getKey(), entry.getValue());
-		}
+		super(outputDir);
 	}
 
 	private static String _getGeneratedDateJavaScriptVariable() {
@@ -490,8 +449,5 @@ public class BuildHistoryReport {
 				"(|-downstream)\\(master\\)");
 	private static final Pattern _portalReleaseJobNamePattern = Pattern.compile(
 		"test-portal(|-fixpack|-hotfix)-release(|-downstream)");
-
-	private final Map<File, String> _fileMap = new HashMap<>();
-	private final File _outputDir;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/SpotInterruptionReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/metrics/SpotInterruptionReport.java
@@ -1,0 +1,380 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.metrics;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class SpotInterruptionReport extends BaseReport {
+
+	public static JSONObject newDailyDataJSONObject(
+		List<JSONObject> bidEvictedEventJSONObjects, String dateString,
+		List<JSONObject> runInstancesEventJSONObjects) {
+
+		JSONArray evictionsJSONArray = new JSONArray();
+
+		for (JSONObject bidEvictedEventJSONObject :
+				bidEvictedEventJSONObjects) {
+
+			if (!dateString.equals(
+					_getEventDateString(bidEvictedEventJSONObject))) {
+
+				continue;
+			}
+
+			JSONObject serviceEventDetailsJSONObject =
+				bidEvictedEventJSONObject.optJSONObject("serviceEventDetails");
+
+			if (serviceEventDetailsJSONObject == null) {
+				continue;
+			}
+
+			JSONArray instanceIdSetJSONArray =
+				serviceEventDetailsJSONObject.optJSONArray("instanceIdSet");
+
+			if (instanceIdSetJSONArray == null) {
+				continue;
+			}
+
+			for (int i = 0; i < instanceIdSetJSONArray.length(); i++) {
+				evictionsJSONArray.put(instanceIdSetJSONArray.getString(i));
+			}
+		}
+
+		JSONArray launchesJSONArray = new JSONArray();
+
+		for (JSONObject runInstancesEventJSONObject :
+				runInstancesEventJSONObjects) {
+
+			if (!dateString.equals(
+					_getEventDateString(runInstancesEventJSONObject)) ||
+				runInstancesEventJSONObject.has("errorCode")) {
+
+				continue;
+			}
+
+			JSONObject responseElementsJSONObject =
+				runInstancesEventJSONObject.optJSONObject("responseElements");
+
+			if (responseElementsJSONObject == null) {
+				continue;
+			}
+
+			JSONObject instancesSetJSONObject =
+				responseElementsJSONObject.optJSONObject("instancesSet");
+
+			if (instancesSetJSONObject == null) {
+				continue;
+			}
+
+			JSONArray itemsJSONArray = instancesSetJSONObject.optJSONArray(
+				"items");
+
+			if (itemsJSONArray == null) {
+				continue;
+			}
+
+			for (int i = 0; i < itemsJSONArray.length(); i++) {
+				JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
+
+				String asgName = _getASGName(itemJSONObject);
+
+				launchesJSONArray.put(
+					new JSONObject(
+					).put(
+						"asgType", _getASGType(asgName)
+					).put(
+						"instanceId", itemJSONObject.getString("instanceId")
+					).put(
+						"instanceType", itemJSONObject.getString("instanceType")
+					).put(
+						"master", _getMasterName(asgName)
+					));
+			}
+		}
+
+		return new JSONObject(
+		).put(
+			"date", dateString
+		).put(
+			"evictions", evictionsJSONArray
+		).put(
+			"launches", launchesJSONArray
+		);
+	}
+
+	public static SpotInterruptionReport newSpotInterruptionReport(
+		File dailyDataBaseDir, long durationDays, File outputDir,
+		String startDateString) {
+
+		List<JSONObject> dailyDataJSONObjects = new ArrayList<>();
+
+		for (String dateString :
+				JenkinsResultsParserUtil.getDateStrings(
+					durationDays,
+					LocalDate.parse(
+						startDateString,
+						DateTimeFormatter.ofPattern("yyyyMMdd")))) {
+
+			File dailyDataFile = new File(
+				dailyDataBaseDir, dateString + "/spot-interruption.json");
+
+			if (!dailyDataFile.exists()) {
+				System.out.println("Unable to find " + dailyDataFile);
+
+				continue;
+			}
+
+			try {
+				dailyDataJSONObjects.add(
+					new JSONObject(
+						JenkinsResultsParserUtil.read(dailyDataFile)));
+			}
+			catch (IOException ioException) {
+				System.out.println("Unable to read " + dailyDataFile);
+			}
+		}
+
+		SpotInterruptionReport spotInterruptionReport =
+			new SpotInterruptionReport(outputDir);
+
+		spotInterruptionReport.addFilesFromResource(
+			"dependencies/metrics/spot-interruption-report", "/css/main.css",
+			"/index.html", "/js/main.js");
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("var dataGeneratedDate = new Date(");
+		sb.append(JenkinsResultsParserUtil.getCurrentTimeMillis());
+		sb.append(");\nvar reportName = \"Spot Interruption Report\";\n");
+		sb.append("var dailyTally = ");
+		sb.append(_newDailyTallyJSONArray(dailyDataJSONObjects));
+		sb.append(";");
+
+		spotInterruptionReport.addFile(sb.toString(), "js/table-data.js");
+
+		return spotInterruptionReport;
+	}
+
+	public SpotInterruptionReport(File outputDir) {
+		super(outputDir);
+	}
+
+	private static String _getASGName(JSONObject instanceItemJSONObject) {
+		JSONObject tagSetJSONObject = instanceItemJSONObject.optJSONObject(
+			"tagSet");
+
+		if (tagSetJSONObject == null) {
+			return null;
+		}
+
+		JSONArray itemsJSONArray = tagSetJSONObject.optJSONArray("items");
+
+		if (itemsJSONArray == null) {
+			return null;
+		}
+
+		for (int i = 0; i < itemsJSONArray.length(); i++) {
+			JSONObject itemJSONObject = itemsJSONArray.getJSONObject(i);
+
+			String key = itemJSONObject.optString("key");
+
+			if (key.equals("aws:autoscaling:groupName")) {
+				return itemJSONObject.optString("value");
+			}
+		}
+
+		return null;
+	}
+
+	private static String _getASGType(String asgName) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(asgName)) {
+			return "unknown";
+		}
+
+		if (asgName.contains("bundle-builder")) {
+			return "bundle-builder";
+		}
+
+		if (asgName.contains("-io-")) {
+			return "io";
+		}
+
+		if (asgName.contains("-mem-")) {
+			return "mem";
+		}
+
+		if (asgName.contains("-pco-")) {
+			return "pco";
+		}
+
+		return "slave";
+	}
+
+	private static String _getEventDateString(JSONObject eventJSONObject) {
+		String eventTime = eventJSONObject.optString("eventTime");
+
+		if (eventTime.length() < 10) {
+			return "";
+		}
+
+		String dateString = eventTime.substring(0, 10);
+
+		return dateString.replace("-", "");
+	}
+
+	private static String _getMasterASGTypeKey(
+		String asgType, String masterName) {
+
+		return masterName + "/" + asgType;
+	}
+
+	private static String _getMasterName(String asgName) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(asgName)) {
+			return "unknown";
+		}
+
+		Matcher matcher = _masterNamePattern.matcher(asgName);
+
+		if (!matcher.find()) {
+			return "unknown";
+		}
+
+		return matcher.group(1);
+	}
+
+	private static void _increment(String key, JSONObject tallyJSONObject) {
+		tallyJSONObject.put(key, tallyJSONObject.optInt(key) + 1);
+	}
+
+	private static JSONArray _newDailyTallyJSONArray(
+		List<JSONObject> dailyDataJSONObjects) {
+
+		Map<String, JSONObject> launchJSONObjectsMap = new HashMap<>();
+
+		for (JSONObject dailyDataJSONObject : dailyDataJSONObjects) {
+			JSONArray launchesJSONArray = dailyDataJSONObject.getJSONArray(
+				"launches");
+
+			for (int i = 0; i < launchesJSONArray.length(); i++) {
+				JSONObject launchJSONObject = launchesJSONArray.getJSONObject(
+					i);
+
+				launchJSONObjectsMap.put(
+					launchJSONObject.getString("instanceId"), launchJSONObject);
+			}
+		}
+
+		JSONArray dailyTallyJSONArray = new JSONArray();
+
+		for (JSONObject dailyDataJSONObject : dailyDataJSONObjects) {
+			JSONObject launchesByASGTypeJSONObject = new JSONObject();
+			JSONObject launchesByInstanceTypeJSONObject = new JSONObject();
+			JSONObject launchesByMasterASGTypeJSONObject = new JSONObject();
+			JSONObject launchesByMasterJSONObject = new JSONObject();
+
+			JSONArray launchesJSONArray = dailyDataJSONObject.getJSONArray(
+				"launches");
+
+			for (int i = 0; i < launchesJSONArray.length(); i++) {
+				JSONObject launchJSONObject = launchesJSONArray.getJSONObject(
+					i);
+
+				_increment(
+					launchJSONObject.getString("asgType"),
+					launchesByASGTypeJSONObject);
+				_increment(
+					launchJSONObject.getString("instanceType"),
+					launchesByInstanceTypeJSONObject);
+				_increment(
+					_getMasterASGTypeKey(
+						launchJSONObject.getString("asgType"),
+						launchJSONObject.getString("master")),
+					launchesByMasterASGTypeJSONObject);
+				_increment(
+					launchJSONObject.getString("master"),
+					launchesByMasterJSONObject);
+			}
+
+			JSONObject evictionsByASGTypeJSONObject = new JSONObject();
+			JSONObject evictionsByInstanceTypeJSONObject = new JSONObject();
+			JSONObject evictionsByMasterASGTypeJSONObject = new JSONObject();
+			JSONObject evictionsByMasterJSONObject = new JSONObject();
+
+			JSONArray evictionsJSONArray = dailyDataJSONObject.getJSONArray(
+				"evictions");
+
+			for (int i = 0; i < evictionsJSONArray.length(); i++) {
+				String asgType = "unknown";
+				String instanceType = "unknown";
+				String masterName = "unknown";
+
+				JSONObject launchJSONObject = launchJSONObjectsMap.get(
+					evictionsJSONArray.getString(i));
+
+				if (launchJSONObject != null) {
+					asgType = launchJSONObject.getString("asgType");
+					instanceType = launchJSONObject.getString("instanceType");
+					masterName = launchJSONObject.getString("master");
+				}
+
+				_increment(asgType, evictionsByASGTypeJSONObject);
+				_increment(instanceType, evictionsByInstanceTypeJSONObject);
+				_increment(
+					_getMasterASGTypeKey(asgType, masterName),
+					evictionsByMasterASGTypeJSONObject);
+				_increment(masterName, evictionsByMasterJSONObject);
+			}
+
+			dailyTallyJSONArray.put(
+				new JSONObject(
+				).put(
+					"date", dailyDataJSONObject.getString("date")
+				).put(
+					"evictionsByASGType", evictionsByASGTypeJSONObject
+				).put(
+					"evictionsByInstanceType", evictionsByInstanceTypeJSONObject
+				).put(
+					"evictionsByMaster", evictionsByMasterJSONObject
+				).put(
+					"evictionsByMasterASGType",
+					evictionsByMasterASGTypeJSONObject
+				).put(
+					"launchesByASGType", launchesByASGTypeJSONObject
+				).put(
+					"launchesByInstanceType", launchesByInstanceTypeJSONObject
+				).put(
+					"launchesByMaster", launchesByMasterJSONObject
+				).put(
+					"launchesByMasterASGType", launchesByMasterASGTypeJSONObject
+				));
+		}
+
+		return dailyTallyJSONArray;
+	}
+
+	private static final Pattern _masterNamePattern = Pattern.compile(
+		"(test-\\d+-\\d+)");
+
+}

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/spot-interruption-report/css/main.css
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/spot-interruption-report/css/main.css
@@ -1,0 +1,44 @@
+.accordion {
+	margin-top: 16px;
+}
+
+.panel {
+	padding-bottom: 12px;
+	padding-top: 16px;
+}
+
+.range-selector {
+	margin-bottom: 16px;
+}
+
+.range-selector button {
+	background: #f8f9fa;
+	border: 1px solid #ced4da;
+	border-radius: 4px;
+	margin-right: 4px;
+	padding: 4px 12px;
+}
+
+.range-selector button.active {
+	background: #007bff;
+	border-color: #007bff;
+	color: #fff;
+}
+
+.search {
+	border: 1px solid #d3d3d3;
+	font-size: 14px;
+	margin-bottom: 12px;
+	padding: 12px 12px 12px 40px;
+	position: relative;
+	width: 100%;
+}
+
+.table-wrapper {
+	max-height: 1080px;
+}
+
+.table-wrapper-full {
+	max-height: none;
+	overflow: visible;
+}

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/spot-interruption-report/index.html
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/spot-interruption-report/index.html
@@ -1,0 +1,100 @@
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+
+		<title id="title"></title>
+	</head>
+
+	<body>
+		<h2 id="report-name"></h2>
+
+		<div class="date">
+			<p id="spot-interruption-data-date"></p>
+		</div>
+
+		<div>
+			<button class="accordion"><h3>Interruption Rate Over Time by ASG Type</h3></button>
+
+			<div class="panel">
+				<div class="chart-container">
+					<canvas id="spot-interruption-canvas"></canvas>
+				</div>
+
+				<br />
+			</div>
+
+			<div class="range-selector">
+				<button id="range-1" type="button">Today</button>
+				<button class="active" id="range-7" type="button">Last 7 Days</button>
+				<button id="range-0" type="button"></button>
+			</div>
+
+			<button class="accordion"><h3>Interruption Rate by ASG Type</h3></button>
+
+			<div class="panel">
+				<div class="table-wrapper table-wrapper-full">
+					<table class="sortable-theme-bootstrap" data-sortable id="spot-interruption-asg-type-table"></table>
+				</div>
+
+				<br />
+			</div>
+
+			<button class="accordion"><h3>Interruption Rate by Instance Type</h3></button>
+
+			<div class="panel">
+				<div class="table-wrapper">
+					<table class="sortable-theme-bootstrap" data-sortable id="spot-interruption-instance-type-table"></table>
+				</div>
+
+				<br />
+			</div>
+
+			<button class="accordion"><h3>Interruption Rate by Master</h3></button>
+
+			<div class="panel">
+				<div class="table-wrapper table-wrapper-full">
+					<table class="sortable-theme-bootstrap" data-sortable id="spot-interruption-master-table"></table>
+				</div>
+
+				<br />
+			</div>
+
+			<button class="accordion"><h3>Interruption Rate by Master and ASG Type</h3></button>
+
+			<div class="panel">
+				<div>
+					<i class="fa fa-search"></i>
+
+					<input class="search" id="spot-interruption-master-asg-type-search" placeholder="Filter by master or ASG type (e.g. test-1-41)" type="text" />
+				</div>
+
+				<div class="table-wrapper">
+					<table class="sortable-theme-bootstrap" data-sortable id="spot-interruption-master-asg-type-table"></table>
+				</div>
+
+				<br />
+			</div>
+		</div>
+
+		<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" rel="stylesheet" />
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/css/sortable-theme-bootstrap.min.css" rel="stylesheet" />
+
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
+
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.5.0/chart.umd.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.2/timeago.min.js"></script>
+
+		<script src="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/js/utils.js"></script>
+
+		<link href="https://cdn.jsdelivr.net/gh/liferay/liferay-portal@5efc3355b3fd817bc00f60c67b0feaa01d81909f/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/css/report.css" rel="stylesheet" />
+
+		<script src="js/table-data.js"></script>
+
+		<link href="css/main.css" rel="stylesheet" />
+
+		<script src="js/main.js"></script>
+	</body>
+</html>

--- a/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/spot-interruption-report/js/main.js
+++ b/modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/spot-interruption-report/js/main.js
@@ -1,0 +1,282 @@
+var SPOT_ASG_TYPES = ['bundle-builder', 'io', 'mem', 'pco', 'slave', 'unknown'];
+
+function createSpotInterruptionTable(table, tableElementID) {
+	let tableElement = document.getElementById(tableElementID);
+
+	tableElement.innerHTML = '';
+
+	let tbodyElement = tableElement.createTBody();
+
+	table.forEach((cellValues, index) => {
+		if (index == 0) {
+			let theadElement = tableElement.createTHead();
+
+			theadElement.classList.add('thead-light');
+
+			let rowElement = theadElement.insertRow();
+
+			cellValues.forEach((cellValue) => {
+				let thElement = document.createElement('th');
+
+				thElement.appendChild(document.createTextNode(cellValue));
+
+				rowElement.appendChild(thElement);
+			});
+
+			return;
+		}
+
+		let rowElement = tbodyElement.insertRow();
+
+		cellValues.forEach((cellValue, columnIndex) => {
+			let cellElement = rowElement.insertCell();
+
+			cellElement.setAttribute(
+				'data-value', (cellValue === null) ? -1 : cellValue);
+
+			if (table[0][columnIndex].includes('%')) {
+				cellValue = (cellValue === null) ? '-' : cellValue + '%';
+			}
+
+			cellElement.appendChild(document.createTextNode(cellValue));
+		});
+	});
+
+	tableElement.removeAttribute('data-sortable-initialized');
+
+	return tableElement;
+}
+
+function getGroupNames(entries, tallyNames) {
+	let groupNames = new Set();
+
+	entries.forEach((entry) => {
+		tallyNames.forEach((tallyName) => {
+			Object.keys(entry[tallyName]).forEach((groupName) => {
+				groupNames.add(groupName);
+			});
+		});
+	});
+
+	return Array.from(groupNames).sort();
+}
+
+function getRate(evictionCount, launchCount) {
+	if ((launchCount == 0) || (evictionCount > launchCount)) {
+		return null;
+	}
+
+	return Number(((evictionCount / launchCount) * 100).toFixed(1));
+}
+
+function getSpotChartDatasets() {
+	let datasets = [];
+
+	SPOT_ASG_TYPES.forEach((asgType, slot) => {
+		let launchTotal = 0;
+
+		let dataPoints = dailyTally.map((entry) => {
+			let launchCount = entry.launchesByASGType[asgType] || 0;
+			let evictionCount = entry.evictionsByASGType[asgType] || 0;
+
+			launchTotal += launchCount;
+
+			return {
+				x: getSpotDateMillis(entry.date),
+				y: getRate(evictionCount, launchCount)
+			};
+		});
+
+		if (launchTotal > 0) {
+			let color = getColor(slot);
+
+			datasets.push({
+				backgroundColor: color,
+				borderColor: color,
+				data: dataPoints,
+				label: asgType
+			});
+		}
+	});
+
+	return datasets;
+}
+
+function getSpotDateMillis(dateString) {
+	let date = new Date(dateString.slice(0, 4), dateString.slice(4, 6) - 1, dateString.slice(6, 8));
+
+	return date.getTime();
+}
+
+function getTallySum(entries, tallyName, groupName) {
+	let sum = 0;
+
+	entries.forEach((entry) => {
+		let tally = entry[tallyName];
+
+		if (groupName in tally) {
+			sum += tally[groupName];
+		}
+	});
+
+	return sum;
+}
+
+function newCrossTable(entries, evictionsTallyName, groupHeader1, groupHeader2, launchesTallyName) {
+	let table = [[groupHeader1, groupHeader2, 'Launches', 'Evictions', 'Interruption Rate (%)']];
+
+	getGroupNames(entries, [evictionsTallyName, launchesTallyName]).forEach((groupKey) => {
+		let groupNames = groupKey.split('/');
+
+		let evictionCount = getTallySum(entries, evictionsTallyName, groupKey);
+		let launchCount = getTallySum(entries, launchesTallyName, groupKey);
+
+		table.push([groupNames[0], groupNames[1], launchCount, evictionCount, getRate(evictionCount, launchCount)]);
+	});
+
+	return table;
+}
+
+function newGroupTable(entries, evictionsTallyName, groupHeader, launchesTallyName) {
+	let table = [[groupHeader, 'Launches', 'Evictions', 'Interruption Rate (%)']];
+
+	getGroupNames(entries, [evictionsTallyName, launchesTallyName]).forEach((groupName) => {
+		let evictionCount = getTallySum(entries, evictionsTallyName, groupName);
+		let launchCount = getTallySum(entries, launchesTallyName, groupName);
+
+		table.push([groupName, launchCount, evictionCount, getRate(evictionCount, launchCount)]);
+	});
+
+	return table;
+}
+
+function renderChart() {
+	return new Chart(document.getElementById('spot-interruption-canvas'), {
+		data: {
+			datasets: getSpotChartDatasets()
+		},
+		options: {
+			elements: {
+				point: {
+					hitRadius: 10,
+					hoverRadius: 4,
+					radius: 0
+				}
+			},
+			maintainAspectRatio: false,
+			plugins: {
+				tooltip: {
+					callbacks: {
+						label: function(context) {
+							let rate = context.parsed.y;
+
+							if ((rate === null) || isNaN(rate)) {
+								return context.dataset.label + ': -';
+							}
+
+							return context.dataset.label + ': ' + rate + '%';
+						}
+					},
+					mode: 'index'
+				}
+			},
+			responsive: true,
+			scales: {
+				x: {
+					time: {
+						displayFormats: {
+							day: 'MMM d'
+						},
+						unit: 'day'
+					},
+					type: 'time'
+				},
+				y: {
+					beginAtZero: true,
+					ticks: {
+						callback: function(value) {
+							return value + '%';
+						}
+					},
+					title: {
+						display: true,
+						text: 'Interruption Rate (%)'
+					}
+				}
+			}
+		},
+		type: 'line'
+	});
+}
+
+function renderRange(rangeDays) {
+	let entries = dailyTally;
+
+	if (rangeDays > 0) {
+		entries = dailyTally.slice(-rangeDays);
+	}
+
+	createSpotInterruptionTable(newGroupTable(entries, 'evictionsByASGType', 'ASG Type', 'launchesByASGType'), 'spot-interruption-asg-type-table');
+	createSpotInterruptionTable(newGroupTable(entries, 'evictionsByInstanceType', 'Instance Type', 'launchesByInstanceType'), 'spot-interruption-instance-type-table');
+	createSpotInterruptionTable(newGroupTable(entries, 'evictionsByMaster', 'Master', 'launchesByMaster'), 'spot-interruption-master-table');
+	createSpotInterruptionTable(newCrossTable(entries, 'evictionsByMasterASGType', 'Master', 'ASG Type', 'launchesByMasterASGType'), 'spot-interruption-master-asg-type-table');
+
+	searchTable('spot-interruption-master-asg-type-search', 'spot-interruption-master-asg-type-table');
+
+	[1, 7, 0].forEach((buttonRangeDays) => {
+		let buttonElement = document.getElementById('range-' + buttonRangeDays);
+
+		if (buttonRangeDays == rangeDays) {
+			buttonElement.classList.add('active');
+		}
+		else {
+			buttonElement.classList.remove('active');
+		}
+	});
+
+	Sortable.init();
+}
+
+addReportName();
+
+addDateText(document.getElementById("spot-interruption-data-date"), dataGeneratedDate);
+
+document.getElementById('range-0').textContent =
+	'Last ' + dailyTally.length + ' Days';
+
+[1, 7, 0].forEach((rangeDays) => {
+	let buttonElement = document.getElementById('range-' + rangeDays);
+
+	buttonElement.addEventListener('click', () => renderRange(rangeDays));
+});
+
+document.getElementById('spot-interruption-master-asg-type-search').addEventListener('keyup', () => searchTable('spot-interruption-master-asg-type-search', 'spot-interruption-master-asg-type-table'));
+
+let accordionButtonElements = document.getElementsByClassName('accordion');
+
+for (let i = 0; i < accordionButtonElements.length; i++) {
+	let accordionButtonElement = accordionButtonElements[i];
+
+	accordionButtonElement.classList.add('active');
+
+	accordionButtonElement.nextElementSibling.style.display = 'block';
+
+	accordionButtonElement.addEventListener('click', function () {
+		this.classList.toggle('active');
+
+		let panelElement = this.nextElementSibling;
+
+		if (panelElement.style.display === 'block') {
+			panelElement.style.display = 'none';
+		}
+		else {
+			panelElement.style.display = 'block';
+		}
+	});
+}
+
+if ((typeof dailyTally !== 'undefined') && dailyTally) {
+	renderChart();
+
+	renderRange(7);
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7822

## What Is Being Fixed

Spot-instance interruption rates vary widely across the CI fleet — the
bundle-builder pool runs far higher than the others — but there is no way to
see the trend over time. This adds a daily Spot Interruption report so the team
can track interruption rate (evictions / launches) by ASG type, instance type,
and master, and spot regressions early.

## How It Is Being Fixed

The report is built on the existing `GenerateReportsBuildRunner` infrastructure.
`CloudTrailEventCrawler` pulls `BidEvictedEvent` and `RunInstances` events from
CloudTrail `LookupEvents` using the master's instance-profile credentials, with
an adaptive-retry client and paced pagination to stay within the account's
request throttle. `SpotInterruptionReport` reduces the raw events into a per-day
JSON document and aggregates the counts, attributing each eviction back to its
launch by instance ID so evictions land under the right ASG type; unattributable
evictions fall to an `unknown` bucket. The report renders a Chart.js trend plus
four sortable tables client-side, with a range selector and a guard that shows
`-` for the meaningless over-100% case.

The shared file-writing logic is lifted out of `BuildHistoryReport` into a new
`BaseReport` that both reports extend. The report is registered as a
`SPOT_INTERRUPTION` entry in `GenerateReportsBuildRunner` and routed to a
downstream `slave-pco` node by `GenerateReportsControllerBuildRunner`. The pull
window is 14 days, chosen so the run completes within the report job's one-hour
timeout given the `LookupEvents` throttle; a longer window is a follow-up.

The companion `liferay-jenkins-ee` build properties (window, region, stale
duration) land in a separate PR, and the report reads the newly added
`aws-java-sdk-cloudtrail` dependency, so it needs the usual jar publish before
that companion can consume it.

## Why Are There No Tests?

The `metrics` report classes follow the established package precedent —
`BuildHistoryReport` and the other report classes ship without unit tests. The
logic was validated end to end against live CloudTrail data on CI
(`test-1-43/generate-reports/9`: SUCCESS, ~36 min, report published, ~145k
`RunInstances` events processed).

## PR Check

**pr-check: PASS** — tested on `48628a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |
| Per-Module Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "48628a5b204330a10f1a83da33be719d516b8b1b"} -->
