### PR TITLE
LRCI-7275 Set a default s3 bucket name when not already set

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1360,10 +1360,18 @@ public class JenkinsResultsParserUtil {
 
 			String s3BucketName = Environment.get("S3_BUCKET_NAME");
 
-			if (!isNullOrEmpty(s3BucketName)) {
-				properties.setProperty(
-					"env.S3_BUCKET_NAME", Environment.get("S3_BUCKET_NAME"));
+			if (isNullOrEmpty(s3BucketName)) {
+				String jenkinsURL = Environment.get("JENKINS_URL");
+
+				if ((jenkinsURL != null) && jenkinsURL.contains("test-5")) {
+					s3BucketName = "liferayci-file-propagator-staging";
+				}
+				else {
+					s3BucketName = "liferayci-file-propagator";
+				}
 			}
+
+			properties.setProperty("env.S3_BUCKET_NAME", s3BucketName);
 
 			if (!properties.containsKey("user.home")) {
 				properties.setProperty(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7275

## What Is Being Fixed

When the `S3_BUCKET_NAME` environment variable was unset, the build properties left `env.S3_BUCKET_NAME` unspecified, so downstream file propagation had no bucket to target.

## How It Is Being Fixed

When `S3_BUCKET_NAME` is empty, a default bucket name is derived from the Jenkins master: `liferayci-file-propagator-staging` when `JENKINS_URL` contains `test-5`, otherwise `liferayci-file-propagator`. The `env.S3_BUCKET_NAME` property is now always set, whether from the environment or from this default.

## Why Are There No Tests?

This change is Jenkins CI tooling whose behavior is driven by the runtime environment (bucket selection keyed off `JENKINS_URL`), which the module's unit test harness does not exercise.

## PR Check

**pr-check: PASS** — tested on `d5eab8ab4e1c5b0aa35373cfd663aacfd113c0bf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d5eab8ab4e1c5b0aa35373cfd663aacfd113c0bf"} -->
