### PR TITLE
LRCI-7918 Recover missing downstream results from the live test report

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildReport.java
@@ -5,6 +5,8 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.net.URL;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -139,8 +141,10 @@ public abstract class BaseDownstreamBuildReport
 		JSONArray testResultsJSONArray = buildReportJSONObject.optJSONArray(
 			"testResults");
 
-		if (testResultsJSONArray == null) {
-			_testReports = testReports;
+		if ((testResultsJSONArray == null) ||
+			(testResultsJSONArray.length() == 0)) {
+
+			_testReports = _getLiveTestReports();
 
 			return _testReports;
 		}
@@ -210,6 +214,106 @@ public abstract class BaseDownstreamBuildReport
 		_topLevelBuildReport = topLevelBuildReport;
 
 		_buildCached = buildReportJSONObject.optBoolean("buildCached", false);
+	}
+
+	private List<TestReport> _getLiveTestReports() {
+		List<TestReport> testReports = new ArrayList<>();
+
+		JenkinsMaster jenkinsMaster = getJenkinsMaster();
+
+		if ((jenkinsMaster == null) || !jenkinsMaster.isAvailable()) {
+			return testReports;
+		}
+
+		String testReportURL = JenkinsResultsParserUtil.getLocalURL(
+			JenkinsResultsParserUtil.combine(
+				String.valueOf(getBuildURL()), "/testReport/api/json"));
+
+		JSONObject testReportJSONObject = null;
+
+		try {
+			if (!JenkinsResultsParserUtil.exists(new URL(testReportURL))) {
+				return testReports;
+			}
+
+			testReportJSONObject = JenkinsResultsParserUtil.toJSONObject(
+				testReportURL, false, 5000);
+		}
+		catch (Exception exception) {
+			return testReports;
+		}
+
+		if (testReportJSONObject == null) {
+			return testReports;
+		}
+
+		JSONArray suitesJSONArray = testReportJSONObject.optJSONArray("suites");
+
+		if (suitesJSONArray == null) {
+			return testReports;
+		}
+
+		for (int i = 0; i < suitesJSONArray.length(); i++) {
+			JSONObject suiteJSONObject = suitesJSONArray.getJSONObject(i);
+
+			JSONArray casesJSONArray = suiteJSONObject.optJSONArray("cases");
+
+			if (casesJSONArray == null) {
+				continue;
+			}
+
+			for (int j = 0; j < casesJSONArray.length(); j++) {
+				testReports.add(
+					TestReportFactory.newTestReport(
+						this,
+						_toTestResultJSONObject(
+							casesJSONArray.getJSONObject(j))));
+			}
+		}
+
+		return testReports;
+	}
+
+	private JSONObject _toTestResultJSONObject(JSONObject caseJSONObject) {
+		JSONObject testResultJSONObject = new JSONObject();
+
+		testResultJSONObject.put(
+			"duration", (long)(caseJSONObject.optDouble("duration", 0) * 1000));
+
+		String errorDetails = caseJSONObject.optString("errorDetails", null);
+
+		if (errorDetails != null) {
+			if (errorDetails.contains("\n")) {
+				errorDetails = errorDetails.substring(
+					0, errorDetails.indexOf("\n"));
+			}
+
+			if (errorDetails.length() > 200) {
+				errorDetails = errorDetails.substring(0, 200);
+			}
+
+			testResultJSONObject.put("errorDetails", errorDetails);
+		}
+
+		String status = caseJSONObject.optString("status");
+
+		if (!status.equals("FIXED") && !status.equals("PASSED") &&
+			!status.equals("SKIPPED")) {
+
+			testResultJSONObject.put(
+				"errorStackTrace", caseJSONObject.optString("errorStackTrace"));
+		}
+
+		testResultJSONObject.put(
+			"name",
+			JenkinsResultsParserUtil.combine(
+				caseJSONObject.optString("className"), ".",
+				caseJSONObject.optString("name"))
+		).put(
+			"status", status
+		);
+
+		return testResultJSONObject;
 	}
 
 	private final String _batchName;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7918

## What Is Being Fixed

When a top-level PR-test build is aborted mid-publish, its downstream test results are never collected into `build-database.json`. Re-running `publish-testray-report` then reports every test in those axes to Testray as "Failed prior to running test" — false failures — even though the tests passed, because the stored `testResults` are empty. The real results still exist on each downstream build's live Jenkins `testReport`, just not in any artifact publish reads.

## How It Is Being Fixed

`BaseDownstreamBuildReport.getTestReports()` now falls back to the downstream build's live testReport when the stored `testResults` array is missing or empty. It guards on `JenkinsMaster.isAvailable()` and a `JenkinsResultsParserUtil.exists()` HEAD (a fast fail when the build has been purged), fetches `<buildURL>/testReport/api/json`, and maps `suites[].cases[]` into `TestReport`s through a helper that mirrors `BaseTestResult.getTestReportJSONObject` (duration in ms, first-line/200-char `errorDetails`, `errorStackTrace` only when failing, raw status). Builds with populated stored `testResults` take the existing path unchanged, so healthy builds are unaffected.

This recovers aborted builds whose downstream builds are still retained. Aborts whose downstream builds have since been purged are out of scope: the data is unrecoverable, and the resolve-phase handling would be a separate build-lifecycle change (recorded in a comment on LRCI-7918).

Two things worth flagging for review. Recovered cases carry no `testTaskName` — it is not present in `testReport/api/json` (only the Gradle task provides it), so module/app-path and component attribution degrades on recovered cases, though pass/fail is unaffected. And the failing-status check (`{FIXED, PASSED, SKIPPED}`) is inlined rather than delegating to `isFailing()`, because the `TestReport` is not constructed at that point; consolidating it into a shared `isFailingStatus(String)` would touch `BaseTestReport` and `BaseTestResult`, so it is left as a possible follow-up.

## Why Are There No Tests?

jenkins-results-parser report classes are validated by real-data spot-checks rather than unit tests, per house convention. This fix was validated with a live-testReport harness run against a retained downstream build, which reproduced the real 1,555 results and caught a missing-slash URL-construction bug that has been fixed.

## PR Check

**pr-check: PASS** — tested on `15bc6ecd8892fb54fc7f7bdc2ae92a6a97f50f67`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

Java Unit Tests matched the diff but were not run: `BaseDownstreamBuildReport` is a report class with no unit-test counterpart (see Why Are There No Tests).

<!-- pr-check {"result": "success", "sha": "15bc6ecd8892fb54fc7f7bdc2ae92a6a97f50f67"} -->
