### PR TITLE
LRCI-7915 Drain blacklisted masters during rebalance

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -62,10 +62,22 @@ public class JenkinsCohort {
 	public List<JenkinsMaster> getBlackListedJenkinsMasters() {
 		List<JenkinsMaster> blackListedJenkinsMasters = new ArrayList<>();
 
-		for (JenkinsMaster jenkinsMaster : getJenkinsMasters()) {
-			if (jenkinsMaster.isBlackListed()) {
-				blackListedJenkinsMasters.add(jenkinsMaster);
+		try {
+			List<JenkinsMaster> jenkinsMasters =
+				JenkinsResultsParserUtil.getJenkinsMasters(
+					JenkinsResultsParserUtil.getBuildProperties(),
+					JenkinsMaster.getSlaveRAMMinimumDefault(),
+					JenkinsMaster.getSlavesPerHostDefault(), getName(), null,
+					true);
+
+			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
+				if (jenkinsMaster.isBlackListed()) {
+					blackListedJenkinsMasters.add(jenkinsMaster);
+				}
 			}
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
 		}
 
 		return blackListedJenkinsMasters;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -65,10 +65,9 @@ public class JenkinsCohort {
 		try {
 			List<JenkinsMaster> jenkinsMasters =
 				JenkinsResultsParserUtil.getJenkinsMasters(
-					JenkinsResultsParserUtil.getBuildProperties(),
-					JenkinsMaster.getSlaveRAMMinimumDefault(),
-					JenkinsMaster.getSlavesPerHostDefault(), getName(), null,
-					true);
+					JenkinsResultsParserUtil.getBuildProperties(), getName(),
+					true, JenkinsMaster.getSlavesPerHostDefault(),
+					JenkinsMaster.getSlaveRAMMinimumDefault(), null);
 
 			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
 				if (jenkinsMaster.isBlackListed()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2469,6 +2469,16 @@ public class JenkinsResultsParserUtil {
 		Properties buildProperties, int minimumRAM, int maximumSlavesPerHost,
 		String cohortName, String networkName) {
 
+		return getJenkinsMasters(
+			buildProperties, minimumRAM, maximumSlavesPerHost, cohortName,
+			networkName, false);
+	}
+
+	public static List<JenkinsMaster> getJenkinsMasters(
+		Properties buildProperties, int minimumRAM, int maximumSlavesPerHost,
+		String cohortName, String networkName,
+		boolean includeBlackListedJenkinsMasters) {
+
 		List<JenkinsMaster> jenkinsMasters = new ArrayList<>();
 
 		Pattern pattern = Pattern.compile(
@@ -2485,7 +2495,8 @@ public class JenkinsResultsParserUtil {
 			JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
 				matcher.group("jenkinsMasterName"));
 
-			if (jenkinsMaster.isBlackListed() ||
+			if ((!includeBlackListedJenkinsMasters &&
+				 jenkinsMaster.isBlackListed()) ||
 				(jenkinsMaster.getSlaveRAM() < minimumRAM) ||
 				(jenkinsMaster.getSlavesPerHost() > maximumSlavesPerHost)) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2470,14 +2470,14 @@ public class JenkinsResultsParserUtil {
 		String cohortName, String networkName) {
 
 		return getJenkinsMasters(
-			buildProperties, minimumRAM, maximumSlavesPerHost, cohortName,
-			networkName, false);
+			buildProperties, cohortName, false, maximumSlavesPerHost,
+			minimumRAM, networkName);
 	}
 
 	public static List<JenkinsMaster> getJenkinsMasters(
-		Properties buildProperties, int minimumRAM, int maximumSlavesPerHost,
-		String cohortName, String networkName,
-		boolean includeBlackListedJenkinsMasters) {
+		Properties buildProperties, String cohortName,
+		boolean includeBlackListedJenkinsMasters, int maximumSlavesPerHost,
+		int minimumRAM, String networkName) {
 
 		List<JenkinsMaster> jenkinsMasters = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.lang.reflect.Field;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * @author Calum Ragan
+ */
+public class BuildQueueRebalancerTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@After
+	@Override
+	public void tearDown() {
+		try {
+			Map<String, JenkinsMaster> jenkinsMasters = _getStaticFieldValue(
+				JenkinsMaster.class, "_jenkinsMasters");
+
+			jenkinsMasters.remove(_AVAILABLE_JENKINS_MASTER_NAME);
+			jenkinsMasters.remove(_BLACK_LISTED_JENKINS_MASTER_NAME);
+
+			Map<String, JenkinsCohort> jenkinsCohorts = _getStaticFieldValue(
+				JenkinsCohort.class, "_jenkinsCohorts");
+
+			jenkinsCohorts.remove(_JENKINS_COHORT_NAME);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new RuntimeException(reflectiveOperationException);
+		}
+
+		JenkinsResultsParserUtil.setBuildProperties(
+			(Hashtable<Object, Object>)null);
+
+		super.tearDown();
+	}
+
+	@Test
+	public void testRebalanceDrainsBlackListedJenkinsMasters()
+		throws Exception {
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("jenkins.load.balancer.blacklist", "");
+
+		for (String jenkinsMasterName :
+				new String[] {
+					_AVAILABLE_JENKINS_MASTER_NAME,
+					_BLACK_LISTED_JENKINS_MASTER_NAME
+				}) {
+
+			buildProperties.setProperty(
+				JenkinsResultsParserUtil.combine(
+					"jenkins.local.url[", jenkinsMasterName, "]"),
+				JenkinsResultsParserUtil.combine(
+					"http://", jenkinsMasterName, ".liferay.com"));
+			buildProperties.setProperty(
+				JenkinsResultsParserUtil.combine(
+					"jenkins.remote.url[", jenkinsMasterName, "]"),
+				JenkinsResultsParserUtil.combine(
+					"https://", jenkinsMasterName, ".liferay.com"));
+			buildProperties.setProperty(
+				JenkinsResultsParserUtil.combine(
+					"master.property(", jenkinsMasterName, "/executors.size)"),
+				"2");
+		}
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			JenkinsResultsParserUtil.combine(
+				"{\"items\":[{\"id\":101,\"inQueueSince\":1,\"task\":",
+				"{\"name\":\"test-portal-acceptance-pullrequest(master)\",",
+				"\"url\":\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
+				".liferay.com/job/test-portal-acceptance-pullrequest",
+				"(master)/\"},\"url\":\"queue/item/101/\",\"why\":\"\"},",
+				"{\"id\":102,\"inQueueSince\":2,\"task\":{\"name\":",
+				"\"test-portal-acceptance-pullrequest(master)\",\"url\":",
+				"\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
+				".liferay.com/job/test-portal-acceptance-pullrequest",
+				"(master)/\"},\"url\":\"queue/item/102/\",\"why\":\"\"}]}"),
+			_BLACK_LISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			urlReader);
+		setUrlReaderOutput(
+			"{\"mode\":\"NORMAL\"}",
+			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/api/json?tree=mode",
+			urlReader);
+		setUrlReaderOutput(
+			"{\"items\":[]}",
+			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			urlReader);
+
+		for (String jenkinsMasterName :
+				new String[] {
+					_AVAILABLE_JENKINS_MASTER_NAME,
+					_BLACK_LISTED_JENKINS_MASTER_NAME
+				}) {
+
+			JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
+				jenkinsMasterName);
+
+			_setFieldValue(
+				jenkinsMaster, "_awsFleetCloudLastUpdateTimestamp",
+				Long.MAX_VALUE);
+			_setFieldValue(jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
+		}
+
+		_setFieldValue(
+			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
+			"_blacklisted", true);
+
+		JenkinsCohort jenkinsCohort = JenkinsCohort.getInstance(
+			_JENKINS_COHORT_NAME);
+
+		List<JenkinsMaster> availableJenkinsMasters =
+			jenkinsCohort.getAvailableJenkinsMasters();
+
+		testEquals(1, availableJenkinsMasters.size());
+
+		JenkinsMaster jenkinsMaster = availableJenkinsMasters.get(0);
+
+		testEquals(_AVAILABLE_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+
+		List<JenkinsMaster> blackListedJenkinsMasters =
+			jenkinsCohort.getBlackListedJenkinsMasters();
+
+		testEquals(1, blackListedJenkinsMasters.size());
+
+		jenkinsMaster = blackListedJenkinsMasters.get(0);
+
+		testEquals(_BLACK_LISTED_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+
+		BuildQueueRebalancer buildQueueRebalancer = new BuildQueueRebalancer(
+			jenkinsCohort);
+
+		buildQueueRebalancer.rebalance();
+
+		String summary = buildQueueRebalancer.getSummary();
+
+		testEquals(
+			true,
+			summary.startsWith(
+				"Build queue rebalanced by 2 reinvocations and 0 aborts"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T _getStaticFieldValue(Class<?> clazz, String fieldName)
+		throws ReflectiveOperationException {
+
+		Field field = clazz.getDeclaredField(fieldName);
+
+		field.setAccessible(true);
+
+		return (T)field.get(null);
+	}
+
+	private void _setFieldValue(Object object, String fieldName, Object value)
+		throws Exception {
+
+		Class<?> clazz = object.getClass();
+
+		Field field = clazz.getDeclaredField(fieldName);
+
+		field.setAccessible(true);
+
+		field.set(object, value);
+	}
+
+	private static final String _AVAILABLE_JENKINS_MASTER_NAME = "test-9-2";
+
+	private static final String _BLACK_LISTED_JENKINS_MASTER_NAME = "test-9-1";
+
+	private static final String _JENKINS_COHORT_NAME = "test-9";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -48,9 +48,7 @@ public class BuildQueueRebalancerTest
 	}
 
 	@Test
-	public void testRebalanceDrainsBlackListedJenkinsMasters()
-		throws Exception {
-
+	public void testRebalanceBlackListedJenkinsMasters() throws Exception {
 		Properties buildProperties = new Properties();
 
 		buildProperties.setProperty("jenkins.load.balancer.blacklist", "");
@@ -131,18 +129,22 @@ public class BuildQueueRebalancerTest
 
 		testEquals(1, availableJenkinsMasters.size());
 
-		JenkinsMaster jenkinsMaster = availableJenkinsMasters.get(0);
+		JenkinsMaster availableJenkinsMaster = availableJenkinsMasters.get(0);
 
-		testEquals(_AVAILABLE_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+		testEquals(
+			_AVAILABLE_JENKINS_MASTER_NAME, availableJenkinsMaster.getName());
 
 		List<JenkinsMaster> blackListedJenkinsMasters =
 			jenkinsCohort.getBlackListedJenkinsMasters();
 
 		testEquals(1, blackListedJenkinsMasters.size());
 
-		jenkinsMaster = blackListedJenkinsMasters.get(0);
+		JenkinsMaster blackListedJenkinsMaster = blackListedJenkinsMasters.get(
+			0);
 
-		testEquals(_BLACK_LISTED_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+		testEquals(
+			_BLACK_LISTED_JENKINS_MASTER_NAME,
+			blackListedJenkinsMaster.getName());
 
 		BuildQueueRebalancer buildQueueRebalancer = new BuildQueueRebalancer(
 			jenkinsCohort);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7915

## What Is Being Fixed

The rebalance-build-queue job is supposed to move queued builds off blacklisted Jenkins masters, but it never does. `JenkinsResultsParserUtil.getJenkinsMasters` filters out blacklisted masters when building the cohort master list, so `JenkinsCohort.getBlackListedJenkinsMasters()` always returns an empty list and the blacklist-drain phase of `BuildQueueRebalancer.rebalance()` is dead code. Example run: test-1-42 rebalance-build-queue #56 reported 0 reinvocations and 0 aborts while test-1-41 and test-1-42 were blacklisted with queued items.

## How It Is Being Fixed

`JenkinsResultsParserUtil.getJenkinsMasters` gains an overload with an `includeBlackListedJenkinsMasters` flag that skips only the blacklist filter while keeping the RAM and slaves-per-host filters; the existing overloads delegate with the filter enabled, so every existing caller keeps the current behavior. `JenkinsCohort.getBlackListedJenkinsMasters()` now enumerates the cohort group through the non-filtering overload and keeps the masters where `isBlackListed()` is true, without touching the shared `_jenkinsMastersMap` that other callers expect to hold available masters only. A new `BuildQueueRebalancerTest` drives a synthetic cohort with a blacklisted master holding two queued items and asserts the drain phase produces the expected reinvocation actions.

## PR Check

**pr-check: PASS** — tested on `aacaa3c638bec00cf32b2f2454e66adf7ecde902`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "aacaa3c638bec00cf32b2f2454e66adf7ecde902"} -->
