### PR TITLE
LRCI-7786 Add S3 secret caching to jenkins-results-parser

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -655,6 +655,61 @@ public class CloudBucketUtil {
 		}
 	}
 
+	public static void writeS3Object(String content, String s3ObjectPath)
+		throws IOException {
+
+		s3ObjectPath = _replaceS3ObjectPath(s3ObjectPath);
+
+		String suffix = ".temp";
+
+		File s3TempFile = _createTempFile(suffix);
+
+		File s3TempGzFile = null;
+
+		if (s3ObjectPath.endsWith(".gz")) {
+			s3TempGzFile = _createTempFile(".temp.gz");
+		}
+
+		try {
+			String s3TempFilePath = JenkinsResultsParserUtil.getCanonicalPath(
+				s3TempFile);
+
+			JenkinsResultsParserUtil.write(s3TempFile, content);
+
+			if (s3TempGzFile != null) {
+				JenkinsResultsParserUtil.gzip(s3TempFile, s3TempGzFile);
+
+				s3TempFilePath = JenkinsResultsParserUtil.getCanonicalPath(
+					s3TempGzFile);
+			}
+
+			Process process = JenkinsResultsParserUtil.executeBashCommands(
+				new File("."), true, false, 1000 * 60 * 10,
+				JenkinsResultsParserUtil.combine(
+					"aws s3 cp --quiet \"", s3TempFilePath, "\" \"",
+					s3ObjectPath, "\""));
+
+			if (process.exitValue() != 0) {
+				String errorMessage = JenkinsResultsParserUtil.readInputStream(
+					process.getErrorStream());
+
+				throw new IOException(
+					JenkinsResultsParserUtil.combine(
+						"Unable upload to ", s3ObjectPath, "\n", errorMessage));
+			}
+		}
+		catch (TimeoutException timeoutException) {
+			throw new IOException(timeoutException);
+		}
+		finally {
+			JenkinsResultsParserUtil.delete(s3TempFile);
+
+			if (s3TempGzFile != null) {
+				JenkinsResultsParserUtil.delete(s3TempGzFile);
+			}
+		}
+	}
+
 	private static void _createChecksumFile(
 			String s3DestinationPath, File sourceFile)
 		throws IOException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -383,7 +383,7 @@ public class CloudBucketUtil {
 		}
 
 		try {
-			String listS3Files = listS3Files(s3ObjectPath, true);
+			String listS3Files = _listS3Files(s3ObjectPath, true);
 
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(listS3Files.trim())) {
 				return true;
@@ -438,15 +438,7 @@ public class CloudBucketUtil {
 	public static String listS3Files(String path, boolean file)
 		throws IOException, TimeoutException {
 
-		if (!path.endsWith("/") && !file) {
-			path += "/";
-		}
-
-		Process process = JenkinsResultsParserUtil.executeBashCommands(
-			true, "aws s3 ls " + _escapeParentheses(path));
-
-		return JenkinsResultsParserUtil.readInputStream(
-			process.getInputStream());
+		return _listS3Files(path, file);
 	}
 
 	public static String readS3Object(String s3ObjectPath) throws IOException {
@@ -1026,6 +1018,20 @@ public class CloudBucketUtil {
 			s3ObjectPath);
 
 		return s3ObjectPathMatcher.find();
+	}
+
+	private static String _listS3Files(String path, boolean file)
+		throws IOException, TimeoutException {
+
+		if (!path.endsWith("/") && !file) {
+			path += "/";
+		}
+
+		Process process = JenkinsResultsParserUtil.executeBashCommands(
+			true, false, "aws s3 ls " + _escapeParentheses(path));
+
+		return JenkinsResultsParserUtil.readInputStream(
+			process.getInputStream());
 	}
 
 	private static String _replaceS3ObjectPath(String s3ObjectPath) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1358,11 +1358,10 @@ public class JenkinsResultsParserUtil {
 					new EnvironmentBuildProperties(getLocalURL(url)));
 			}
 
-			String s3BucketName = Environment.get("S3_BUCKET_NAME");
+			String s3BucketName = _getS3BucketName();
 
 			if (!isNullOrEmpty(s3BucketName)) {
-				properties.setProperty(
-					"env.S3_BUCKET_NAME", Environment.get("S3_BUCKET_NAME"));
+				properties.setProperty("env.S3_BUCKET_NAME", s3BucketName);
 			}
 
 			if (!properties.containsKey("user.home")) {
@@ -6292,7 +6291,13 @@ public class JenkinsResultsParserUtil {
 		if (cacheDir.exists() && jenkinsRepositoryDir.exists()) {
 			String cacheDirPath = cacheDir.getPath();
 
-			System.out.println("Using " + cacheDirPath + " for cached files");
+			EnvironmentBuildProperties.Environment environment =
+				EnvironmentBuildProperties.getCurrentEnvironment();
+
+			System.out.println(
+				combine(
+					"Using ", cacheDirPath, " for cached files in ",
+					environment.getExtension()));
 
 			_cacheURL = "file://" + cacheDirPath;
 
@@ -6832,6 +6837,28 @@ public class JenkinsResultsParserUtil {
 		}
 
 		return hostName + ":" + filePath;
+	}
+
+	private static String _getS3BucketName() {
+		String s3BucketName = Environment.get("S3_BUCKET_NAME");
+
+		if (!isNullOrEmpty(s3BucketName)) {
+			return s3BucketName;
+		}
+
+		if (EnvironmentBuildProperties.getCurrentEnvironment() ==
+				EnvironmentBuildProperties.Environment.LOCAL) {
+
+			return null;
+		}
+
+		String jenkinsURL = Environment.get("JENKINS_URL");
+
+		if ((jenkinsURL != null) && jenkinsURL.contains("test-5")) {
+			return "liferayci-file-propagator-staging";
+		}
+
+		return "liferayci-file-propagator";
 	}
 
 	private static void _initializeRedactTokens() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -542,6 +542,15 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static Process executeBashCommands(
+			boolean exitOnFirstFail, boolean printCommands, String... commands)
+		throws IOException, TimeoutException {
+
+		return executeBashCommands(
+			new File("."), exitOnFirstFail, printCommands,
+			_MILLIS_BASH_COMMAND_TIMEOUT_DEFAULT, commands);
+	}
+
+	public static Process executeBashCommands(
 			boolean exitOnFirstFail, File baseDir, long timeout,
 			String... commands)
 		throws IOException, TimeoutException {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -108,37 +108,66 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
+	public static void writeCachedSecrets() {
+		String cachedSecretsURL = _getCachedSecretsURL();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsURL)) {
+			try {
+				writeCachedSecrets(cachedSecretsURL);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+		}
+
+		String s3CachedSecretsPath = _getS3CachedSecretsPath();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(s3CachedSecretsPath)) {
+			try {
+				_writeS3CachedSecrets(s3CachedSecretsPath);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+		}
+	}
+
 	public static void writeCachedSecrets(File cachedSecretsFile)
 		throws IOException {
 
-		String encryptedCachedSecrets = _getEncryptedCachedSecrets();
+		String encryptedConnectSecrets = _getEncryptedConnectSecrets();
 
-		if (encryptedCachedSecrets == null) {
+		if (encryptedConnectSecrets == null) {
 			return;
 		}
 
 		JenkinsResultsParserUtil.write(
-			cachedSecretsFile, encryptedCachedSecrets);
+			cachedSecretsFile, encryptedConnectSecrets);
 
 		System.out.println(
-			"Wrote encrypted 1Password cache to " + cachedSecretsFile);
+			JenkinsResultsParserUtil.combine(
+				"Wrote ", String.valueOf(_connectSecrets.size()),
+				" encrypted 1Password secrets to ",
+				JenkinsResultsParserUtil.getCanonicalPath(cachedSecretsFile)));
 	}
 
 	public static void writeCachedSecrets(String cachedSecretsURL)
 		throws IOException {
 
 		if (cachedSecretsURL.startsWith("s3://")) {
-			String encryptedCachedSecrets = _getEncryptedCachedSecrets();
+			String encryptedConnectSecrets = _getEncryptedConnectSecrets();
 
-			if (encryptedCachedSecrets == null) {
+			if (encryptedConnectSecrets == null) {
 				return;
 			}
 
 			CloudBucketUtil.uploadS3Object(
-				encryptedCachedSecrets, cachedSecretsURL);
+				encryptedConnectSecrets, cachedSecretsURL);
 
 			System.out.println(
-				"Wrote encrypted 1Password cache to " + cachedSecretsURL);
+				JenkinsResultsParserUtil.combine(
+					"Wrote ", String.valueOf(_connectSecrets.size()),
+					" encrypted 1Password secrets to ", cachedSecretsURL));
 
 			return;
 		}
@@ -452,6 +481,19 @@ public abstract class SecretsUtil {
 		return _cachedSecretsURL;
 	}
 
+	private static String _getConnectSecrets() {
+		if (!_isSecretsConfigured()) {
+			System.out.println(
+				"Secrets are not configured, unable to write 1Password cache");
+
+			return null;
+		}
+
+		_loadConnectSecrets();
+
+		return String.valueOf(new JSONObject(_connectSecrets));
+	}
+
 	private static synchronized String _getConnectURL() {
 		if (_connectURL != null) {
 			return _connectURL;
@@ -509,7 +551,57 @@ public abstract class SecretsUtil {
 		return _encryptedCachedSecrets.get(key);
 	}
 
-	private static String _getEncryptedCachedSecrets() throws IOException {
+	private static synchronized String _getEncryptedCachedSecretsContent()
+		throws IOException {
+
+		if (_encryptedCachedSecretsContent != null) {
+			return _encryptedCachedSecretsContent;
+		}
+
+		String cachedSecretsURL = _getCachedSecretsURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsURL)) {
+			_encryptedCachedSecretsContent = "";
+
+			return _encryptedCachedSecretsContent;
+		}
+
+		if (cachedSecretsURL.startsWith("s3://")) {
+			_encryptedCachedSecretsContent = CloudBucketUtil.readS3Object(
+				cachedSecretsURL);
+
+			return _encryptedCachedSecretsContent;
+		}
+
+		if (JenkinsResultsParserUtil.isURL(cachedSecretsURL)) {
+			_encryptedCachedSecretsContent = JenkinsResultsParserUtil.toString(
+				cachedSecretsURL, false);
+
+			return _encryptedCachedSecretsContent;
+		}
+
+		String filePrefix = "file://";
+
+		if (!cachedSecretsURL.startsWith(filePrefix)) {
+			_encryptedCachedSecretsContent = "";
+
+			return _encryptedCachedSecretsContent;
+		}
+
+		File file = new File(cachedSecretsURL.substring(filePrefix.length()));
+
+		if (!file.exists()) {
+			_encryptedCachedSecretsContent = "";
+
+			return _encryptedCachedSecretsContent;
+		}
+
+		_encryptedCachedSecretsContent = JenkinsResultsParserUtil.read(file);
+
+		return _encryptedCachedSecretsContent;
+	}
+
+	private static String _getEncryptedConnectSecrets() throws IOException {
 		if (!_isSecretsConfigured()) {
 			System.out.println(
 				"Secrets are not configured, unable to write 1Password cache");
@@ -527,75 +619,19 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
-		_loadConnectSecrets();
-
-		JSONObject jsonObject = new JSONObject(_connectSecrets);
-
-		String encryptedCachedSecrets = null;
-
 		try {
-			encryptedCachedSecrets = _encrypt(
-				jsonObject.toString(), cachedSecretsPublicKey);
+			String connectSecrets = _getConnectSecrets();
+
+			if (connectSecrets == null) {
+				return null;
+			}
+
+			return _encrypt(connectSecrets, cachedSecretsPublicKey);
 		}
 		catch (GeneralSecurityException generalSecurityException) {
 			throw new IOException(
 				"Unable to encrypt 1Password cache", generalSecurityException);
 		}
-
-		System.out.println(
-			"Encrypted " + jsonObject.length() + " 1Password secrets");
-
-		return encryptedCachedSecrets;
-	}
-
-	private static synchronized String _getEncryptedCachedSecretsContent()
-		throws IOException {
-
-		if (_ecnryptedCachedSecretsContent != null) {
-			return _ecnryptedCachedSecretsContent;
-		}
-
-		String cachedSecretsURL = _getCachedSecretsURL();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsURL)) {
-			_ecnryptedCachedSecretsContent = "";
-
-			return _ecnryptedCachedSecretsContent;
-		}
-
-		if (cachedSecretsURL.startsWith("s3://")) {
-			_ecnryptedCachedSecretsContent = CloudBucketUtil.readS3Object(
-				cachedSecretsURL);
-
-			return _ecnryptedCachedSecretsContent;
-		}
-
-		if (JenkinsResultsParserUtil.isURL(cachedSecretsURL)) {
-			_ecnryptedCachedSecretsContent = JenkinsResultsParserUtil.toString(
-				cachedSecretsURL, false);
-
-			return _ecnryptedCachedSecretsContent;
-		}
-
-		String filePrefix = "file://";
-
-		if (!cachedSecretsURL.startsWith(filePrefix)) {
-			_ecnryptedCachedSecretsContent = "";
-
-			return _ecnryptedCachedSecretsContent;
-		}
-
-		File file = new File(cachedSecretsURL.substring(filePrefix.length()));
-
-		if (!file.exists()) {
-			_ecnryptedCachedSecretsContent = "";
-
-			return _ecnryptedCachedSecretsContent;
-		}
-
-		_ecnryptedCachedSecretsContent = JenkinsResultsParserUtil.read(file);
-
-		return _ecnryptedCachedSecretsContent;
 	}
 
 	private static synchronized HTTPAuthorization _getHTTPAuthorization() {
@@ -878,7 +914,9 @@ public abstract class SecretsUtil {
 		String cachedSecretsS3Path = _getS3CachedSecretsPath();
 
 		try {
-			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsS3Path)) {
+			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsS3Path) ||
+				!CloudBucketUtil.isS3ObjectPathAvailable(cachedSecretsS3Path)) {
+
 				return;
 			}
 
@@ -962,6 +1000,23 @@ public abstract class SecretsUtil {
 		}
 	}
 
+	private static void _writeS3CachedSecrets(String s3CachedSecretsPath)
+		throws IOException {
+
+		String connectSecrets = _getConnectSecrets();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(connectSecrets)) {
+			return;
+		}
+
+		CloudBucketUtil.writeS3Object(connectSecrets, s3CachedSecretsPath);
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Wrote ", String.valueOf(_connectSecrets.size()),
+				" 1Password secrets to ", s3CachedSecretsPath));
+	}
+
 	private static final String _CACHE_CIPHER = "RSA-OAEP+AES-GCM";
 
 	private static String _accessToken;
@@ -976,8 +1031,8 @@ public abstract class SecretsUtil {
 		new ConcurrentHashMap<>();
 	private static boolean _connectSecretsLoaded;
 	private static String _connectURL;
-	private static String _ecnryptedCachedSecretsContent;
 	private static Map<String, String> _encryptedCachedSecrets;
+	private static String _encryptedCachedSecretsContent;
 	private static boolean _encryptedCachedSecretsLoaded;
 	private static BearerHTTPAuthorization _httpAuthorization;
 	private static Map<String, String> _s3CachedSecrets;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -75,10 +75,10 @@ public abstract class SecretsUtil {
 			return secret;
 		}
 
-		String cachedSecret = _getCachedSecret(secretReference);
+		secret = _getEncryptedCachedSecret(secretReference);
 
-		if (cachedSecret != null) {
-			return cachedSecret;
+		if (secret != null) {
+			return secret;
 		}
 
 		_loadConnectSecrets();
@@ -282,68 +282,6 @@ public abstract class SecretsUtil {
 		_accessToken = accessToken;
 
 		return _accessToken;
-	}
-
-	private static synchronized String _getCachedSecret(String key) {
-		if (!_cachedSecretsLoaded) {
-			_loadCachedSecrets();
-		}
-
-		if (_cachedSecrets == null) {
-			return null;
-		}
-
-		return _cachedSecrets.get(key);
-	}
-
-	private static synchronized String _getCachedSecretsContent()
-		throws IOException {
-
-		if (_cachedSecretsContent != null) {
-			return _cachedSecretsContent;
-		}
-
-		String cachedSecretsURL = _getCachedSecretsURL();
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsURL)) {
-			_cachedSecretsContent = "";
-
-			return _cachedSecretsContent;
-		}
-
-		if (cachedSecretsURL.startsWith("s3://")) {
-			_cachedSecretsContent = CloudBucketUtil.readS3Object(
-				cachedSecretsURL);
-
-			return _cachedSecretsContent;
-		}
-
-		if (JenkinsResultsParserUtil.isURL(cachedSecretsURL)) {
-			_cachedSecretsContent = JenkinsResultsParserUtil.toString(
-				cachedSecretsURL, false);
-
-			return _cachedSecretsContent;
-		}
-
-		String filePrefix = "file://";
-
-		if (!cachedSecretsURL.startsWith(filePrefix)) {
-			_cachedSecretsContent = "";
-
-			return _cachedSecretsContent;
-		}
-
-		File file = new File(cachedSecretsURL.substring(filePrefix.length()));
-
-		if (!file.exists()) {
-			_cachedSecretsContent = "";
-
-			return _cachedSecretsContent;
-		}
-
-		_cachedSecretsContent = JenkinsResultsParserUtil.read(file);
-
-		return _cachedSecretsContent;
 	}
 
 	private static synchronized PrivateKey _getCachedSecretsPrivateKey() {
@@ -553,6 +491,18 @@ public abstract class SecretsUtil {
 		return _connectURL;
 	}
 
+	private static synchronized String _getEncryptedCachedSecret(String key) {
+		if (!_encryptedCachedSecretsLoaded) {
+			_loadEncryptedCachedSecrets();
+		}
+
+		if (_encryptedCachedSecrets == null) {
+			return null;
+		}
+
+		return _encryptedCachedSecrets.get(key);
+	}
+
 	private static String _getEncryptedCachedSecrets() throws IOException {
 		if (!_isSecretsConfigured()) {
 			System.out.println(
@@ -590,6 +540,56 @@ public abstract class SecretsUtil {
 			"Encrypted " + jsonObject.length() + " 1Password secrets");
 
 		return encryptedCachedSecrets;
+	}
+
+	private static synchronized String _getEncryptedCachedSecretsContent()
+		throws IOException {
+
+		if (_ecnryptedCachedSecretsContent != null) {
+			return _ecnryptedCachedSecretsContent;
+		}
+
+		String cachedSecretsURL = _getCachedSecretsURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsURL)) {
+			_ecnryptedCachedSecretsContent = "";
+
+			return _ecnryptedCachedSecretsContent;
+		}
+
+		if (cachedSecretsURL.startsWith("s3://")) {
+			_ecnryptedCachedSecretsContent = CloudBucketUtil.readS3Object(
+				cachedSecretsURL);
+
+			return _ecnryptedCachedSecretsContent;
+		}
+
+		if (JenkinsResultsParserUtil.isURL(cachedSecretsURL)) {
+			_ecnryptedCachedSecretsContent = JenkinsResultsParserUtil.toString(
+				cachedSecretsURL, false);
+
+			return _ecnryptedCachedSecretsContent;
+		}
+
+		String filePrefix = "file://";
+
+		if (!cachedSecretsURL.startsWith(filePrefix)) {
+			_ecnryptedCachedSecretsContent = "";
+
+			return _ecnryptedCachedSecretsContent;
+		}
+
+		File file = new File(cachedSecretsURL.substring(filePrefix.length()));
+
+		if (!file.exists()) {
+			_ecnryptedCachedSecretsContent = "";
+
+			return _ecnryptedCachedSecretsContent;
+		}
+
+		_ecnryptedCachedSecretsContent = JenkinsResultsParserUtil.read(file);
+
+		return _ecnryptedCachedSecretsContent;
 	}
 
 	private static synchronized HTTPAuthorization _getHTTPAuthorization() {
@@ -640,57 +640,6 @@ public abstract class SecretsUtil {
 		}
 
 		return true;
-	}
-
-	private static synchronized void _loadCachedSecrets() {
-		_cachedSecretsLoaded = true;
-
-		try {
-			String cachedSecretsContent = _getCachedSecretsContent();
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsContent)) {
-				return;
-			}
-
-			PrivateKey cachedSecretsPrivateKey = _getCachedSecretsPrivateKey();
-
-			if (cachedSecretsPrivateKey == null) {
-				return;
-			}
-
-			cachedSecretsContent = _decrypt(
-				cachedSecretsContent, cachedSecretsPrivateKey);
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsContent)) {
-				return;
-			}
-
-			JSONObject jsonObject = new JSONObject(cachedSecretsContent);
-
-			_cachedSecrets = new HashMap<>();
-
-			for (String key : jsonObject.keySet()) {
-				String value = jsonObject.getString(key);
-
-				if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-					continue;
-				}
-
-				_cachedSecrets.put(key, value);
-
-				JenkinsResultsParserUtil.addRedactToken(value);
-			}
-
-			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"Loaded ", String.valueOf(_cachedSecrets.size()),
-					" cached secrets from ", _getCachedSecretsURL()));
-		}
-		catch (Exception exception) {
-			exception.printStackTrace();
-
-			_cachedSecrets = null;
-		}
 	}
 
 	private static synchronized void _loadConnectSecrets() {
@@ -778,6 +727,67 @@ public abstract class SecretsUtil {
 		}
 	}
 
+	private static synchronized void _loadEncryptedCachedSecrets() {
+		if (_encryptedCachedSecretsLoaded) {
+			return;
+		}
+
+		_encryptedCachedSecretsLoaded = true;
+
+		try {
+			String encryptedCachedSecretsContent =
+				_getEncryptedCachedSecretsContent();
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(
+					encryptedCachedSecretsContent)) {
+
+				return;
+			}
+
+			PrivateKey cachedSecretsPrivateKey = _getCachedSecretsPrivateKey();
+
+			if (cachedSecretsPrivateKey == null) {
+				return;
+			}
+
+			String decryptedCachedSecretsContent = _decrypt(
+				encryptedCachedSecretsContent, cachedSecretsPrivateKey);
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(
+					decryptedCachedSecretsContent)) {
+
+				return;
+			}
+
+			JSONObject jsonObject = new JSONObject(
+				decryptedCachedSecretsContent);
+
+			_encryptedCachedSecrets = new HashMap<>();
+
+			for (String key : jsonObject.keySet()) {
+				String value = jsonObject.getString(key);
+
+				if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+					continue;
+				}
+
+				_encryptedCachedSecrets.put(key, value);
+
+				JenkinsResultsParserUtil.addRedactToken(value);
+			}
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"Loaded ", String.valueOf(_encryptedCachedSecrets.size()),
+					" cached secrets from ", _getCachedSecretsURL()));
+		}
+		catch (Exception exception) {
+			exception.printStackTrace();
+
+			_encryptedCachedSecrets = null;
+		}
+	}
+
 	private static JSONArray _toJSONArray(String path) {
 		if (!_isSecretsConfigured()) {
 			return new JSONArray();
@@ -835,9 +845,6 @@ public abstract class SecretsUtil {
 	private static final String _CACHE_CIPHER = "RSA-OAEP+AES-GCM";
 
 	private static String _accessToken;
-	private static Map<String, String> _cachedSecrets;
-	private static String _cachedSecretsContent;
-	private static boolean _cachedSecretsLoaded;
 	private static PrivateKey _cachedSecretsPrivateKey;
 	private static boolean _cachedSecretsPrivateKeyInitialized;
 	private static String _cachedSecretsPrivateKeyPEM;
@@ -849,6 +856,9 @@ public abstract class SecretsUtil {
 		new ConcurrentHashMap<>();
 	private static boolean _connectSecretsLoaded;
 	private static String _connectURL;
+	private static String _ecnryptedCachedSecretsContent;
+	private static Map<String, String> _encryptedCachedSecrets;
+	private static boolean _encryptedCachedSecretsLoaded;
 	private static BearerHTTPAuthorization _httpAuthorization;
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -657,21 +657,57 @@ public abstract class SecretsUtil {
 			"op://", vaultName, "/", itemTitle, "/", fieldLabel);
 	}
 
-	private static String _getSSMParameterValue(String parameterName)
+	private static synchronized String _getSSMParameterValue(
+			String parameterName)
 		throws IOException, TimeoutException {
 
-		Process process = JenkinsResultsParserUtil.executeBashCommands(
-			new File("."), true, false, 60000,
-			JenkinsResultsParserUtil.combine(
-				"aws ssm get-parameter --name \"", parameterName,
-				"\" --with-decryption | jq -r .Parameter.Value"));
+		Retryable<String> retryable = new Retryable<String>(
+			false, 3, 30, true) {
 
-		String value = JenkinsResultsParserUtil.readInputStream(
-			process.getInputStream());
+			@Override
+			public String execute() {
+				try {
+					Process process =
+						JenkinsResultsParserUtil.executeBashCommands(
+							new File("."), true, false, 60000, _getCommand());
 
-		value = value.replace("Finished executing Bash commands.", "");
+					String value = JenkinsResultsParserUtil.readInputStream(
+						process.getInputStream());
 
-		return value.trim();
+					value = value.replace(
+						"Finished executing Bash commands.", "");
+
+					value = value.trim();
+
+					if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+						throw new RuntimeException(
+							"Unable to get SSM parameter value for " +
+								parameterName);
+					}
+
+					return value;
+				}
+				catch (IOException | TimeoutException exception) {
+					throw new RuntimeException(exception);
+				}
+			}
+
+			private String _getCommand() {
+				return JenkinsResultsParserUtil.combine(
+					"aws ssm get-parameter --name \"", parameterName,
+					"\" --with-decryption | jq -r .Parameter.Value");
+			}
+
+		};
+
+		String value = retryable.executeWithRetries();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+			throw new IOException(
+				"Unable to get SSM parameter value for " + parameterName);
+		}
+
+		return value;
 	}
 
 	private static boolean _isSecretsConfigured() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -75,6 +75,12 @@ public abstract class SecretsUtil {
 			return secret;
 		}
 
+		secret = _getS3CachedSecret(secretReference);
+
+		if (secret != null) {
+			return secret;
+		}
+
 		secret = _getEncryptedCachedSecret(secretReference);
 
 		if (secret != null) {
@@ -608,6 +614,42 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
+	private static synchronized String _getS3CachedSecret(String key) {
+		if (!_s3CachedSecretsLoaded) {
+			_loadS3CachedSecrets();
+		}
+
+		if (_s3CachedSecrets == null) {
+			return null;
+		}
+
+		return _s3CachedSecrets.get(key);
+	}
+
+	private static synchronized String _getS3CachedSecretsPath() {
+		if (_s3CachedSecretsPath != null) {
+			return _s3CachedSecretsPath;
+		}
+
+		String s3CachedSecretsPath;
+
+		try {
+			s3CachedSecretsPath = JenkinsResultsParserUtil.getBuildProperty(
+				"one.password.cached.secrets.s3.path");
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(s3CachedSecretsPath)) {
+				s3CachedSecretsPath = "";
+			}
+		}
+		catch (IOException ioException) {
+			s3CachedSecretsPath = "";
+		}
+
+		_s3CachedSecretsPath = s3CachedSecretsPath;
+
+		return _s3CachedSecretsPath;
+	}
+
 	private static String _getSecretReference(
 		String vaultName, String itemTitle, String fieldLabel) {
 
@@ -788,6 +830,48 @@ public abstract class SecretsUtil {
 		}
 	}
 
+	private static synchronized void _loadS3CachedSecrets() {
+		if (_s3CachedSecretsLoaded) {
+			return;
+		}
+
+		_s3CachedSecretsLoaded = true;
+
+		_s3CachedSecrets = new HashMap<>();
+
+		String cachedSecretsS3Path = _getS3CachedSecretsPath();
+
+		try {
+			if (JenkinsResultsParserUtil.isNullOrEmpty(cachedSecretsS3Path)) {
+				return;
+			}
+
+			JSONObject jsonObject = new JSONObject(
+				CloudBucketUtil.readS3Object(cachedSecretsS3Path));
+
+			for (String key : jsonObject.keySet()) {
+				String value = jsonObject.getString(key);
+
+				if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+					continue;
+				}
+
+				_s3CachedSecrets.put(key, value);
+
+				JenkinsResultsParserUtil.addRedactToken(value);
+			}
+		}
+		catch (Exception exception) {
+			exception.printStackTrace();
+		}
+		finally {
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"Loaded ", String.valueOf(_s3CachedSecrets.size()),
+					" s3 cached secrets from ", cachedSecretsS3Path));
+		}
+	}
+
 	private static JSONArray _toJSONArray(String path) {
 		if (!_isSecretsConfigured()) {
 			return new JSONArray();
@@ -860,6 +944,9 @@ public abstract class SecretsUtil {
 	private static Map<String, String> _encryptedCachedSecrets;
 	private static boolean _encryptedCachedSecretsLoaded;
 	private static BearerHTTPAuthorization _httpAuthorization;
+	private static Map<String, String> _s3CachedSecrets;
+	private static boolean _s3CachedSecretsLoaded;
+	private static String _s3CachedSecretsPath;
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7786

## What Is Being Fixed

The jenkins-results-parser secret cache stored only an encrypted blob fetched over the Connect URL, and the `aws ssm get-parameter` lookup had no retry, so a single transient SSM failure could break secret resolution. There was also no way to cache secrets in S3 or read them back from it.

## How It Is Being Fixed

A new `CloudBucketUtil` wraps `aws s3 cp` to read and write S3 objects, with optional gzip for `.gz` paths and temp-file cleanup. `SecretsUtil` now resolves a secret by first consulting the S3 cache (`_getS3CachedSecret` / `_loadS3CachedSecrets`) and falling back to the existing encrypted cache, which was renamed from "cached" to "encrypted cached" throughout to distinguish the two sources. `writeCachedSecrets` publishes the resolved secrets to S3. The SSM parameter lookup is wrapped in a `Retryable` so transient failures retry rather than fail outright, and the S3 bucket name is resolved through `_getS3BucketName` with environment- and Jenkins-URL-based fallbacks.

The S3-cached secrets are not application-encrypted like the existing cache; they rely on S3's server-side encryption, with access to the S3 cached-secrets folder restricted to the VPS only.

## Why Are There No Tests?

jenkins-results-parser is CI infrastructure not covered by the automated test suite; these changes are exercised by CI runs.

## PR Check

**pr-check: PASS** — tested on `82cb6f593b9aa9dfc8253e2e049db3f180d4cae2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "82cb6f593b9aa9dfc8253e2e049db3f180d4cae2"} -->
