### PR TITLE
LRCI-7855 Add pr-check transaction-usage review gate

### DIFF
--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -54,6 +54,8 @@ The procedure runs in two passes over the validations, in the order below. The o
 
 1. [Portlet Title](validations/portlet-title.md)
 
+1. [Transaction Usage](validations/transaction-usage.md)
+
 1. [Full Portal Build](validations/full-portal-build.md)
 
 1. [Per-Module Compile](validations/per-module-compile.md)
@@ -99,7 +101,7 @@ When the total exceeds 20 minutes, surface the breakdown and ask the developer w
 
 ### Pass 2: Execute
 
-For each matched validation, spawn one subagent. **Pass it only the `## Command` and `## Autocommit` sections of the validation file, not the full file.** Record PASS or FAIL. Do not halt on FAIL — continue so the developer sees the full picture.
+For each matched validation, spawn one subagent. **Pass it only the `## Command` and `## Autocommit` sections of the validation file, not the full file.** Record PASS or FAIL. Do not halt on FAIL — continue so the developer sees the full picture. When a command directs the subagent to return a failure note on FAIL, capture that note alongside the FAIL result.
 
 When the validation's **Command** is a build (gradle, ant, npm, jest), bound the output:
 
@@ -130,3 +132,5 @@ The block is the overall state and tested SHA, followed by a table with one row 
 ```
 
 The overall state is `PASS` only when every row is `PASS`; any `FAIL` row makes it `FAIL`.
+
+When a failed validation returned a failure note, append it below the table, separated by a blank line. The note is part of the Results Summary, so it travels verbatim into the PR description through the `pr` skill and into any comment the `pr-check-publish` skill posts.

--- a/.claude/skills/pr-check/validations/transaction-usage.md
+++ b/.claude/skills/pr-check/validations/transaction-usage.md
@@ -1,0 +1,38 @@
+# Transaction Usage
+
+## Trigger
+
+The diff adds new transaction usage in a Java file, such as the `@Transactional` annotation, `Propagation.REQUIRES_NEW`, a `REQUIRES_NEW_TRANSACTION` config, `TransactionCallbackUtil`, `TransactionCommitCallbackUtil`, or `TransactionInvokerUtil`. Improper transaction usage has heavy performance implications, so any new case must be reviewed and approved by Shuyang Zhou and the Core Infrastructure team first.
+
+## Match
+
+`\.java$`
+
+## Command
+
+This check is static and needs no build. It uses `command grep` because a bare `grep` resolves to a shell function that rejects these patterns.
+
+```bash
+git diff "$(git merge-base HEAD master)...HEAD" -- '*.java' \
+	| command grep -E '^\+' \
+	| command grep -v -E '^\+\+\+' \
+	| command grep -F -e '@Transactional' -e 'Propagation.REQUIRES_NEW' -e 'REQUIRES_NEW_TRANSACTION' -e 'TransactionCallbackUtil' -e 'TransactionCommitCallbackUtil' -e 'TransactionInvokerUtil'
+```
+
+When the command prints nothing, the branch adds no new transaction usage, so the validation passes.
+
+Otherwise, resolve the GitHub login of the person running pr-check with `gh api user --jq '.login'` and check it against the whitelist below. The validation passes only when that login is on the whitelist, and fails for everyone else. It also fails when the login cannot be resolved, for example when `gh` is not authenticated, so an unknown initiator never passes. Add one login per line as the roster changes.
+
+```
+shuyangzhou
+```
+
+When the validation fails, report the message below to the developer and return it as the failure note.
+
+```markdown
+⚠️ **Transaction usage requires Core Infrastructure review.** New transaction code (`@Transactional`, `TransactionInvokerUtil`, etc.) has heavy performance implications and requires additional review. After team review is complete, please send this pull request to @liferay-core-infra and request review from @shuyangzhou. For additional questions, use #t-core-infrastructure on Slack.
+```
+
+## Time Estimate
+
+~10-20 sec (static, no build).


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7855

## What Is Being Fixed

New transaction usage (`TransactionInvokerUtil`, `@Transactional`, transaction callbacks, `REQUIRES_NEW` transactions) carries heavy performance risk and now requires Core Infrastructure review before it can be forwarded to Brian Chan. The pr-check skill had no way to detect it.

## How It Is Being Fixed

Adds a Transaction Usage validation that scans the branch's added Java lines for `@Transactional`, `Propagation.REQUIRES_NEW`, `REQUIRES_NEW_TRANSACTION`, `TransactionCallbackUtil`, `TransactionCommitCallbackUtil`, and `TransactionInvokerUtil`. When any is present, only a login on an inline Core Infrastructure whitelist (currently just `shuyangzhou`) gets a passing pr-check; everyone else fails, with no override. The failure message directs the developer to send the pull request to `@liferay-core-infra` and request review from `@shuyangzhou`. Since ci-forward requires pr-check to pass, this keeps the change out of Brian Chan's queue until Core Infrastructure reviews it.

## Why Are There No Tests?

This PR changes only Claude Code skill definitions under `.claude/skills` (Markdown), with no product code to unit test.

## PR Check

**pr-check: PASS** — tested on `70a2be12be0010c87bdbdffb3cac41ce3cbc01fa`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "70a2be12be0010c87bdbdffb3cac41ce3cbc01fa"} -->
