### PR TITLE
LRCI-7687 Select the generate-reports master via the load balancer

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
@@ -241,10 +241,10 @@ public class GenerateReportsControllerBuildRunner
 
 		StringBuilder sb = new StringBuilder();
 
-		String jenkinsMasterName = buildProperties.getProperty(
-			"report.generate.reports.jenkins.master");
-
-		String jobURL = "http://" + jenkinsMasterName + "/job/generate-reports";
+		String jobURL = JenkinsResultsParserUtil.combine(
+			JenkinsResultsParserUtil.getMostAvailableMasterURL(
+				"http://test-1.liferay.com", null, 1, "generate-reports"),
+			"/job/generate-reports");
 
 		sb.append(jobURL);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7687

## What Is Being Fixed

The generate-reports-controller job selects its downstream master from the fixed build property `report.generate.reports.jenkins.master` and builds the job URL directly, so it never consults the load balancer blacklist. The current AWS value is `test-1-42`, which is in `jenkins.load.balancer.blacklist`, so the controller actively invokes generate-reports on a blacklisted master.

## How It Is Being Fixed

`GenerateReportsControllerBuildRunner._invoke()` now selects the master through `JenkinsResultsParserUtil.getMostAvailableMasterURL` over the test-1 load balancer group, the same path the other controller build runners use, so the blacklist is honored and load is spread. This is safe because the generate-reports job exists on the whole test-1 group and report generation is stateless with respect to the run master: inputs come from the GCS/Testray mirrors, output is rsynced to test-1-0 and archived to GCS. The now-unused `report.generate.reports.jenkins.master` property read is removed.

## Why Are There No Tests?

`getMostAvailableMasterURL` is a live HTTP call to the load balancer, and the controller build runners have no unit coverage or mock pattern; validation happens by invoking generate-reports-controller in CI.

## PR Check

**pr-check: PASS** — tested on `b4c36e9c959e71833bd612c067448a26f7bf6e15`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b4c36e9c959e71833bd612c067448a26f7bf6e15"} -->
