### PR TITLE
LRCI-7938 Convert remaining gsutil calls to gcloud storage

### DIFF
--- a/build-test-gcs-store.xml
+++ b/build-test-gcs-store.xml
@@ -55,8 +55,8 @@
 				<sequential>
 					<echo>Expired Bucket: @{delete.name}</echo>
 
-					<exec executable="gsutil">
-						<arg line="rm -r gs://@{delete.name}" />
+					<exec executable="gcloud">
+						<arg line="storage rm --recursive gs://@{delete.name}" />
 					</exec>
 				</sequential>
 			</for>
@@ -184,8 +184,8 @@
 	</target>
 
 	<target name="delete-gcs-bucket">
-		<exec executable="gsutil">
-			<arg line="rm -r gs://lfr-qa-poshi-test-${gcs.bucket.id}" />
+		<exec executable="gcloud">
+			<arg line="storage rm --recursive gs://lfr-qa-poshi-test-${gcs.bucket.id}" />
 		</exec>
 
 		<delete-gcs-buckets />

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -396,13 +396,6 @@ public class MirrorsGetTask extends Task {
 					"gcloud", "storage", "cp", gsURL, targetFile.toString()
 				});
 
-			if (process.exitValue() == 0) {
-				return;
-			}
-
-			process = _executeCommands(
-				new String[] {"gsutil", "cp", gsURL, targetFile.toString()});
-
 			if (process.exitValue() != 0) {
 				System.out.println(
 					"Unable to download file from " + gsURL + ".");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7938

## What Is Being Fixed

gsutil is in maintenance mode and Google recommends `gcloud storage` as its replacement. Two gsutil invocations remained in liferay-portal: a `gsutil cp` fallback in `MirrorsGetTask` and two `gsutil rm -r` calls in `build-test-gcs-store.xml`.

## How It Is Being Fixed

`MirrorsGetTask._downloadGCPFile` no longer falls back to `gsutil cp` when `gcloud storage cp` fails; the failure is now logged and the partial file deleted directly. In `build-test-gcs-store.xml`, the `delete-gcs-buckets` macrodef and the `delete-gcs-bucket` target now run `gcloud storage rm --recursive`, matching the bucket creation and listing already in the file. Both call sites already authenticate through gcloud, so no credential changes are needed.

## Why Are There No Tests?

CI-only infrastructure change: Ant script conversions and removal of a process-exec fallback; these paths run only in CI and have no unit test harness.

## PR Check

**pr-check: PASS** — tested on `7dc19d4c909707fd24dfeb0df522680997f8001e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "7dc19d4c909707fd24dfeb0df522680997f8001e"} -->
