### PR TITLE
LRCI-7783 Refactor workspace Git repository classes for testability (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -39,7 +39,7 @@ public abstract class BaseWorkspaceGitRepository
 
 	@Override
 	public void fetchGitHubDevBranch() {
-		if (_snapshot) {
+		if (isSnapshot()) {
 			System.out.println(
 				"Using git archive, unable to fetch from GitHub dev");
 		}
@@ -179,7 +179,7 @@ public abstract class BaseWorkspaceGitRepository
 
 	@Override
 	public GitWorkingDirectory getGitWorkingDirectory() {
-		if (_snapshot && !_isDotGitDirArchiveRequired()) {
+		if (!_isDotGitDirArchiveRequired() && isSnapshot()) {
 			throw new RuntimeException(
 				"Using Git archive, unable to get Git working directory");
 		}
@@ -467,7 +467,7 @@ public abstract class BaseWorkspaceGitRepository
 
 	@Override
 	public void synchronizeToGitHubDev() {
-		if (_snapshot) {
+		if (isSnapshot()) {
 			throw new RuntimeException(
 				"Using Git archive, unable to synchronize to GitHub dev");
 		}
@@ -477,7 +477,7 @@ public abstract class BaseWorkspaceGitRepository
 
 	@Override
 	public void tearDown() {
-		if (_snapshot) {
+		if (isSnapshot()) {
 			_deleteGitRepository();
 
 			return;
@@ -781,6 +781,10 @@ public abstract class BaseWorkspaceGitRepository
 		return _setUp;
 	}
 
+	protected boolean isSnapshot() {
+		return _snapshot;
+	}
+
 	protected void prepareGitWorkingDirectory() throws IOException {
 		if (!_isGitArchiveEnabled()) {
 			initializeGitWorkingDirectory();
@@ -790,7 +794,7 @@ public abstract class BaseWorkspaceGitRepository
 
 		promoteGitArchive();
 
-		if (_snapshot) {
+		if (isSnapshot()) {
 			downloadGitArchives();
 
 			return;
@@ -800,7 +804,7 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	protected void promoteGitArchive() throws IOException {
-		if (_snapshot) {
+		if (isSnapshot()) {
 			return;
 		}
 
@@ -842,7 +846,7 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	protected void uploadGitArchives() throws IOException {
-		if (!_isGitArchiveEnabled() || _snapshot ||
+		if (!_isGitArchiveEnabled() || isSnapshot() ||
 			!JenkinsResultsParserUtil.isCloudCINode()) {
 
 			return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -179,7 +179,7 @@ public abstract class BaseWorkspaceGitRepository
 
 	@Override
 	public GitWorkingDirectory getGitWorkingDirectory() {
-		if (!_isDotGitDirArchiveRequired() && isSnapshot()) {
+		if (isSnapshot() && !_isDotGitDirArchiveRequired()) {
 			throw new RuntimeException(
 				"Using Git archive, unable to get Git working directory");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -562,11 +562,50 @@ public abstract class BaseWorkspaceGitRepository
 		validateKeys(_REQUIRED_KEYS);
 	}
 
-	protected void downloadGitArchive() throws IOException {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
-			return;
+	protected void downloadDotGitArchive() throws IOException {
+		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
+			"base.repository.dir");
+
+		File dotGitArchiveFile = new File(
+			baseRepositoryDir, _getDotGitArchiveName());
+
+		CloudBucketUtil.downloadS3File(
+			dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
+
+		File directory = getDirectory();
+
+		JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
+
+		JenkinsResultsParserUtil.delete(dotGitArchiveFile);
+
+		GitUtil.ExecutionResult executionResult = GitUtil.executeBashCommands(
+			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+			GitUtil.MILLIS_TIMEOUT, directory, "git reset");
+
+		if (executionResult.getExitValue() != 0) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to reset Git directory: " + directory,
+					executionResult.getStandardError()));
 		}
 
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		gitWorkingDirectory.checkoutLocalGitBranch(
+			gitWorkingDirectory.createLocalGitBranch(
+				getBranchName(), true, "HEAD"));
+
+		String upstreamBranchName = getUpstreamBranchName();
+
+		if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
+			gitWorkingDirectory.createLocalGitBranch(
+				upstreamBranchName, true, getBaseBranchSHA());
+		}
+
+		gitWorkingDirectory.displayLog();
+	}
+
+	protected void downloadGitArchive() throws IOException {
 		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
 			"base.repository.dir");
 
@@ -584,44 +623,17 @@ public abstract class BaseWorkspaceGitRepository
 		JenkinsResultsParserUtil.unzip(gitArchiveFile, directory);
 
 		JenkinsResultsParserUtil.delete(gitArchiveFile);
+	}
+
+	protected void downloadGitArchives() throws IOException {
+		if (!JenkinsResultsParserUtil.isCloudCINode()) {
+			return;
+		}
+
+		downloadGitArchive();
 
 		if (_isDotGitDirArchiveRequired()) {
-			File dotGitArchiveFile = new File(
-				baseRepositoryDir, _getDotGitArchiveName());
-
-			CloudBucketUtil.downloadS3File(
-				dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
-
-			JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
-
-			JenkinsResultsParserUtil.delete(dotGitArchiveFile);
-
-			GitUtil.ExecutionResult executionResult =
-				GitUtil.executeBashCommands(
-					GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-					GitUtil.MILLIS_TIMEOUT, directory, "git reset");
-
-			if (executionResult.getExitValue() != 0) {
-				throw new RuntimeException(
-					JenkinsResultsParserUtil.combine(
-						"Unable to reset Git directory: " + directory,
-						executionResult.getStandardError()));
-			}
-
-			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-			gitWorkingDirectory.checkoutLocalGitBranch(
-				gitWorkingDirectory.createLocalGitBranch(
-					getBranchName(), true, "HEAD"));
-
-			String upstreamBranchName = getUpstreamBranchName();
-
-			if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
-				gitWorkingDirectory.createLocalGitBranch(
-					upstreamBranchName, true, getBaseBranchSHA());
-			}
-
-			gitWorkingDirectory.displayLog();
+			downloadDotGitArchive();
 		}
 	}
 
@@ -779,7 +791,7 @@ public abstract class BaseWorkspaceGitRepository
 		promoteGitArchive();
 
 		if (_snapshot) {
-			downloadGitArchive();
+			downloadGitArchives();
 
 			return;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -401,7 +401,7 @@ public abstract class BaseWorkspaceGitRepository
 
 			setUpAdditionalCaches();
 
-			uploadGitArchive();
+			uploadGitArchives();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -809,7 +809,27 @@ public abstract class BaseWorkspaceGitRepository
 	protected void setUpAdditionalCaches() throws IOException {
 	}
 
+	protected void uploadDotGitArchive() throws IOException {
+		File dotGitDirArchiveFile = _archiveDotGitDir();
+
+		CloudBucketUtil.uploadS3File(
+			_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
+			dotGitDirArchiveFile);
+
+		JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
+	}
+
 	protected void uploadGitArchive() throws IOException {
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		File archiveFile = gitWorkingDirectory.archive(_getGitArchiveName());
+
+		CloudBucketUtil.uploadS3File(_getGitArchiveS3BucketPath(), archiveFile);
+
+		JenkinsResultsParserUtil.delete(archiveFile);
+	}
+
+	protected void uploadGitArchives() throws IOException {
 		if (!_isGitArchiveEnabled() || _snapshot ||
 			!JenkinsResultsParserUtil.isCloudCINode()) {
 
@@ -819,23 +839,9 @@ public abstract class BaseWorkspaceGitRepository
 		String jobName = _getJobName();
 
 		if (JenkinsResultsParserUtil.isTopLevelJobName(jobName)) {
-			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+			uploadGitArchive();
 
-			File archiveFile = gitWorkingDirectory.archive(
-				_getGitArchiveName());
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(), archiveFile);
-
-			JenkinsResultsParserUtil.delete(archiveFile);
-
-			File dotGitDirArchiveFile = _archiveDotGitDir();
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
-				dotGitDirArchiveFile);
-
-			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
+			uploadDotGitArchive();
 		}
 
 		if (!jobName.contains("root-cause-analysis-tool")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -361,7 +361,7 @@ public abstract class BaseWorkspaceGitRepository
 
 		validateKeys(_REQUIRED_KEYS);
 
-		_updateBuildDatabase();
+		updateBuildDatabase();
 	}
 
 	@Override
@@ -777,6 +777,14 @@ public abstract class BaseWorkspaceGitRepository
 		return workingDirectoryName.contains("ee-6.2.x");
 	}
 
+	protected boolean isGitArchivesAvailable() {
+		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
+			return true;
+		}
+
+		return false;
+	}
+
 	protected boolean isSetUp() {
 		return _setUp;
 	}
@@ -808,13 +816,12 @@ public abstract class BaseWorkspaceGitRepository
 			return;
 		}
 
-		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
-			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
-			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
+		if (isGitArchivesAvailable()) {
+			touchGitArchives();
 
-			_setSnapshot(true);
+			setSnapshot(true);
 
-			_updateBuildDatabase();
+			updateBuildDatabase();
 		}
 	}
 
@@ -822,7 +829,24 @@ public abstract class BaseWorkspaceGitRepository
 		_setUp = setUp;
 	}
 
+	protected void setSnapshot(boolean snapshot) {
+		put("snapshot", snapshot);
+
+		_snapshot = snapshot;
+	}
+
 	protected void setUpAdditionalCaches() throws IOException {
+	}
+
+	protected void touchGitArchives() throws IOException {
+		CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
+		CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
+	}
+
+	protected void updateBuildDatabase() {
+		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase();
+
+		buildDatabase.putWorkspaceGitRepository(getDirectoryName(), this);
 	}
 
 	protected void uploadDotGitArchive() throws IOException {
@@ -861,10 +885,10 @@ public abstract class BaseWorkspaceGitRepository
 		}
 
 		if (!jobName.contains("root-cause-analysis-tool")) {
-			_setSnapshot(true);
+			setSnapshot(true);
 		}
 
-		_updateBuildDatabase();
+		updateBuildDatabase();
 	}
 
 	protected void validateSHAInRemoteGitRef(
@@ -1455,18 +1479,6 @@ public abstract class BaseWorkspaceGitRepository
 
 	private void _setSenderBranchUsername(String username) {
 		put("sender_branch_username", username);
-	}
-
-	private void _setSnapshot(boolean snapshot) {
-		put("snapshot", snapshot);
-
-		_snapshot = snapshot;
-	}
-
-	private void _updateBuildDatabase() {
-		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase();
-
-		buildDatabase.putWorkspaceGitRepository(getDirectoryName(), this);
 	}
 
 	private static final int _MAX_BASE_BRANCH_SHA_LENGTH = 7;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -401,7 +401,7 @@ public abstract class BaseWorkspaceGitRepository
 
 			setUpAdditionalCaches();
 
-			_uploadGitArchive();
+			uploadGitArchive();
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -562,6 +562,69 @@ public abstract class BaseWorkspaceGitRepository
 		validateKeys(_REQUIRED_KEYS);
 	}
 
+	protected void downloadGitArchive() throws IOException {
+		if (!JenkinsResultsParserUtil.isCloudCINode()) {
+			return;
+		}
+
+		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
+			"base.repository.dir");
+
+		File gitArchiveFile = new File(baseRepositoryDir, _getGitArchiveName());
+
+		CloudBucketUtil.downloadS3File(
+			gitArchiveFile, _getGitArchiveS3BucketPath());
+
+		File directory = getDirectory();
+
+		if (directory.exists()) {
+			_deleteGitRepository();
+		}
+
+		JenkinsResultsParserUtil.unzip(gitArchiveFile, directory);
+
+		JenkinsResultsParserUtil.delete(gitArchiveFile);
+
+		if (_isDotGitDirArchiveRequired()) {
+			File dotGitArchiveFile = new File(
+				baseRepositoryDir, _getDotGitArchiveName());
+
+			CloudBucketUtil.downloadS3File(
+				dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
+
+			JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
+
+			JenkinsResultsParserUtil.delete(dotGitArchiveFile);
+
+			GitUtil.ExecutionResult executionResult =
+				GitUtil.executeBashCommands(
+					GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+					GitUtil.MILLIS_TIMEOUT, directory, "git reset");
+
+			if (executionResult.getExitValue() != 0) {
+				throw new RuntimeException(
+					JenkinsResultsParserUtil.combine(
+						"Unable to reset Git directory: " + directory,
+						executionResult.getStandardError()));
+			}
+
+			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+			gitWorkingDirectory.checkoutLocalGitBranch(
+				gitWorkingDirectory.createLocalGitBranch(
+					getBranchName(), true, "HEAD"));
+
+			String upstreamBranchName = getUpstreamBranchName();
+
+			if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
+				gitWorkingDirectory.createLocalGitBranch(
+					upstreamBranchName, true, getBaseBranchSHA());
+			}
+
+			gitWorkingDirectory.displayLog();
+		}
+	}
+
 	protected synchronized LocalGitBranch getLocalGitBranch() {
 		if (_localGitBranch != null) {
 			return _localGitBranch;
@@ -643,6 +706,55 @@ public abstract class BaseWorkspaceGitRepository
 		return _propertyOptions;
 	}
 
+	protected void initializeGitWorkingDirectory() {
+		File dotGitFolder = new File(getDirectory(), ".git");
+
+		if (JenkinsResultsParserUtil.isCloudCINode() &&
+			!dotGitFolder.exists()) {
+
+			_downloadGitRepository();
+
+			_fetchCommitFileSHA();
+		}
+
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		if (_rebase) {
+			gitWorkingDirectory.createLocalGitBranch(
+				getUpstreamBranchName(), true, getBaseBranchSHA());
+		}
+
+		LocalGitBranch localGitBranch = getLocalGitBranch();
+
+		gitWorkingDirectory.checkoutLocalGitBranch(localGitBranch);
+
+		LocalGitBranch baseLocalGitBranch =
+			gitWorkingDirectory.createLocalGitBranch(
+				getUpstreamBranchName(), true, getBaseBranchSHA());
+
+		if (_rebase) {
+			gitWorkingDirectory.rebase(
+				true, baseLocalGitBranch, localGitBranch);
+		}
+
+		gitWorkingDirectory.reset("--hard " + localGitBranch.getSHA());
+
+		if ((_patchSHAs != null) && !_patchSHAs.isEmpty()) {
+			for (String patchSHA : _patchSHAs) {
+				try {
+					gitWorkingDirectory.cherryPick(patchSHA.trim());
+				}
+				catch (Exception exception) {
+					gitWorkingDirectory.reset("--hard");
+				}
+			}
+		}
+
+		gitWorkingDirectory.clean();
+
+		gitWorkingDirectory.displayLog();
+	}
+
 	protected boolean isFullDotGitDirArchiveRequired() {
 		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
@@ -659,7 +771,7 @@ public abstract class BaseWorkspaceGitRepository
 
 	protected void prepareGitWorkingDirectory() throws IOException {
 		if (!_isGitArchiveEnabled()) {
-			_initializeGitWorkingDirectory();
+			initializeGitWorkingDirectory();
 
 			return;
 		}
@@ -667,12 +779,12 @@ public abstract class BaseWorkspaceGitRepository
 		promoteGitArchive();
 
 		if (_snapshot) {
-			_downloadGitArchive();
+			downloadGitArchive();
 
 			return;
 		}
 
-		_initializeGitWorkingDirectory();
+		initializeGitWorkingDirectory();
 	}
 
 	protected void promoteGitArchive() throws IOException {
@@ -695,6 +807,42 @@ public abstract class BaseWorkspaceGitRepository
 	}
 
 	protected void setUpAdditionalCaches() throws IOException {
+	}
+
+	protected void uploadGitArchive() throws IOException {
+		if (!_isGitArchiveEnabled() || _snapshot ||
+			!JenkinsResultsParserUtil.isCloudCINode()) {
+
+			return;
+		}
+
+		String jobName = _getJobName();
+
+		if (JenkinsResultsParserUtil.isTopLevelJobName(jobName)) {
+			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+			File archiveFile = gitWorkingDirectory.archive(
+				_getGitArchiveName());
+
+			CloudBucketUtil.uploadS3File(
+				_getGitArchiveS3BucketPath(), archiveFile);
+
+			JenkinsResultsParserUtil.delete(archiveFile);
+
+			File dotGitDirArchiveFile = _archiveDotGitDir();
+
+			CloudBucketUtil.uploadS3File(
+				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
+				dotGitDirArchiveFile);
+
+			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
+		}
+
+		if (!jobName.contains("root-cause-analysis-tool")) {
+			_setSnapshot(true);
+		}
+
+		_updateBuildDatabase();
 	}
 
 	protected void validateSHAInRemoteGitRef(
@@ -1039,69 +1187,6 @@ public abstract class BaseWorkspaceGitRepository
 		}
 	}
 
-	private void _downloadGitArchive() throws IOException {
-		if (!JenkinsResultsParserUtil.isCloudCINode()) {
-			return;
-		}
-
-		String baseRepositoryDir = JenkinsResultsParserUtil.getBuildProperty(
-			"base.repository.dir");
-
-		File gitArchiveFile = new File(baseRepositoryDir, _getGitArchiveName());
-
-		CloudBucketUtil.downloadS3File(
-			gitArchiveFile, _getGitArchiveS3BucketPath());
-
-		File directory = getDirectory();
-
-		if (directory.exists()) {
-			_deleteGitRepository();
-		}
-
-		JenkinsResultsParserUtil.unzip(gitArchiveFile, directory);
-
-		JenkinsResultsParserUtil.delete(gitArchiveFile);
-
-		if (_isDotGitDirArchiveRequired()) {
-			File dotGitArchiveFile = new File(
-				baseRepositoryDir, _getDotGitArchiveName());
-
-			CloudBucketUtil.downloadS3File(
-				dotGitArchiveFile, _getDotGitArchiveS3BucketPath());
-
-			JenkinsResultsParserUtil.unzip(dotGitArchiveFile, directory);
-
-			JenkinsResultsParserUtil.delete(dotGitArchiveFile);
-
-			GitUtil.ExecutionResult executionResult =
-				GitUtil.executeBashCommands(
-					GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-					GitUtil.MILLIS_TIMEOUT, directory, "git reset");
-
-			if (executionResult.getExitValue() != 0) {
-				throw new RuntimeException(
-					JenkinsResultsParserUtil.combine(
-						"Unable to reset Git directory: " + directory,
-						executionResult.getStandardError()));
-			}
-
-			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-			gitWorkingDirectory.checkoutLocalGitBranch(
-				gitWorkingDirectory.createLocalGitBranch(
-					getBranchName(), true, "HEAD"));
-
-			String upstreamBranchName = getUpstreamBranchName();
-
-			if (!gitWorkingDirectory.localGitBranchExists(upstreamBranchName)) {
-				gitWorkingDirectory.createLocalGitBranch(
-					upstreamBranchName, true, getBaseBranchSHA());
-			}
-
-			gitWorkingDirectory.displayLog();
-		}
-	}
-
 	private void _downloadGitRepository() {
 		try {
 			File baseGitRepositoryDir =
@@ -1251,55 +1336,6 @@ public abstract class BaseWorkspaceGitRepository
 		return _upstreamRemoteGitRef;
 	}
 
-	private void _initializeGitWorkingDirectory() {
-		File dotGitFolder = new File(getDirectory(), ".git");
-
-		if (JenkinsResultsParserUtil.isCloudCINode() &&
-			!dotGitFolder.exists()) {
-
-			_downloadGitRepository();
-
-			_fetchCommitFileSHA();
-		}
-
-		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-		if (_rebase) {
-			gitWorkingDirectory.createLocalGitBranch(
-				getUpstreamBranchName(), true, getBaseBranchSHA());
-		}
-
-		LocalGitBranch localGitBranch = getLocalGitBranch();
-
-		gitWorkingDirectory.checkoutLocalGitBranch(localGitBranch);
-
-		LocalGitBranch baseLocalGitBranch =
-			gitWorkingDirectory.createLocalGitBranch(
-				getUpstreamBranchName(), true, getBaseBranchSHA());
-
-		if (_rebase) {
-			gitWorkingDirectory.rebase(
-				true, baseLocalGitBranch, localGitBranch);
-		}
-
-		gitWorkingDirectory.reset("--hard " + localGitBranch.getSHA());
-
-		if ((_patchSHAs != null) && !_patchSHAs.isEmpty()) {
-			for (String patchSHA : _patchSHAs) {
-				try {
-					gitWorkingDirectory.cherryPick(patchSHA.trim());
-				}
-				catch (Exception exception) {
-					gitWorkingDirectory.reset("--hard");
-				}
-			}
-		}
-
-		gitWorkingDirectory.clean();
-
-		gitWorkingDirectory.displayLog();
-	}
-
 	private boolean _isArchiveAvailable(String s3Path) {
 		if (!JenkinsResultsParserUtil.isCloudCINode()) {
 			return false;
@@ -1409,42 +1445,6 @@ public abstract class BaseWorkspaceGitRepository
 		BuildDatabase buildDatabase = BuildDatabaseUtil.getBuildDatabase();
 
 		buildDatabase.putWorkspaceGitRepository(getDirectoryName(), this);
-	}
-
-	private void _uploadGitArchive() throws IOException {
-		if (!_isGitArchiveEnabled() || _snapshot ||
-			!JenkinsResultsParserUtil.isCloudCINode()) {
-
-			return;
-		}
-
-		String jobName = _getJobName();
-
-		if (JenkinsResultsParserUtil.isTopLevelJobName(jobName)) {
-			GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-			File archiveFile = gitWorkingDirectory.archive(
-				_getGitArchiveName());
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(), archiveFile);
-
-			JenkinsResultsParserUtil.delete(archiveFile);
-
-			File dotGitDirArchiveFile = _archiveDotGitDir();
-
-			CloudBucketUtil.uploadS3File(
-				_getGitArchiveS3BucketPath(dotGitDirArchiveFile.getName()),
-				dotGitDirArchiveFile);
-
-			JenkinsResultsParserUtil.delete(dotGitDirArchiveFile);
-		}
-
-		if (!jobName.contains("root-cause-analysis-tool")) {
-			_setSnapshot(true);
-		}
-
-		_updateBuildDatabase();
 	}
 
 	private static final int _MAX_BASE_BRANCH_SHA_LENGTH = 7;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -664,7 +664,7 @@ public abstract class BaseWorkspaceGitRepository
 			return;
 		}
 
-		_promoteGitArchive();
+		promoteGitArchive();
 
 		if (_snapshot) {
 			_downloadGitArchive();
@@ -673,6 +673,21 @@ public abstract class BaseWorkspaceGitRepository
 		}
 
 		_initializeGitWorkingDirectory();
+	}
+
+	protected void promoteGitArchive() throws IOException {
+		if (_snapshot) {
+			return;
+		}
+
+		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
+			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
+			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
+
+			_setSnapshot(true);
+
+			_updateBuildDatabase();
+		}
 	}
 
 	protected void setSetUp(boolean setUp) {
@@ -1344,21 +1359,6 @@ public abstract class BaseWorkspaceGitRepository
 
 	private boolean _isPullRequest() {
 		return PullRequest.isValidGitHubPullRequestURL(getGitHubURL());
-	}
-
-	private void _promoteGitArchive() throws IOException {
-		if (_snapshot) {
-			return;
-		}
-
-		if (_isGitArchiveAvailable() && _isDotGitArchiveAvailable()) {
-			CloudBucketUtil.touchS3File(_getGitArchiveS3BucketPath());
-			CloudBucketUtil.touchS3File(_getDotGitArchiveS3BucketPath());
-
-			_setSnapshot(true);
-
-			_updateBuildDatabase();
-		}
 	}
 
 	private void _setBaseBranchHeadSHA(String branchSHA) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -643,6 +643,16 @@ public abstract class BaseWorkspaceGitRepository
 		return _propertyOptions;
 	}
 
+	protected boolean isFullDotGitDirArchiveRequired() {
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		File workingDirectory = gitWorkingDirectory.getWorkingDirectory();
+
+		String workingDirectoryName = workingDirectory.getName();
+
+		return workingDirectoryName.contains("ee-6.2.x");
+	}
+
 	protected boolean isSetUp() {
 		return _setUp;
 	}
@@ -672,6 +682,23 @@ public abstract class BaseWorkspaceGitRepository
 	protected void setUpAdditionalCaches() throws IOException {
 	}
 
+	protected void validateSHAInRemoteGitRef(
+		String branchName, RemoteGitRef remoteGitRef, String sha) {
+
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		LocalGitBranch localGitBranch = gitWorkingDirectory.fetch(remoteGitRef);
+
+		if ((localGitBranch == null) ||
+			!gitWorkingDirectory.refContainsSHA(localGitBranch, sha)) {
+
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"SHA ", sha, " was not found in branch \"", branchName,
+					"\" on ", remoteGitRef.getRemoteURL()));
+		}
+	}
+
 	private File _archiveDotGitDir() {
 		List<String> commands = new ArrayList<>();
 
@@ -694,7 +721,7 @@ public abstract class BaseWorkspaceGitRepository
 
 		sb.setLength(0);
 
-		if (_isFullDotGitDirArchiveRequired()) {
+		if (isFullDotGitDirArchiveRequired()) {
 			sb.append("cd ");
 			sb.append(workingDirectory);
 		}
@@ -895,7 +922,7 @@ public abstract class BaseWorkspaceGitRepository
 			gitWorkingDirectory.fetch(_getSenderRemoteGitRef());
 		}
 
-		_validateSHAInRemoteGitRef(
+		validateSHAInRemoteGitRef(
 			getSenderBranchName(), _getSenderRemoteGitRef(), senderBranchSHA);
 
 		gitWorkingDirectory.createLocalGitBranch(
@@ -909,7 +936,7 @@ public abstract class BaseWorkspaceGitRepository
 
 		String upstreamBranchName = getUpstreamBranchName();
 
-		_validateSHAInRemoteGitRef(
+		validateSHAInRemoteGitRef(
 			upstreamBranchName, _getUpstreamRemoteGitRef(), baseBranchSHA);
 
 		gitWorkingDirectory.createLocalGitBranch(
@@ -969,7 +996,7 @@ public abstract class BaseWorkspaceGitRepository
 			}
 		}
 
-		_validateSHAInRemoteGitRef(
+		validateSHAInRemoteGitRef(
 			getSenderBranchName(), _getSenderRemoteGitRef(), senderBranchSHA);
 
 		gitWorkingDirectory.createLocalGitBranch(
@@ -1299,16 +1326,6 @@ public abstract class BaseWorkspaceGitRepository
 		}
 	}
 
-	private boolean _isFullDotGitDirArchiveRequired() {
-		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-		File workingDirectory = gitWorkingDirectory.getWorkingDirectory();
-
-		String workingDirectoryName = workingDirectory.getName();
-
-		return workingDirectoryName.contains("ee-6.2.x");
-	}
-
 	private boolean _isGitArchiveAvailable() {
 		return _isArchiveAvailable(_getGitArchiveS3BucketPath());
 	}
@@ -1428,23 +1445,6 @@ public abstract class BaseWorkspaceGitRepository
 		}
 
 		_updateBuildDatabase();
-	}
-
-	private void _validateSHAInRemoteGitRef(
-		String branchName, RemoteGitRef remoteGitRef, String sha) {
-
-		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
-
-		LocalGitBranch localGitBranch = gitWorkingDirectory.fetch(remoteGitRef);
-
-		if ((localGitBranch == null) ||
-			!gitWorkingDirectory.refContainsSHA(localGitBranch, sha)) {
-
-			throw new RuntimeException(
-				JenkinsResultsParserUtil.combine(
-					"SHA ", sha, " was not found in branch \"", branchName,
-					"\" on ", remoteGitRef.getRemoteURL()));
-		}
 	}
 
 	private static final int _MAX_BASE_BRANCH_SHA_LENGTH = 7;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -4885,6 +4885,18 @@ public class JenkinsResultsParserUtil {
 		_buildPropertiesURLs = urls;
 	}
 
+	public static synchronized void setTopLevelJobNames(
+		Set<String> topLevelJobNames) {
+
+		if (topLevelJobNames == null) {
+			_topLevelJobNames = null;
+
+			return;
+		}
+
+		_topLevelJobNames = new HashSet<>(topLevelJobNames);
+	}
+
 	public static void sleep(long duration) {
 		try {
 			Thread.sleep(duration);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -236,6 +236,19 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		String portalLatestBundleVersion = Environment.get(
 			"PORTAL_LATEST_BUNDLE_VERSION");
 
+		if (JenkinsResultsParserUtil.isNullOrEmpty(portalLatestBundleVersion)) {
+			try {
+				portalLatestBundleVersion =
+					JenkinsResultsParserUtil.getBuildProperty(
+						"portal.latest.bundle.version",
+						getUpstreamBranchName());
+			}
+			catch (IOException ioException) {
+				System.out.println(
+					"WARNING: Unable to get \"portal.latest.bundle.version\"");
+			}
+		}
+
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(
 				portalLatestBundleVersion)) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -246,7 +246,65 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 	@Override
 	protected void setUpAdditionalCaches() throws IOException {
 		if (isBinariesCacheEnabled()) {
-			_setUpBinariesCache();
+			setUpBinariesCache();
+		}
+	}
+
+	protected void setUpBinariesCache() {
+		if (!JenkinsResultsParserUtil.isCloudCINode() || _setUpBinariesCache) {
+			return;
+		}
+
+		String binariesCacheS3Path;
+
+		try {
+			binariesCacheS3Path = JenkinsResultsParserUtil.getBuildProperty(
+				"binaries.cache.s3.path", getUpstreamBranchName());
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"WARNING: Unable to get \"binaries.cache.s3.path\"");
+
+			_setUpBinariesCache = true;
+
+			return;
+		}
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(binariesCacheS3Path)) {
+			return;
+		}
+
+		File binariesCacheTarGzipFile = new File(
+			getDirectory(), "binaries-cache.tar.gz");
+
+		try {
+			CloudBucketUtil.downloadS3File(
+				binariesCacheTarGzipFile, binariesCacheS3Path);
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"WARNING: Unable to download " + binariesCacheS3Path);
+
+			_setUpBinariesCache = true;
+
+			return;
+		}
+
+		try {
+			JenkinsResultsParserUtil.unTarGzip(
+				binariesCacheTarGzipFile, getDirectory());
+
+			System.out.println(
+				"Successfully untared " + binariesCacheS3Path + " to " +
+					getDirectory());
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+		finally {
+			JenkinsResultsParserUtil.delete(binariesCacheTarGzipFile);
+
+			_setUpBinariesCache = true;
 		}
 	}
 
@@ -333,64 +391,6 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			null, portalGitWorkingDirectory, upstreamBranchName, null,
 			portalGitWorkingDirectory.getGitRepositoryName(), "relevant",
 			upstreamBranchName);
-	}
-
-	private void _setUpBinariesCache() {
-		if (!JenkinsResultsParserUtil.isCloudCINode() || _setUpBinariesCache) {
-			return;
-		}
-
-		String binariesCacheS3Path;
-
-		try {
-			binariesCacheS3Path = JenkinsResultsParserUtil.getBuildProperty(
-				"binaries.cache.s3.path", getUpstreamBranchName());
-		}
-		catch (IOException ioException) {
-			System.out.println(
-				"WARNING: Unable to get \"binaries.cache.s3.path\"");
-
-			_setUpBinariesCache = true;
-
-			return;
-		}
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(binariesCacheS3Path)) {
-			return;
-		}
-
-		File binariesCacheTarGzipFile = new File(
-			getDirectory(), "binaries-cache.tar.gz");
-
-		try {
-			CloudBucketUtil.downloadS3File(
-				binariesCacheTarGzipFile, binariesCacheS3Path);
-		}
-		catch (IOException ioException) {
-			System.out.println(
-				"WARNING: Unable to download " + binariesCacheS3Path);
-
-			_setUpBinariesCache = true;
-
-			return;
-		}
-
-		try {
-			JenkinsResultsParserUtil.unTarGzip(
-				binariesCacheTarGzipFile, getDirectory());
-
-			System.out.println(
-				"Successfully untared " + binariesCacheS3Path + " to " +
-					getDirectory());
-		}
-		catch (Exception exception) {
-			throw new RuntimeException(exception);
-		}
-		finally {
-			JenkinsResultsParserUtil.delete(binariesCacheTarGzipFile);
-
-			_setUpBinariesCache = true;
-		}
 	}
 
 	private void _writeAppServerPropertiesFile() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -181,7 +181,7 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		Map<String, String> parameters = new HashMap<>();
 
 		String tckHome = JenkinsResultsParserUtil.getProperty(
-			_getPortalTestProperties(), "tck.home");
+			getPortalTestProperties(), "tck.home");
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(tckHome)) {
 			parameters.put("tck.home", tckHome);
@@ -220,6 +220,52 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		RemoteGitRef remoteGitRef, String upstreamBranchName) {
 
 		super(remoteGitRef, upstreamBranchName);
+	}
+
+	protected Properties getPortalTestProperties() {
+		Properties testProperties = getProperties("portal.test.properties");
+
+		String companyDefaultLocale = Environment.get(
+			"TEST_COMPANY_DEFAULT_LOCALE");
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(companyDefaultLocale)) {
+			testProperties.setProperty(
+				"test.company.default.locale", companyDefaultLocale);
+		}
+
+		String portalLatestBundleVersion = Environment.get(
+			"PORTAL_LATEST_BUNDLE_VERSION");
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(
+				portalLatestBundleVersion)) {
+
+			testProperties.put(
+				"test.released.release.bundle.version",
+				portalLatestBundleVersion);
+
+			Properties buildProperties = null;
+
+			try {
+				buildProperties = JenkinsResultsParserUtil.getBuildProperties();
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+
+			String portalBundleTomcatURL = JenkinsResultsParserUtil.getProperty(
+				buildProperties, "portal.bundle.tomcat",
+				portalLatestBundleVersion);
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(
+					portalBundleTomcatURL)) {
+
+				testProperties.put(
+					"test.released.test.portal.bundle.zip.url",
+					portalBundleTomcatURL);
+			}
+		}
+
+		return testProperties;
 	}
 
 	@Override
@@ -330,52 +376,6 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		}
 	}
 
-	private Properties _getPortalTestProperties() {
-		Properties testProperties = getProperties("portal.test.properties");
-
-		String companyDefaultLocale = Environment.get(
-			"TEST_COMPANY_DEFAULT_LOCALE");
-
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(companyDefaultLocale)) {
-			testProperties.setProperty(
-				"test.company.default.locale", companyDefaultLocale);
-		}
-
-		String portalLatestBundleVersion = Environment.get(
-			"PORTAL_LATEST_BUNDLE_VERSION");
-
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(
-				portalLatestBundleVersion)) {
-
-			testProperties.put(
-				"test.released.release.bundle.version",
-				portalLatestBundleVersion);
-
-			Properties buildProperties = null;
-
-			try {
-				buildProperties = JenkinsResultsParserUtil.getBuildProperties();
-			}
-			catch (IOException ioException) {
-				throw new RuntimeException(ioException);
-			}
-
-			String portalBundleTomcatURL = JenkinsResultsParserUtil.getProperty(
-				buildProperties, "portal.bundle.tomcat",
-				portalLatestBundleVersion);
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(
-					portalBundleTomcatURL)) {
-
-				testProperties.put(
-					"test.released.test.portal.bundle.zip.url",
-					portalBundleTomcatURL);
-			}
-		}
-
-		return testProperties;
-	}
-
 	private PortalAcceptancePullRequestJob
 		_getRelevantPortalAcceptancePullRequestJob() {
 
@@ -435,7 +435,7 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 				getDirectory(),
 				JenkinsResultsParserUtil.combine(
 					"test.", Environment.get("HOSTNAME"), ".properties")),
-			_getPortalTestProperties(), true);
+			getPortalTestProperties(), true);
 	}
 
 	private Properties _appServerProperties;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepositoryTest.java
@@ -122,6 +122,11 @@ public class PortalWorkspaceGitRepositoryTest
 			portalWorkspaceGitRepository
 		).setUpAdditionalCaches();
 
+		Mockito.doCallRealMethod(
+		).when(
+			portalWorkspaceGitRepository
+		).setUpBinariesCache();
+
 		portalWorkspaceGitRepository.setUp();
 
 		Mockito.verify(


### PR DESCRIPTION
[LRCI-7783](https://liferay.atlassian.net/browse/LRCI-7783)

Revises [#4459](https://github.com/pyoo47/liferay-portal/pull/4459) (opened by @michaelhashimoto) with the following follow-up commits:

- [e85c5a61a1e0](https://github.com/pyoo47/liferay-portal/commit/e85c5a61a1e0ea8316c2431afaf1a957751a09ca) LRCI-7783 Make PortalWorkspaceGitRepository#setUpBinariesCache into a protected method
- [a3579c161a4a](https://github.com/pyoo47/liferay-portal/commit/a3579c161a4a8236e45ea29d7a84be9ad690768c) LRCI-7783 Make PortalWorkspaceGitRepository#getPortalTestProperties into a protected method
- [746b1c2d4584](https://github.com/pyoo47/liferay-portal/commit/746b1c2d45844b79257de143352072983277e540) LRCI-7783 Fall back to the portal.latest.bundle.version build property when the PORTAL_LATEST_BUNDLE_VERSION environment variable is unset
- [c55cb4e2d301](https://github.com/pyoo47/liferay-portal/commit/c55cb4e2d3013a93120b0b6846fc71d9d26e0720) LRCI-7783 Check isSnapshot() before _isDotGitDirArchiveRequired() in getGitWorkingDirectory to keep the short-circuit

The bundle-version fallback that was bundled into the `setUpBinariesCache` commit is now its own commit and logs a `WARNING` when the build-property lookup fails; the `getGitWorkingDirectory` guard is reordered so the cheap `isSnapshot()` check short-circuits before the network-backed `_isDotGitDirArchiveRequired()`.
