### PR TITLE
LRCI-7945 Avoid excluded globs for RCA Tool

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/JUnitBatchTestClassGroup.java
@@ -71,6 +71,10 @@ public class JUnitBatchTestClassGroup extends BatchTestClassGroup {
 	}
 
 	public List<JobProperty> getExcludesJobProperties() {
+		if (isRootCauseAnalysis()) {
+			return new ArrayList<>();
+		}
+
 		if (_jUnitTestBatch != null) {
 			List<JobProperty> testBatchJobProperties =
 				getTestSelectorExcludesJobProperties();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7945

## What Is Being Fixed

When the RCA (root cause analysis) Tool reruns a JUnit batch, `JUnitBatchTestClassGroup` still applied the test selector exclude globs configured for the normal CI batch. Those excludes filter out test classes the RCA run specifically needs to execute, so the tool could not reproduce the failure it was asked to analyze.

## How It Is Being Fixed

`getExcludesJobProperties` now short circuits with an empty list when the batch is running in root cause analysis mode, so no exclude globs are contributed and the RCA run considers the full set of candidate test classes. The normal, non-RCA path is untouched and keeps resolving its test selector excludes as before.

## Why Are There No Tests?

The change is to Jenkins results parser build tooling. There is no unit-test counterpart for `JUnitBatchTestClassGroup`, and the RCA batch selection path is exercised by actual CI test batch runs rather than by a local unit test.

## PR Check

**pr-check: PASS** — tested on `28cb5b65c0318bccc447db0eb0f71f64b7996387`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "28cb5b65c0318bccc447db0eb0f71f64b7996387"} -->
