### PR TITLE
LRCI-7915 Drain blacklisted masters during rebalance (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
@@ -114,7 +114,7 @@ public class BuildQueueRebalancer {
 
 	private void _generateBlacklistRebalanceActions() {
 		for (JenkinsMaster jenkinsMaster :
-				_jenkinsCohort.getBlackListedJenkinsMasters()) {
+				_jenkinsCohort.getBlacklistedJenkinsMasters()) {
 
 			try {
 				for (JenkinsMaster.QueueItem queueItem :

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
@@ -45,7 +45,7 @@ public class BuildQueueRebalancer {
 	}
 
 	public void rebalance() {
-		_generateBlackListRebalanceActions();
+		_generateBlacklistRebalanceActions();
 
 		_generateAvailableRebalanceActions();
 
@@ -112,7 +112,7 @@ public class BuildQueueRebalancer {
 		}
 	}
 
-	private void _generateBlackListRebalanceActions() {
+	private void _generateBlacklistRebalanceActions() {
 		for (JenkinsMaster jenkinsMaster :
 				_jenkinsCohort.getBlackListedJenkinsMasters()) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
@@ -116,10 +116,17 @@ public class BuildQueueRebalancer {
 		for (JenkinsMaster jenkinsMaster :
 				_jenkinsCohort.getBlackListedJenkinsMasters()) {
 
-			for (JenkinsMaster.QueueItem queueItem :
-					jenkinsMaster.getQueueItems()) {
+			try {
+				for (JenkinsMaster.QueueItem queueItem :
+						jenkinsMaster.getQueueItems()) {
 
-				_rebalanceActions.add(new RebalanceAction(queueItem));
+					_rebalanceActions.add(new RebalanceAction(queueItem));
+				}
+			}
+			catch (Exception exception) {
+				System.out.println(
+					"Unable to drain queue items from " +
+						jenkinsMaster.getName() + ": " + exception);
 			}
 		}
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -60,7 +60,7 @@ public class JenkinsCohort {
 	}
 
 	public List<JenkinsMaster> getBlackListedJenkinsMasters() {
-		List<JenkinsMaster> blackListedJenkinsMasters = new ArrayList<>();
+		List<JenkinsMaster> blacklistedJenkinsMasters = new ArrayList<>();
 
 		try {
 			List<JenkinsMaster> jenkinsMasters =
@@ -71,7 +71,7 @@ public class JenkinsCohort {
 
 			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
 				if (jenkinsMaster.isBlackListed()) {
-					blackListedJenkinsMasters.add(jenkinsMaster);
+					blacklistedJenkinsMasters.add(jenkinsMaster);
 				}
 			}
 		}
@@ -79,7 +79,7 @@ public class JenkinsCohort {
 			throw new RuntimeException(ioException);
 		}
 
-		return blackListedJenkinsMasters;
+		return blacklistedJenkinsMasters;
 	}
 
 	public int getIdleJenkinsSlaveCount() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -62,10 +62,22 @@ public class JenkinsCohort {
 	public List<JenkinsMaster> getBlackListedJenkinsMasters() {
 		List<JenkinsMaster> blackListedJenkinsMasters = new ArrayList<>();
 
-		for (JenkinsMaster jenkinsMaster : getJenkinsMasters()) {
-			if (jenkinsMaster.isBlackListed()) {
-				blackListedJenkinsMasters.add(jenkinsMaster);
+		try {
+			List<JenkinsMaster> jenkinsMasters =
+				JenkinsResultsParserUtil.getJenkinsMasters(
+					JenkinsResultsParserUtil.getBuildProperties(),
+					JenkinsMaster.getSlaveRAMMinimumDefault(),
+					JenkinsMaster.getSlavesPerHostDefault(), getName(), null,
+					true);
+
+			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
+				if (jenkinsMaster.isBlackListed()) {
+					blackListedJenkinsMasters.add(jenkinsMaster);
+				}
 			}
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
 		}
 
 		return blackListedJenkinsMasters;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -51,7 +51,7 @@ public class JenkinsCohort {
 		List<JenkinsMaster> availableJenkinsMasters = new ArrayList<>();
 
 		for (JenkinsMaster jenkinsMaster : getJenkinsMasters()) {
-			if (!jenkinsMaster.isBlackListed() && jenkinsMaster.isAvailable()) {
+			if (!jenkinsMaster.isBlacklisted() && jenkinsMaster.isAvailable()) {
 				availableJenkinsMasters.add(jenkinsMaster);
 			}
 		}
@@ -59,7 +59,7 @@ public class JenkinsCohort {
 		return availableJenkinsMasters;
 	}
 
-	public List<JenkinsMaster> getBlackListedJenkinsMasters() {
+	public List<JenkinsMaster> getBlacklistedJenkinsMasters() {
 		List<JenkinsMaster> blacklistedJenkinsMasters = new ArrayList<>();
 
 		try {
@@ -70,7 +70,7 @@ public class JenkinsCohort {
 					JenkinsMaster.getSlaveRAMMinimumDefault(), null);
 
 			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
-				if (jenkinsMaster.isBlackListed()) {
+				if (jenkinsMaster.isBlacklisted()) {
 					blacklistedJenkinsMasters.add(jenkinsMaster);
 				}
 			}
@@ -249,7 +249,7 @@ public class JenkinsCohort {
 		}
 
 		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
-			if (jenkinsMaster.isBlackListed() || !jenkinsMaster.isAvailable()) {
+			if (jenkinsMaster.isBlacklisted() || !jenkinsMaster.isAvailable()) {
 				continue;
 			}
 
@@ -267,7 +267,7 @@ public class JenkinsCohort {
 		}
 
 		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
-			if (jenkinsMaster.isBlackListed() || !jenkinsMaster.isAvailable()) {
+			if (jenkinsMaster.isBlacklisted() || !jenkinsMaster.isAvailable()) {
 				continue;
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -65,10 +65,9 @@ public class JenkinsCohort {
 		try {
 			List<JenkinsMaster> jenkinsMasters =
 				JenkinsResultsParserUtil.getJenkinsMasters(
-					JenkinsResultsParserUtil.getBuildProperties(),
-					JenkinsMaster.getSlaveRAMMinimumDefault(),
-					JenkinsMaster.getSlavesPerHostDefault(), getName(), null,
-					true);
+					JenkinsResultsParserUtil.getBuildProperties(), getName(),
+					true, JenkinsMaster.getSlavesPerHostDefault(),
+					JenkinsMaster.getSlaveRAMMinimumDefault(), null);
 
 			for (JenkinsMaster jenkinsMaster : jenkinsMasters) {
 				if (jenkinsMaster.isBlackListed()) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -735,7 +735,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				_AVAILABLE_TIMEOUT)) {
 
 			try {
-				if (!isBlackListed()) {
+				if (!isBlacklisted()) {
 					JenkinsResultsParserUtil.toJSONObject(
 						getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
 
@@ -755,7 +755,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _available;
 	}
 
-	public boolean isBlackListed() {
+	public boolean isBlacklisted() {
 		if (_jenkinsMastersBlacklist.contains(getName())) {
 			_blacklisted = true;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2469,6 +2469,16 @@ public class JenkinsResultsParserUtil {
 		Properties buildProperties, int minimumRAM, int maximumSlavesPerHost,
 		String cohortName, String networkName) {
 
+		return getJenkinsMasters(
+			buildProperties, minimumRAM, maximumSlavesPerHost, cohortName,
+			networkName, false);
+	}
+
+	public static List<JenkinsMaster> getJenkinsMasters(
+		Properties buildProperties, int minimumRAM, int maximumSlavesPerHost,
+		String cohortName, String networkName,
+		boolean includeBlackListedJenkinsMasters) {
+
 		List<JenkinsMaster> jenkinsMasters = new ArrayList<>();
 
 		Pattern pattern = Pattern.compile(
@@ -2485,7 +2495,8 @@ public class JenkinsResultsParserUtil {
 			JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
 				matcher.group("jenkinsMasterName"));
 
-			if (jenkinsMaster.isBlackListed() ||
+			if ((!includeBlackListedJenkinsMasters &&
+				 jenkinsMaster.isBlackListed()) ||
 				(jenkinsMaster.getSlaveRAM() < minimumRAM) ||
 				(jenkinsMaster.getSlavesPerHost() > maximumSlavesPerHost)) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2470,14 +2470,14 @@ public class JenkinsResultsParserUtil {
 		String cohortName, String networkName) {
 
 		return getJenkinsMasters(
-			buildProperties, minimumRAM, maximumSlavesPerHost, cohortName,
-			networkName, false);
+			buildProperties, cohortName, false, maximumSlavesPerHost,
+			minimumRAM, networkName);
 	}
 
 	public static List<JenkinsMaster> getJenkinsMasters(
-		Properties buildProperties, int minimumRAM, int maximumSlavesPerHost,
-		String cohortName, String networkName,
-		boolean includeBlackListedJenkinsMasters) {
+		Properties buildProperties, String cohortName,
+		boolean includeBlackListedJenkinsMasters, int maximumSlavesPerHost,
+		int minimumRAM, String networkName) {
 
 		List<JenkinsMaster> jenkinsMasters = new ArrayList<>();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2496,7 +2496,7 @@ public class JenkinsResultsParserUtil {
 				matcher.group("jenkinsMasterName"));
 
 			if ((!includeBlacklistedJenkinsMasters &&
-				 jenkinsMaster.isBlackListed()) ||
+				 jenkinsMaster.isBlacklisted()) ||
 				(jenkinsMaster.getSlaveRAM() < minimumRAM) ||
 				(jenkinsMaster.getSlavesPerHost() > maximumSlavesPerHost)) {
 
@@ -2665,7 +2665,7 @@ public class JenkinsResultsParserUtil {
 	public static int getJobTimeoutMinutes(
 		JenkinsMaster jenkinsMaster, String jobName) {
 
-		if (jenkinsMaster.isBlackListed()) {
+		if (jenkinsMaster.isBlacklisted()) {
 			jenkinsMaster = JenkinsMaster.getInstance(
 				Environment.get("MASTER_HOSTNAME"));
 		}
@@ -4354,7 +4354,7 @@ public class JenkinsResultsParserUtil {
 				jenkinsCohort.getJenkinsMasters()) {
 
 			if (!availableJenkinsMaster.isAvailable() ||
-				availableJenkinsMaster.isBlackListed()) {
+				availableJenkinsMaster.isBlacklisted()) {
 
 				continue;
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2476,7 +2476,7 @@ public class JenkinsResultsParserUtil {
 
 	public static List<JenkinsMaster> getJenkinsMasters(
 		Properties buildProperties, String cohortName,
-		boolean includeBlackListedJenkinsMasters, int maximumSlavesPerHost,
+		boolean includeBlacklistedJenkinsMasters, int maximumSlavesPerHost,
 		int minimumRAM, String networkName) {
 
 		List<JenkinsMaster> jenkinsMasters = new ArrayList<>();
@@ -2495,7 +2495,7 @@ public class JenkinsResultsParserUtil {
 			JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
 				matcher.group("jenkinsMasterName"));
 
-			if ((!includeBlackListedJenkinsMasters &&
+			if ((!includeBlacklistedJenkinsMasters &&
 				 jenkinsMaster.isBlackListed()) ||
 				(jenkinsMaster.getSlaveRAM() < minimumRAM) ||
 				(jenkinsMaster.getSlavesPerHost() > maximumSlavesPerHost)) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.IOException;
+
 import java.lang.reflect.Field;
 
 import java.util.ArrayList;
@@ -15,6 +17,8 @@ import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Test;
+
+import org.mockito.Mockito;
 
 /**
  * @author Calum Ragan
@@ -128,6 +132,67 @@ public class BuildQueueRebalancerTest
 			true,
 			summary.startsWith(
 				"Build queue rebalanced by 2 reinvocations and 0 aborts"));
+	}
+
+	@Test
+	public void testRebalanceUnreachableBlackListedJenkinsMaster()
+		throws Exception {
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("jenkins.load.balancer.blacklist", "");
+
+		_setJenkinsMasterBuildProperties(
+			buildProperties, _AVAILABLE_JENKINS_MASTER_NAME);
+		_setJenkinsMasterBuildProperties(
+			buildProperties, _BLACK_LISTED_JENKINS_MASTER_NAME);
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		UrlReader urlReader = mockUrlReader();
+
+		Mockito.doThrow(
+			new IOException("Connection refused")
+		).when(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.argThat(
+				readURL ->
+					(readURL != null) &&
+					readURL.contains(
+						_BLACK_LISTED_JENKINS_MASTER_NAME +
+							".liferay.com/queue/api/json"))
+		);
+
+		setUrlReaderOutput(
+			"{\"mode\":\"NORMAL\"}",
+			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/api/json?tree=mode",
+			urlReader);
+		setUrlReaderOutput(
+			"{\"items\":[]}",
+			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			urlReader);
+
+		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
+		_setJenkinsMasterAWSFleetClouds(_BLACK_LISTED_JENKINS_MASTER_NAME);
+
+		_setFieldValue(
+			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
+			"_blacklisted", true);
+
+		BuildQueueRebalancer buildQueueRebalancer = new BuildQueueRebalancer(
+			JenkinsCohort.getInstance(_JENKINS_COHORT_NAME));
+
+		buildQueueRebalancer.rebalance();
+
+		String summary = buildQueueRebalancer.getSummary();
+
+		testEquals(
+			true,
+			summary.startsWith(
+				"Build queue rebalanced by 0 reinvocations and 0 aborts"));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -53,27 +53,10 @@ public class BuildQueueRebalancerTest
 
 		buildProperties.setProperty("jenkins.load.balancer.blacklist", "");
 
-		for (String jenkinsMasterName :
-				new String[] {
-					_AVAILABLE_JENKINS_MASTER_NAME,
-					_BLACK_LISTED_JENKINS_MASTER_NAME
-				}) {
-
-			buildProperties.setProperty(
-				JenkinsResultsParserUtil.combine(
-					"jenkins.local.url[", jenkinsMasterName, "]"),
-				JenkinsResultsParserUtil.combine(
-					"http://", jenkinsMasterName, ".liferay.com"));
-			buildProperties.setProperty(
-				JenkinsResultsParserUtil.combine(
-					"jenkins.remote.url[", jenkinsMasterName, "]"),
-				JenkinsResultsParserUtil.combine(
-					"https://", jenkinsMasterName, ".liferay.com"));
-			buildProperties.setProperty(
-				JenkinsResultsParserUtil.combine(
-					"master.property(", jenkinsMasterName, "/executors.size)"),
-				"2");
-		}
+		_setJenkinsMasterBuildProperties(
+			buildProperties, _AVAILABLE_JENKINS_MASTER_NAME);
+		_setJenkinsMasterBuildProperties(
+			buildProperties, _BLACK_LISTED_JENKINS_MASTER_NAME);
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
@@ -102,20 +85,8 @@ public class BuildQueueRebalancerTest
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
 			urlReader);
 
-		for (String jenkinsMasterName :
-				new String[] {
-					_AVAILABLE_JENKINS_MASTER_NAME,
-					_BLACK_LISTED_JENKINS_MASTER_NAME
-				}) {
-
-			JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
-				jenkinsMasterName);
-
-			_setFieldValue(
-				jenkinsMaster, "_awsFleetCloudLastUpdateTimestamp",
-				Long.MAX_VALUE);
-			_setFieldValue(jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
-		}
+		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
+		_setJenkinsMasterAWSFleetClouds(_BLACK_LISTED_JENKINS_MASTER_NAME);
 
 		_setFieldValue(
 			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
@@ -180,6 +151,36 @@ public class BuildQueueRebalancerTest
 		field.setAccessible(true);
 
 		field.set(object, value);
+	}
+
+	private void _setJenkinsMasterAWSFleetClouds(String jenkinsMasterName)
+		throws Exception {
+
+		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
+			jenkinsMasterName);
+
+		_setFieldValue(
+			jenkinsMaster, "_awsFleetCloudLastUpdateTimestamp", Long.MAX_VALUE);
+		_setFieldValue(jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
+	}
+
+	private void _setJenkinsMasterBuildProperties(
+		Properties buildProperties, String jenkinsMasterName) {
+
+		buildProperties.setProperty(
+			JenkinsResultsParserUtil.combine(
+				"jenkins.local.url[", jenkinsMasterName, "]"),
+			JenkinsResultsParserUtil.combine(
+				"http://", jenkinsMasterName, ".liferay.com"));
+		buildProperties.setProperty(
+			JenkinsResultsParserUtil.combine(
+				"jenkins.remote.url[", jenkinsMasterName, "]"),
+			JenkinsResultsParserUtil.combine(
+				"https://", jenkinsMasterName, ".liferay.com"));
+		buildProperties.setProperty(
+			JenkinsResultsParserUtil.combine(
+				"master.property(", jenkinsMasterName, "/executors.size)"),
+			"2");
 	}
 
 	private static final String _AVAILABLE_JENKINS_MASTER_NAME = "test-9-2";

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -7,8 +7,6 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.IOException;
 
-import java.lang.reflect.Field;
-
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -29,21 +27,18 @@ public class BuildQueueRebalancerTest
 	@After
 	@Override
 	public void tearDown() {
-		try {
-			Map<String, JenkinsMaster> jenkinsMasters = _getStaticFieldValue(
+		Map<String, JenkinsMaster> jenkinsMasters =
+			ReflectionTestUtil.getFieldValue(
 				JenkinsMaster.class, "_jenkinsMasters");
 
-			jenkinsMasters.remove(_AVAILABLE_JENKINS_MASTER_NAME);
-			jenkinsMasters.remove(_BLACK_LISTED_JENKINS_MASTER_NAME);
+		jenkinsMasters.remove(_AVAILABLE_JENKINS_MASTER_NAME);
+		jenkinsMasters.remove(_BLACK_LISTED_JENKINS_MASTER_NAME);
 
-			Map<String, JenkinsCohort> jenkinsCohorts = _getStaticFieldValue(
+		Map<String, JenkinsCohort> jenkinsCohorts =
+			ReflectionTestUtil.getFieldValue(
 				JenkinsCohort.class, "_jenkinsCohorts");
 
-			jenkinsCohorts.remove(_JENKINS_COHORT_NAME);
-		}
-		catch (ReflectiveOperationException reflectiveOperationException) {
-			throw new RuntimeException(reflectiveOperationException);
-		}
+		jenkinsCohorts.remove(_JENKINS_COHORT_NAME);
 
 		JenkinsResultsParserUtil.setBuildProperties(
 			(Hashtable<Object, Object>)null);
@@ -92,7 +87,7 @@ public class BuildQueueRebalancerTest
 		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
 		_setJenkinsMasterAWSFleetClouds(_BLACK_LISTED_JENKINS_MASTER_NAME);
 
-		_setFieldValue(
+		ReflectionTestUtil.setFieldValue(
 			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
 			"_blacklisted", true);
 
@@ -178,7 +173,7 @@ public class BuildQueueRebalancerTest
 		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
 		_setJenkinsMasterAWSFleetClouds(_BLACK_LISTED_JENKINS_MASTER_NAME);
 
-		_setFieldValue(
+		ReflectionTestUtil.setFieldValue(
 			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
 			"_blacklisted", true);
 
@@ -195,38 +190,14 @@ public class BuildQueueRebalancerTest
 				"Build queue rebalanced by 0 reinvocations and 0 aborts"));
 	}
 
-	@SuppressWarnings("unchecked")
-	private <T> T _getStaticFieldValue(Class<?> clazz, String fieldName)
-		throws ReflectiveOperationException {
-
-		Field field = clazz.getDeclaredField(fieldName);
-
-		field.setAccessible(true);
-
-		return (T)field.get(null);
-	}
-
-	private void _setFieldValue(Object object, String fieldName, Object value)
-		throws Exception {
-
-		Class<?> clazz = object.getClass();
-
-		Field field = clazz.getDeclaredField(fieldName);
-
-		field.setAccessible(true);
-
-		field.set(object, value);
-	}
-
-	private void _setJenkinsMasterAWSFleetClouds(String jenkinsMasterName)
-		throws Exception {
-
+	private void _setJenkinsMasterAWSFleetClouds(String jenkinsMasterName) {
 		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
 			jenkinsMasterName);
 
-		_setFieldValue(
+		ReflectionTestUtil.setFieldValue(
 			jenkinsMaster, "_awsFleetCloudLastUpdateTimestamp", Long.MAX_VALUE);
-		_setFieldValue(jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
+		ReflectionTestUtil.setFieldValue(
+			jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
 	}
 
 	private void _setJenkinsMasterBuildProperties(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.lang.reflect.Field;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * @author Calum Ragan
+ */
+public class BuildQueueRebalancerTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@After
+	@Override
+	public void tearDown() {
+		try {
+			Map<String, JenkinsMaster> jenkinsMasters = _getStaticFieldValue(
+				JenkinsMaster.class, "_jenkinsMasters");
+
+			jenkinsMasters.remove(_AVAILABLE_JENKINS_MASTER_NAME);
+			jenkinsMasters.remove(_BLACK_LISTED_JENKINS_MASTER_NAME);
+
+			Map<String, JenkinsCohort> jenkinsCohorts = _getStaticFieldValue(
+				JenkinsCohort.class, "_jenkinsCohorts");
+
+			jenkinsCohorts.remove(_JENKINS_COHORT_NAME);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new RuntimeException(reflectiveOperationException);
+		}
+
+		JenkinsResultsParserUtil.setBuildProperties(
+			(Hashtable<Object, Object>)null);
+
+		super.tearDown();
+	}
+
+	@Test
+	public void testRebalanceDrainsBlackListedJenkinsMasters()
+		throws Exception {
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty("jenkins.load.balancer.blacklist", "");
+
+		for (String jenkinsMasterName :
+				new String[] {
+					_AVAILABLE_JENKINS_MASTER_NAME,
+					_BLACK_LISTED_JENKINS_MASTER_NAME
+				}) {
+
+			buildProperties.setProperty(
+				JenkinsResultsParserUtil.combine(
+					"jenkins.local.url[", jenkinsMasterName, "]"),
+				JenkinsResultsParserUtil.combine(
+					"http://", jenkinsMasterName, ".liferay.com"));
+			buildProperties.setProperty(
+				JenkinsResultsParserUtil.combine(
+					"jenkins.remote.url[", jenkinsMasterName, "]"),
+				JenkinsResultsParserUtil.combine(
+					"https://", jenkinsMasterName, ".liferay.com"));
+			buildProperties.setProperty(
+				JenkinsResultsParserUtil.combine(
+					"master.property(", jenkinsMasterName, "/executors.size)"),
+				"2");
+		}
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			JenkinsResultsParserUtil.combine(
+				"{\"items\":[{\"id\":101,\"inQueueSince\":1,\"task\":",
+				"{\"name\":\"test-portal-acceptance-pullrequest(master)\",",
+				"\"url\":\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
+				".liferay.com/job/test-portal-acceptance-pullrequest",
+				"(master)/\"},\"url\":\"queue/item/101/\",\"why\":\"\"},",
+				"{\"id\":102,\"inQueueSince\":2,\"task\":{\"name\":",
+				"\"test-portal-acceptance-pullrequest(master)\",\"url\":",
+				"\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
+				".liferay.com/job/test-portal-acceptance-pullrequest",
+				"(master)/\"},\"url\":\"queue/item/102/\",\"why\":\"\"}]}"),
+			_BLACK_LISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			urlReader);
+		setUrlReaderOutput(
+			"{\"mode\":\"NORMAL\"}",
+			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/api/json?tree=mode",
+			urlReader);
+		setUrlReaderOutput(
+			"{\"items\":[]}",
+			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			urlReader);
+
+		for (String jenkinsMasterName :
+				new String[] {
+					_AVAILABLE_JENKINS_MASTER_NAME,
+					_BLACK_LISTED_JENKINS_MASTER_NAME
+				}) {
+
+			JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(
+				jenkinsMasterName);
+
+			_setFieldValue(
+				jenkinsMaster, "_awsFleetCloudLastUpdateTimestamp",
+				Long.MAX_VALUE);
+			_setFieldValue(jenkinsMaster, "_awsFleetClouds", new ArrayList<>());
+		}
+
+		_setFieldValue(
+			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
+			"_blacklisted", true);
+
+		JenkinsCohort jenkinsCohort = JenkinsCohort.getInstance(
+			_JENKINS_COHORT_NAME);
+
+		List<JenkinsMaster> availableJenkinsMasters =
+			jenkinsCohort.getAvailableJenkinsMasters();
+
+		testEquals(1, availableJenkinsMasters.size());
+
+		JenkinsMaster jenkinsMaster = availableJenkinsMasters.get(0);
+
+		testEquals(_AVAILABLE_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+
+		List<JenkinsMaster> blackListedJenkinsMasters =
+			jenkinsCohort.getBlackListedJenkinsMasters();
+
+		testEquals(1, blackListedJenkinsMasters.size());
+
+		jenkinsMaster = blackListedJenkinsMasters.get(0);
+
+		testEquals(_BLACK_LISTED_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+
+		BuildQueueRebalancer buildQueueRebalancer = new BuildQueueRebalancer(
+			jenkinsCohort);
+
+		buildQueueRebalancer.rebalance();
+
+		String summary = buildQueueRebalancer.getSummary();
+
+		testEquals(
+			true,
+			summary.startsWith(
+				"Build queue rebalanced by 2 reinvocations and 0 aborts"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T _getStaticFieldValue(Class<?> clazz, String fieldName)
+		throws ReflectiveOperationException {
+
+		Field field = clazz.getDeclaredField(fieldName);
+
+		field.setAccessible(true);
+
+		return (T)field.get(null);
+	}
+
+	private void _setFieldValue(Object object, String fieldName, Object value)
+		throws Exception {
+
+		Class<?> clazz = object.getClass();
+
+		Field field = clazz.getDeclaredField(fieldName);
+
+		field.setAccessible(true);
+
+		field.set(object, value);
+	}
+
+	private static final String _AVAILABLE_JENKINS_MASTER_NAME = "test-9-2";
+
+	private static final String _BLACK_LISTED_JENKINS_MASTER_NAME = "test-9-1";
+
+	private static final String _JENKINS_COHORT_NAME = "test-9";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -31,7 +31,7 @@ public class BuildQueueRebalancerTest
 				JenkinsMaster.class, "_jenkinsMasters");
 
 		jenkinsMasters.remove(_AVAILABLE_JENKINS_MASTER_NAME);
-		jenkinsMasters.remove(_BLACK_LISTED_JENKINS_MASTER_NAME);
+		jenkinsMasters.remove(_BLACKLISTED_JENKINS_MASTER_NAME);
 
 		Map<String, JenkinsCohort> jenkinsCohorts =
 			ReflectionTestUtil.getFieldValue(
@@ -45,7 +45,7 @@ public class BuildQueueRebalancerTest
 	}
 
 	@Test
-	public void testRebalanceBlackListedJenkinsMasters() throws Exception {
+	public void testRebalanceBlacklistedJenkinsMasters() throws Exception {
 		Properties buildProperties = new Properties();
 
 		buildProperties.setProperty("jenkins.load.balancer.blacklist", "");
@@ -53,7 +53,7 @@ public class BuildQueueRebalancerTest
 		_setJenkinsMasterBuildProperties(
 			buildProperties, _AVAILABLE_JENKINS_MASTER_NAME);
 		_setJenkinsMasterBuildProperties(
-			buildProperties, _BLACK_LISTED_JENKINS_MASTER_NAME);
+			buildProperties, _BLACKLISTED_JENKINS_MASTER_NAME);
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
@@ -64,17 +64,17 @@ public class BuildQueueRebalancerTest
 				"{\"items\":[", "{\"id\":101,\"inQueueSince\":1,",
 				"\"task\":{\"name\":",
 				"\"test-portal-acceptance-pullrequest(master)\",",
-				"\"url\":\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
+				"\"url\":\"http://", _BLACKLISTED_JENKINS_MASTER_NAME,
 				".liferay.com/job/",
 				"test-portal-acceptance-pullrequest(master)/\"},",
 				"\"url\":\"queue/item/101/\",\"why\":\"\"},",
 				"{\"id\":102,\"inQueueSince\":2,", "\"task\":{\"name\":",
 				"\"test-portal-acceptance-pullrequest(master)\",",
-				"\"url\":\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
+				"\"url\":\"http://", _BLACKLISTED_JENKINS_MASTER_NAME,
 				".liferay.com/job/",
 				"test-portal-acceptance-pullrequest(master)/\"},",
 				"\"url\":\"queue/item/102/\",\"why\":\"\"}", "]}"),
-			_BLACK_LISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			_BLACKLISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
 			urlReader);
 		setUrlReaderOutput(
 			"{\"mode\":\"NORMAL\"}",
@@ -86,10 +86,10 @@ public class BuildQueueRebalancerTest
 			urlReader);
 
 		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
-		_setJenkinsMasterAWSFleetClouds(_BLACK_LISTED_JENKINS_MASTER_NAME);
+		_setJenkinsMasterAWSFleetClouds(_BLACKLISTED_JENKINS_MASTER_NAME);
 
 		ReflectionTestUtil.setFieldValue(
-			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
+			JenkinsMaster.getInstance(_BLACKLISTED_JENKINS_MASTER_NAME),
 			"_blacklisted", true);
 
 		JenkinsCohort jenkinsCohort = JenkinsCohort.getInstance(
@@ -105,17 +105,17 @@ public class BuildQueueRebalancerTest
 		testEquals(
 			_AVAILABLE_JENKINS_MASTER_NAME, availableJenkinsMaster.getName());
 
-		List<JenkinsMaster> blackListedJenkinsMasters =
+		List<JenkinsMaster> blacklistedJenkinsMasters =
 			jenkinsCohort.getBlackListedJenkinsMasters();
 
-		testEquals(1, blackListedJenkinsMasters.size());
+		testEquals(1, blacklistedJenkinsMasters.size());
 
-		JenkinsMaster blackListedJenkinsMaster = blackListedJenkinsMasters.get(
+		JenkinsMaster blacklistedJenkinsMaster = blacklistedJenkinsMasters.get(
 			0);
 
 		testEquals(
-			_BLACK_LISTED_JENKINS_MASTER_NAME,
-			blackListedJenkinsMaster.getName());
+			_BLACKLISTED_JENKINS_MASTER_NAME,
+			blacklistedJenkinsMaster.getName());
 
 		BuildQueueRebalancer buildQueueRebalancer = new BuildQueueRebalancer(
 			jenkinsCohort);
@@ -131,7 +131,7 @@ public class BuildQueueRebalancerTest
 	}
 
 	@Test
-	public void testRebalanceUnreachableBlackListedJenkinsMaster()
+	public void testRebalanceUnreachableBlacklistedJenkinsMaster()
 		throws Exception {
 
 		Properties buildProperties = new Properties();
@@ -141,7 +141,7 @@ public class BuildQueueRebalancerTest
 		_setJenkinsMasterBuildProperties(
 			buildProperties, _AVAILABLE_JENKINS_MASTER_NAME);
 		_setJenkinsMasterBuildProperties(
-			buildProperties, _BLACK_LISTED_JENKINS_MASTER_NAME);
+			buildProperties, _BLACKLISTED_JENKINS_MASTER_NAME);
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
@@ -158,7 +158,7 @@ public class BuildQueueRebalancerTest
 				readURL ->
 					(readURL != null) &&
 					readURL.contains(
-						_BLACK_LISTED_JENKINS_MASTER_NAME +
+						_BLACKLISTED_JENKINS_MASTER_NAME +
 							".liferay.com/queue/api/json"))
 		);
 
@@ -172,10 +172,10 @@ public class BuildQueueRebalancerTest
 			urlReader);
 
 		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
-		_setJenkinsMasterAWSFleetClouds(_BLACK_LISTED_JENKINS_MASTER_NAME);
+		_setJenkinsMasterAWSFleetClouds(_BLACKLISTED_JENKINS_MASTER_NAME);
 
 		ReflectionTestUtil.setFieldValue(
-			JenkinsMaster.getInstance(_BLACK_LISTED_JENKINS_MASTER_NAME),
+			JenkinsMaster.getInstance(_BLACKLISTED_JENKINS_MASTER_NAME),
 			"_blacklisted", true);
 
 		BuildQueueRebalancer buildQueueRebalancer = new BuildQueueRebalancer(
@@ -222,7 +222,7 @@ public class BuildQueueRebalancerTest
 
 	private static final String _AVAILABLE_JENKINS_MASTER_NAME = "test-9-2";
 
-	private static final String _BLACK_LISTED_JENKINS_MASTER_NAME = "test-9-1";
+	private static final String _BLACKLISTED_JENKINS_MASTER_NAME = "test-9-1";
 
 	private static final String _JENKINS_COHORT_NAME = "test-9";
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -8,7 +8,6 @@ package com.liferay.jenkins.results.parser;
 import java.io.IOException;
 
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -40,8 +39,7 @@ public class BuildQueueRebalancerTest
 
 		jenkinsCohorts.remove(_JENKINS_COHORT_NAME);
 
-		JenkinsResultsParserUtil.setBuildProperties(
-			(Hashtable<Object, Object>)null);
+		JenkinsResultsParserUtil.setBuildProperties(new Properties());
 
 		super.tearDown();
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -68,9 +68,11 @@ public class BuildQueueRebalancerTest
 			"items",
 			new JSONArray(
 			).put(
-				_getQueueItemJSONObject(101, 1)
+				_getQueueItemJSONObject(
+					RandomTestUtil.randomLong(), RandomTestUtil.randomLong())
 			).put(
-				_getQueueItemJSONObject(102, 2)
+				_getQueueItemJSONObject(
+					RandomTestUtil.randomLong(), RandomTestUtil.randomLong())
 			));
 
 		setUrlReaderOutput(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -106,7 +106,7 @@ public class BuildQueueRebalancerTest
 			_AVAILABLE_JENKINS_MASTER_NAME, availableJenkinsMaster.getName());
 
 		List<JenkinsMaster> blacklistedJenkinsMasters =
-			jenkinsCohort.getBlackListedJenkinsMasters();
+			jenkinsCohort.getBlacklistedJenkinsMasters();
 
 		testEquals(1, blacklistedJenkinsMasters.size());
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -61,16 +61,19 @@ public class BuildQueueRebalancerTest
 
 		setUrlReaderOutput(
 			JenkinsResultsParserUtil.combine(
-				"{\"items\":[{\"id\":101,\"inQueueSince\":1,\"task\":",
-				"{\"name\":\"test-portal-acceptance-pullrequest(master)\",",
+				"{\"items\":[", "{\"id\":101,\"inQueueSince\":1,",
+				"\"task\":{\"name\":",
+				"\"test-portal-acceptance-pullrequest(master)\",",
 				"\"url\":\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
-				".liferay.com/job/test-portal-acceptance-pullrequest",
-				"(master)/\"},\"url\":\"queue/item/101/\",\"why\":\"\"},",
-				"{\"id\":102,\"inQueueSince\":2,\"task\":{\"name\":",
-				"\"test-portal-acceptance-pullrequest(master)\",\"url\":",
-				"\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
-				".liferay.com/job/test-portal-acceptance-pullrequest",
-				"(master)/\"},\"url\":\"queue/item/102/\",\"why\":\"\"}]}"),
+				".liferay.com/job/",
+				"test-portal-acceptance-pullrequest(master)/\"},",
+				"\"url\":\"queue/item/101/\",\"why\":\"\"},",
+				"{\"id\":102,\"inQueueSince\":2,", "\"task\":{\"name\":",
+				"\"test-portal-acceptance-pullrequest(master)\",",
+				"\"url\":\"http://", _BLACK_LISTED_JENKINS_MASTER_NAME,
+				".liferay.com/job/",
+				"test-portal-acceptance-pullrequest(master)/\"},",
+				"\"url\":\"queue/item/102/\",\"why\":\"\"}", "]}"),
 			_BLACK_LISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
 			urlReader);
 		setUrlReaderOutput(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import org.junit.After;
 import org.junit.Test;
 
@@ -59,29 +62,36 @@ public class BuildQueueRebalancerTest
 
 		UrlReader urlReader = mockUrlReader();
 
+		JSONObject queueJSONObject = new JSONObject();
+
+		queueJSONObject.put(
+			"items",
+			new JSONArray(
+			).put(
+				_getQueueItemJSONObject(101, 1)
+			).put(
+				_getQueueItemJSONObject(102, 2)
+			));
+
 		setUrlReaderOutput(
-			JenkinsResultsParserUtil.combine(
-				"{\"items\":[", "{\"id\":101,\"inQueueSince\":1,",
-				"\"task\":{\"name\":",
-				"\"test-portal-acceptance-pullrequest(master)\",",
-				"\"url\":\"http://", _BLACKLISTED_JENKINS_MASTER_NAME,
-				".liferay.com/job/",
-				"test-portal-acceptance-pullrequest(master)/\"},",
-				"\"url\":\"queue/item/101/\",\"why\":\"\"},",
-				"{\"id\":102,\"inQueueSince\":2,", "\"task\":{\"name\":",
-				"\"test-portal-acceptance-pullrequest(master)\",",
-				"\"url\":\"http://", _BLACKLISTED_JENKINS_MASTER_NAME,
-				".liferay.com/job/",
-				"test-portal-acceptance-pullrequest(master)/\"},",
-				"\"url\":\"queue/item/102/\",\"why\":\"\"}", "]}"),
+			String.valueOf(queueJSONObject),
 			_BLACKLISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
 			urlReader);
+
 		setUrlReaderOutput(
-			"{\"mode\":\"NORMAL\"}",
+			String.valueOf(
+				new JSONObject(
+				).put(
+					"mode", "NORMAL"
+				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/api/json?tree=mode",
 			urlReader);
 		setUrlReaderOutput(
-			"{\"items\":[]}",
+			String.valueOf(
+				new JSONObject(
+				).put(
+					"items", new JSONArray()
+				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
 			urlReader);
 
@@ -163,11 +173,19 @@ public class BuildQueueRebalancerTest
 		);
 
 		setUrlReaderOutput(
-			"{\"mode\":\"NORMAL\"}",
+			String.valueOf(
+				new JSONObject(
+				).put(
+					"mode", "NORMAL"
+				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/api/json?tree=mode",
 			urlReader);
 		setUrlReaderOutput(
-			"{\"items\":[]}",
+			String.valueOf(
+				new JSONObject(
+				).put(
+					"items", new JSONArray()
+				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
 			urlReader);
 
@@ -189,6 +207,35 @@ public class BuildQueueRebalancerTest
 			true,
 			summary.startsWith(
 				"Build queue rebalanced by 0 reinvocations and 0 aborts"));
+	}
+
+	private JSONObject _getQueueItemJSONObject(long id, long inQueueSince) {
+		JSONObject jsonObject = new JSONObject();
+
+		JSONObject taskJSONObject = new JSONObject();
+
+		taskJSONObject.put(
+			"name", _JOB_NAME
+		).put(
+			"url",
+			JenkinsResultsParserUtil.combine(
+				"http://", _BLACKLISTED_JENKINS_MASTER_NAME,
+				".liferay.com/job/", _JOB_NAME, "/")
+		);
+
+		jsonObject.put(
+			"id", id
+		).put(
+			"inQueueSince", inQueueSince
+		).put(
+			"task", taskJSONObject
+		).put(
+			"url", "queue/item/" + id + "/"
+		).put(
+			"why", ""
+		);
+
+		return jsonObject;
 	}
 
 	private void _setJenkinsMasterAWSFleetClouds(String jenkinsMasterName) {
@@ -225,5 +272,8 @@ public class BuildQueueRebalancerTest
 	private static final String _BLACKLISTED_JENKINS_MASTER_NAME = "test-9-1";
 
 	private static final String _JENKINS_COHORT_NAME = "test-9";
+
+	private static final String _JOB_NAME =
+		"test-portal-acceptance-pullrequest(master)";
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -48,9 +48,7 @@ public class BuildQueueRebalancerTest
 	}
 
 	@Test
-	public void testRebalanceDrainsBlackListedJenkinsMasters()
-		throws Exception {
-
+	public void testRebalanceBlackListedJenkinsMasters() throws Exception {
 		Properties buildProperties = new Properties();
 
 		buildProperties.setProperty("jenkins.load.balancer.blacklist", "");
@@ -131,18 +129,22 @@ public class BuildQueueRebalancerTest
 
 		testEquals(1, availableJenkinsMasters.size());
 
-		JenkinsMaster jenkinsMaster = availableJenkinsMasters.get(0);
+		JenkinsMaster availableJenkinsMaster = availableJenkinsMasters.get(0);
 
-		testEquals(_AVAILABLE_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+		testEquals(
+			_AVAILABLE_JENKINS_MASTER_NAME, availableJenkinsMaster.getName());
 
 		List<JenkinsMaster> blackListedJenkinsMasters =
 			jenkinsCohort.getBlackListedJenkinsMasters();
 
 		testEquals(1, blackListedJenkinsMasters.size());
 
-		jenkinsMaster = blackListedJenkinsMasters.get(0);
+		JenkinsMaster blackListedJenkinsMaster = blackListedJenkinsMasters.get(
+			0);
 
-		testEquals(_BLACK_LISTED_JENKINS_MASTER_NAME, jenkinsMaster.getName());
+		testEquals(
+			_BLACK_LISTED_JENKINS_MASTER_NAME,
+			blackListedJenkinsMaster.getName());
 
 		BuildQueueRebalancer buildQueueRebalancer = new BuildQueueRebalancer(
 			jenkinsCohort);


### PR DESCRIPTION
[LRCI-7915](https://liferay.atlassian.net/browse/LRCI-7915)

Revises [#4468](https://github.com/pyoo47/liferay-portal/pull/4468) (opened by @CalumR23) with the following follow-up commits:

- [9c4462a2d2bd](https://github.com/pyoo47/liferay-portal/commit/9c4462a2d2bd6296b1b15e960ed851cd77d23ec3) LRCI-7915 Randomize the unasserted mock queue item values
