### PR TITLE
LRCI-7941 Stop a top level build from crashing on an unknown build URL

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -176,7 +176,11 @@ public abstract class BaseBuild implements Build {
 		for (Invocation invocation :
 				_invocations.subList(0, _invocations.size() - 1)) {
 
-			badBuildURLs.add(invocation.getBuildURL());
+			String buildURL = invocation.getBuildURL();
+
+			if (buildURL != null) {
+				badBuildURLs.add(buildURL);
+			}
 		}
 
 		return badBuildURLs;
@@ -2438,9 +2442,12 @@ public abstract class BaseBuild implements Build {
 				Invocation previousInvocation = getPreviousInvocation();
 
 				if (previousInvocation != null) {
-					sb.append(" ");
+					String previousBuildURL = previousInvocation.getBuildURL();
 
-					sb.append(previousInvocation.getBuildURL());
+					if (previousBuildURL != null) {
+						sb.append(" ");
+						sb.append(previousBuildURL);
+					}
 
 					sb.append(" restarted at ");
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2368,6 +2368,14 @@ public abstract class BaseBuild implements Build {
 		}
 	}
 
+	protected int getBadBuildCount() {
+		if (_invocations.size() <= 1) {
+			return 0;
+		}
+
+		return _invocations.size() - 1;
+	}
+
 	protected String getBaseGitRepositoryType() {
 		if (_jobName.startsWith("test-subrepository-acceptance-pullrequest")) {
 			return getBaseGitRepositoryName();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1679,10 +1679,19 @@ public abstract class BaseBuild implements Build {
 
 	@Override
 	public void saveBuildURLInBuildDatabase() {
+		String buildURL = getBuildURL();
+		String jobVariant = getJobVariant();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL) ||
+			JenkinsResultsParserUtil.isNullOrEmpty(jobVariant)) {
+
+			return;
+		}
+
 		BuildDatabase buildDatabase = getBuildDatabase();
 
 		buildDatabase.putProperty(
-			BUILD_URLS_PROPERTIES_KEY, getJobVariant(), getBuildURL(), false);
+			BUILD_URLS_PROPERTIES_KEY, jobVariant, buildURL, false);
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -183,8 +183,17 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 			return _axisName;
 		}
 
+		String axisVariable = getAxisVariable();
+		String jobVariant = getJobVariant();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(axisVariable) ||
+			JenkinsResultsParserUtil.isNullOrEmpty(jobVariant)) {
+
+			return null;
+		}
+
 		_axisName = JenkinsResultsParserUtil.combine(
-			getJobVariant(), "/", getAxisVariable());
+			jobVariant, "/", axisVariable);
 
 		return _axisName;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -696,17 +696,29 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 
 	@Override
 	public void saveBuildURLInBuildDatabase() {
+		String buildURL = getBuildURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL)) {
+			return;
+		}
+
 		BuildDatabase buildDatabase = getBuildDatabase();
 
 		if (isBuildCached()) {
 			buildDatabase.putProperty(
-				CACHED_BUILD_URLS_PROPERTIES_KEY, getBuildURL(), "", false);
+				CACHED_BUILD_URLS_PROPERTIES_KEY, buildURL, "", false);
 
 			return;
 		}
 
+		String axisName = getAxisName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(axisName)) {
+			return;
+		}
+
 		buildDatabase.putProperty(
-			BUILD_URLS_PROPERTIES_KEY, getAxisName(), getBuildURL(), false);
+			BUILD_URLS_PROPERTIES_KEY, axisName, buildURL, false);
 
 		_saveBadBuildURLsInBuildDatabase(getBadBuildURLs());
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -720,7 +720,7 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 		buildDatabase.putProperty(
 			BUILD_URLS_PROPERTIES_KEY, axisName, buildURL, false);
 
-		_saveBadBuildURLsInBuildDatabase(getBadBuildURLs());
+		_saveBadBuildURLsInBuildDatabase();
 	}
 
 	protected BaseDownstreamBuild(
@@ -1213,9 +1213,17 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 		return sb.toString();
 	}
 
-	private void _saveBadBuildURLsInBuildDatabase(List<String> badBuildURLs) {
-		if (badBuildURLs.isEmpty()) {
+	private void _saveBadBuildURLsInBuildDatabase() {
+		int badBuildCount = getBadBuildCount();
+
+		if (badBuildCount == 0) {
 			return;
+		}
+
+		List<String> badBuildURLs = new ArrayList<>(getBadBuildURLs());
+
+		while (badBuildURLs.size() < badBuildCount) {
+			badBuildURLs.add(_BAD_BUILD_URL_UNKNOWN);
 		}
 
 		BuildDatabase buildDatabase = getBuildDatabase();
@@ -1273,6 +1281,8 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 			JenkinsResultsParserUtil.delete(testrayUploadBaseDir);
 		}
 	}
+
+	private static final String _BAD_BUILD_URL_UNKNOWN = "unknown";
 
 	private static final FailureMessageGenerator[] _FAILURE_MESSAGE_GENERATORS =
 	{

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -2256,12 +2256,21 @@ public abstract class BaseTopLevelBuild
 			return;
 		}
 
+		String buildURL = getBuildURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL)) {
+			System.out.println(
+				"Unable to archive properties to " + archiveFile);
+
+			return;
+		}
+
 		long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
 
 		Properties archiveProperties = new Properties();
 
 		archiveProperties.setProperty(
-			"top.level.build.url", replaceBuildURL(getBuildURL()));
+			"top.level.build.url", replaceBuildURL(buildURL));
 
 		StringWriter sw = new StringWriter();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -282,6 +282,10 @@ public interface Build {
 			_buildURL = JenkinsResultsParserUtil.getBuildURL(
 				_build.getJobName(), getJenkinsMaster(), getQueueId());
 
+			if (_buildURL == null) {
+				return null;
+			}
+
 			String localBuildURL = JenkinsResultsParserUtil.getLocalURL(
 				_buildURL);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -45,4 +45,57 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 			Arrays.asList(firstBuildURL), baseBuild.getBadBuildURLs());
 	}
 
+	@Test
+	public void testSaveBuildURLInBuildDatabase() {
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), null, false);
+		_testSaveBuildURLInBuildDatabase(
+			null, RandomTestUtil.randomString(), false);
+	}
+
+	private void _testSaveBuildURLInBuildDatabase(
+		String buildURL, String jobVariant, boolean saved) {
+
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).saveBuildURLInBuildDatabase();
+
+		Mockito.when(
+			baseBuild.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			baseBuild.getBuildURL()
+		).thenReturn(
+			buildURL
+		);
+
+		Mockito.when(
+			baseBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		baseBuild.saveBuildURLInBuildDatabase();
+
+		if (saved) {
+			Mockito.verify(
+				buildDatabase
+			).putProperty(
+				BaseBuild.BUILD_URLS_PROPERTIES_KEY, jobVariant, buildURL, false
+			);
+		}
+		else {
+			Mockito.verifyNoInteractions(buildDatabase);
+		}
+	}
+
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetBadBuildURLs() {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		Build.Invocation firstInvocation = new Build.Invocation(baseBuild);
+		Build.Invocation lastInvocation = new Build.Invocation(baseBuild);
+
+		String firstBuildURL = "https://test-1-1.liferay.com/job/test/1";
+
+		firstInvocation.setBuildURL(firstBuildURL);
+
+		lastInvocation.setBuildURL("https://test-1-1.liferay.com/job/test/3");
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_invocations",
+			Arrays.asList(
+				firstInvocation, new Build.Invocation(baseBuild),
+				lastInvocation));
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).getBadBuildURLs();
+
+		Assert.assertEquals(
+			Arrays.asList(firstBuildURL), baseBuild.getBadBuildURLs());
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -121,6 +121,83 @@ public class BaseDownstreamBuildTest
 	}
 
 	@Test
+	public void testSaveBadBuildURLsInBuildDatabase() {
+		String axisVariable = RandomTestUtil.randomString();
+		String buildURL = RandomTestUtil.randomString();
+		String jobVariant = RandomTestUtil.randomString();
+
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getAxisName();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getBadBuildCount();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getBadBuildURLs();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).saveBuildURLInBuildDatabase();
+
+		Mockito.when(
+			baseDownstreamBuild.getAxisVariable()
+		).thenReturn(
+			axisVariable
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildURL()
+		).thenReturn(
+			buildURL
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		String firstBuildURL = "https://test-1-1.liferay.com/job/test/1";
+
+		Build.Invocation firstInvocation = new Build.Invocation(
+			baseDownstreamBuild);
+
+		firstInvocation.setBuildURL(firstBuildURL);
+
+		ReflectionTestUtil.setFieldValue(
+			baseDownstreamBuild, "_invocations",
+			Arrays.asList(
+				firstInvocation, new Build.Invocation(baseDownstreamBuild),
+				new Build.Invocation(baseDownstreamBuild)));
+
+		baseDownstreamBuild.saveBuildURLInBuildDatabase();
+
+		Mockito.verify(
+			buildDatabase
+		).putProperty(
+			BaseBuild.BAD_BUILD_URLS_PROPERTIES_KEY,
+			jobVariant + "/" + axisVariable, firstBuildURL + ",unknown", false
+		);
+	}
+
+	@Test
 	public void testSaveBuildURLInBuildDatabase() {
 		_testSaveBuildURLInBuildDatabase(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -21,6 +21,18 @@ public class BaseDownstreamBuildTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testGetAxisName() {
+		String axisVariable = RandomTestUtil.randomString();
+		String jobVariant = RandomTestUtil.randomString();
+
+		_testGetAxisName(
+			axisVariable, jobVariant + "/" + axisVariable, jobVariant);
+
+		_testGetAxisName(axisVariable, null, null);
+		_testGetAxisName(null, null, jobVariant);
+	}
+
+	@Test
 	public void testGetGitHubMessageElement() {
 		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
 			BaseDownstreamBuild.class);
@@ -106,6 +118,33 @@ public class BaseDownstreamBuildTest
 		Assert.assertTrue(
 			gitHubMessageUpstreamJobFailureXML.contains(
 				upstreamJobFailureMarker));
+	}
+
+	private void _testGetAxisName(
+		String axisVariable, String expectedAxisName, String jobVariant) {
+
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getAxisName();
+
+		Mockito.when(
+			baseDownstreamBuild.getAxisVariable()
+		).thenReturn(
+			axisVariable
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		Assert.assertEquals(
+			expectedAxisName, baseDownstreamBuild.getAxisName());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -120,6 +120,16 @@ public class BaseDownstreamBuildTest
 				upstreamJobFailureMarker));
 	}
 
+	@Test
+	public void testSaveBuildURLInBuildDatabase() {
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), null, false);
+		_testSaveBuildURLInBuildDatabase(
+			null, RandomTestUtil.randomString(), false);
+	}
+
 	private void _testGetAxisName(
 		String axisVariable, String expectedAxisName, String jobVariant) {
 
@@ -145,6 +155,64 @@ public class BaseDownstreamBuildTest
 
 		Assert.assertEquals(
 			expectedAxisName, baseDownstreamBuild.getAxisName());
+	}
+
+	private void _testSaveBuildURLInBuildDatabase(
+		String buildURL, String jobVariant, boolean saved) {
+
+		String axisVariable = RandomTestUtil.randomString();
+
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getAxisName();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).saveBuildURLInBuildDatabase();
+
+		Mockito.when(
+			baseDownstreamBuild.getAxisVariable()
+		).thenReturn(
+			axisVariable
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildURL()
+		).thenReturn(
+			buildURL
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		baseDownstreamBuild.saveBuildURLInBuildDatabase();
+
+		if (saved) {
+			Mockito.verify(
+				buildDatabase
+			).putProperty(
+				BaseBuild.BUILD_URLS_PROPERTIES_KEY,
+				jobVariant + "/" + axisVariable, buildURL, false
+			);
+		}
+		else {
+			Mockito.verifyNoInteractions(buildDatabase);
+		}
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7941

## What Is Being Fixed

A top level build died with a `NullPointerException` when a reinvoked downstream build had an earlier invocation whose Jenkins queue item had been pruned. `Build.Invocation.getBuildURL` passed that null into `JenkinsResultsParserUtil.getLocalURL`, and the readers of an unknown build URL passed it on into `Properties` keys and values. In `liferay-jenkins-ee` the throw surfaced inside the BeanShell block that collects bad build URLs, which stops every running downstream build and rethrows, so the run went down with it.

A second defect sat behind the same root cause. An axis name is composed through `JenkinsResultsParserUtil.combine`, which appends through a `StringBuilder` and so turns a null job variant or axis variable into the four characters `null`. An unresolved downstream build wrote a `build.urls` entry keyed `null/AXIS_VARIABLE=3`, `getAxisName` cached that name for the life of the object, and `findDownstreamBuilds` read the property name straight back as an axis name.

## How It Is Being Fixed

An invocation reports that it has no URL rather than passing null on, and each reader copes: the bad build URL list skips it, and the build message still says the build was restarted, naming the earlier build only when that URL is known. `getAxisName` resolves the job variant and axis variable first and returns null when either is missing, matching how `BaseTopLevelBuild.getDownstreamBuild` already treats a build lacking either one, and that is what lets both `saveBuildURLInBuildDatabase` overrides refuse to write until they have both a URL and a name. Archiving skips and says so, because that failure otherwise resurfaces hours later as an unrelated "Unable to find archive" from `BuildFactory`.

Skipping an unresolvable URL costs the report a number, so the last commit accounts for it. `BaseTopLevelBuild` derives "Total number of reinvocations" by counting entries under `bad-build-urls.properties`, and a bad build that can no longer name its URL would silently drop out of that total in exactly the pileup this ticket is about. The recorded list now holds one entry per superseded invocation, naming the URL where known and saying `unknown` where not.

Each guard has a test, and each was verified red against the unpatched source.

## PR Check

**pr-check: PASS** — tested on `278ba2b347f1e7ecd4917d379972fba93d254874`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| Transaction Usage | PASS |

<!-- pr-check {"result": "success", "sha": "278ba2b347f1e7ecd4917d379972fba93d254874"} -->
