### PR TITLE
LRCI-7954 Add unit tests for diff driven PR tester job selection

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsGitRepositoryJobTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsGitRepositoryJobTest.java
@@ -1,0 +1,217 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class JenkinsGitRepositoryJobTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_gitRepositoryDir = temporaryFolder.newFolder();
+		_gitWorkingDirectory = Mockito.mock(GitWorkingDirectory.class);
+
+		JenkinsResultsParserUtil.setBuildProperties(_getBuildProperties());
+
+		mockEnvironment(
+			Collections.singletonMap(
+				"GITHUB_UPSTREAM_BRANCH_NAME", RandomTestUtil.randomString()));
+
+		File upstreamJarFile = temporaryFolder.newFile();
+
+		_writeJarFile(upstreamJarFile, null);
+
+		Mockito.doAnswer(
+			invocation -> {
+				String command = invocation.getArgument(3);
+
+				Files.copy(
+					upstreamJarFile.toPath(),
+					Paths.get(command.substring(command.indexOf(" > ") + 3)),
+					StandardCopyOption.REPLACE_EXISTING);
+
+				return new GitUtil.ExecutionResult(0, "", "");
+			}
+		).when(
+			_gitWorkingDirectory
+		).executeBashCommands(
+			Mockito.anyInt(), Mockito.anyLong(), Mockito.anyLong(),
+			Mockito.anyString()
+		);
+	}
+
+	@Test
+	public void testGetInvokedJobNames() throws Exception {
+		_testGetInvokedJobNames(
+			Arrays.asList(
+				"root-cause-analysis-tool",
+				"test-portal-acceptance-pullrequest(master)/dummy",
+				"test-portal-source-format"),
+			null, "relevant", "commands/build-common.xml",
+			"template/jobs/root-cause-analysis-tool-1/config.xml");
+		_testGetInvokedJobNames(
+			Arrays.asList("test-portal-acceptance-pullrequest(master)"), null,
+			"default", "commands/build-common.xml");
+		_testGetInvokedJobNames(
+			Arrays.asList("test-portal-release"),
+			"com/liferay/jenkins/results/parser/PortalRelease$1.class",
+			"relevant", _JAR_FILE_NAME);
+		_testGetInvokedJobNames(
+			Arrays.asList("test-portal-source-format"), "META-INF/MANIFEST.MF",
+			"relevant", _JAR_FILE_NAME);
+	}
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private Properties _getBuildProperties() {
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"jenkins.pull.request.job.portal.test.suite" +
+				"[test-portal-acceptance-pullrequest(*)]",
+			"dummy");
+		buildProperties.setProperty(
+			"jenkins.pull.request.jobs[build-common-rule][relevant]",
+			"test-portal-source-format," +
+				"test-portal-acceptance-pullrequest(master)");
+		buildProperties.setProperty(
+			"jenkins.pull.request.jobs[default]",
+			"test-portal-acceptance-pullrequest(master)");
+		buildProperties.setProperty(
+			"jenkins.pull.request.jobs[portal-release-rule][relevant]",
+			"test-portal-release");
+		buildProperties.setProperty(
+			"jenkins.pull.request.jobs[relevant]", "test-portal-source-format");
+		buildProperties.setProperty(
+			"jenkins.pull.request.jobs" +
+				"[root-cause-analysis-tool-rule][relevant]",
+			"root-cause-analysis-tool");
+		buildProperties.setProperty(
+			"modified.files.includes[build-common-rule][relevant]",
+			"commands/build-common.xml,lib/jenkins/*");
+		buildProperties.setProperty(
+			"modified.files.includes[root-cause-analysis-tool-rule][relevant]",
+			"template/jobs/root-cause-analysis-tool*/**");
+		buildProperties.setProperty(
+			"modified.jar.entries.includes[portal-release-rule][relevant]",
+			"com/liferay/jenkins/results/parser/PortalRelease.class");
+		buildProperties.setProperty(
+			"modified.jar.entries.includes" +
+				"[root-cause-analysis-tool-rule][relevant]",
+			"META-INF/**");
+
+		return buildProperties;
+	}
+
+	private void _testGetInvokedJobNames(
+			List<String> expectedInvokedJobNames, String modifiedJarEntryName,
+			String testSuiteName, String... modifiedFileNames)
+		throws Exception {
+
+		_writeJarFile(
+			new File(_gitRepositoryDir, _JAR_FILE_NAME), modifiedJarEntryName);
+
+		List<File> modifiedFiles = new ArrayList<>();
+
+		for (String modifiedFileName : modifiedFileNames) {
+			modifiedFiles.add(new File(_gitRepositoryDir, modifiedFileName));
+		}
+
+		Mockito.doReturn(
+			modifiedFiles
+		).when(
+			_gitWorkingDirectory
+		).getModifiedFilesList();
+
+		JenkinsGitRepositoryJob jenkinsGitRepositoryJob = Mockito.mock(
+			JenkinsGitRepositoryJob.class);
+
+		ReflectionTestUtil.setFieldValue(
+			jenkinsGitRepositoryJob, "gitRepositoryDir", _gitRepositoryDir);
+		ReflectionTestUtil.setFieldValue(
+			jenkinsGitRepositoryJob, "gitWorkingDirectory",
+			_gitWorkingDirectory);
+
+		Mockito.doCallRealMethod(
+		).when(
+			jenkinsGitRepositoryJob
+		).getInvokedJobNames();
+
+		Mockito.doReturn(
+			testSuiteName
+		).when(
+			jenkinsGitRepositoryJob
+		).getTestSuiteName();
+
+		testEquals(
+			expectedInvokedJobNames,
+			jenkinsGitRepositoryJob.getInvokedJobNames());
+	}
+
+	private void _writeJarFile(File file, String modifiedEntryName)
+		throws Exception {
+
+		File parentFile = file.getParentFile();
+
+		parentFile.mkdirs();
+
+		try (ZipOutputStream zipOutputStream = new ZipOutputStream(
+				new FileOutputStream(file))) {
+
+			for (String entryName : _entryNames) {
+				zipOutputStream.putNextEntry(new ZipEntry(entryName));
+
+				if (entryName.equals(modifiedEntryName)) {
+					zipOutputStream.write("modified".getBytes());
+				}
+				else {
+					zipOutputStream.write(entryName.getBytes());
+				}
+
+				zipOutputStream.closeEntry();
+			}
+		}
+	}
+
+	private static final String _JAR_FILE_NAME =
+		"lib/jenkins/com.liferay.jenkins.results.parser.jar";
+
+	private static final List<String> _entryNames = Arrays.asList(
+		"META-INF/MANIFEST.MF",
+		"com/liferay/jenkins/results/parser/PortalRelease$1.class");
+
+	private File _gitRepositoryDir;
+	private GitWorkingDirectory _gitWorkingDirectory;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7954

**What is being fixed:** `JenkinsGitRepositoryJob.getInvokedJobNames` selects which pull request jobs a liferay-jenkins-ee change invokes, and it merged under LRCI-7528 with no unit coverage. It is the decision point of the relevant test suite, so a wrong answer either skips a job that should have run or invokes jobs the change cannot affect, and nothing local catches either.

**How it is being fixed:** One test, `testGetInvokedJobNames`, drives four cases through one private method. A suite with no rules of its own falls back to its bare job list. Two files matching two different rules cover additive contribution across rules, a job with no suite mapping, and sorted output. A jar whose only change is the manifest is the every-rebuild case and must invoke nothing extra. A jar with a changed inner class entry must fold that entry onto its outer class before matching.

The harness mocks the job and calls the real method, sets the inherited `gitRepositoryDir` and `gitWorkingDirectory` fields through `ReflectionTestUtil`, and feeds rules through the existing `JenkinsResultsParserUtil.setBuildProperties` seam. The fixture is ten properties covering three rules, two fallback job lists, and one suite mapping, and it uses the property vocabulary and rule names that ship in liferay-jenkins-ee. No production code changes.

**Red check.** A scoped PIT run on the class reports 97 percent test strength, 30 mutants killed, and one survivor, the `deleteOnExit` call on the temporary upstream jar, which has no observable effect in process. The 17 uncovered mutants are all in glue that is out of scope for a unit test, namely the constructors, `_initialize`, `_getJenkinsGitRepositoryDir`, `getJSONObject`, and the constant overrides.

PIT does not mutate string constants or a discarded `List.remove` result, so five behaviors were mutated by hand and each produced a red run that went green on restore. Deleting `modifiedFileNames.remove(_JAR_FILE_NAME)`, dropping the inner class folding `replaceAll`, removing the `META-INF/` skip, replacing the `TreeSet` union with a `LinkedHashSet`, and emptying the resolved portal test suite name each fail the test.

The jar cases carry their weight rather than duplicating the rule cases. Removing them drops the kill count from 30 to 19 and leaves both the folding and the jar path removal mutations alive, so the checksum comparison, the entry folding, and the manifest skip would all go unverified.

A note for anyone editing the fixture. It is deliberately minimal, and every property in it is load bearing in a way that is not locally obvious. Shrinking it during review twice disarmed a guard silently, once the sorted union and once the manifest skip, and giving one rule a second glob disarmed the path matcher conditional. Rerun the five hand mutations above after any fixture change, because the PIT figure alone does not catch all of them.

The full module suite is 152 of 153. The one failure is `PropertyValidatorTest`, which reports four `one.password.*` properties that `SecretsUtil` still consumes after commit 3c221a63f59 in liferay-jenkins-ee removed their declarations. It fails identically on a clean master checkout and is unrelated to this change, so it is excluded from the verdict. Hashimoto is tracking it as LRCI-7947.

**pr-check: PASS** — tested on `8a3820d4610a3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
