### PR TITLE
LRCI-7941 Stop a top level build from crashing on an unknown build URL (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -176,7 +176,11 @@ public abstract class BaseBuild implements Build {
 		for (Invocation invocation :
 				_invocations.subList(0, _invocations.size() - 1)) {
 
-			badBuildURLs.add(invocation.getBuildURL());
+			String buildURL = invocation.getBuildURL();
+
+			if (buildURL != null) {
+				badBuildURLs.add(buildURL);
+			}
 		}
 
 		return badBuildURLs;
@@ -2438,9 +2442,12 @@ public abstract class BaseBuild implements Build {
 				Invocation previousInvocation = getPreviousInvocation();
 
 				if (previousInvocation != null) {
-					sb.append(" ");
+					String previousBuildURL = previousInvocation.getBuildURL();
 
-					sb.append(previousInvocation.getBuildURL());
+					if (previousBuildURL != null) {
+						sb.append(" ");
+						sb.append(previousBuildURL);
+					}
 
 					sb.append(" restarted at ");
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -2368,6 +2368,14 @@ public abstract class BaseBuild implements Build {
 		}
 	}
 
+	protected int getBadBuildCount() {
+		if (_invocations.size() <= 1) {
+			return 0;
+		}
+
+		return _invocations.size() - 1;
+	}
+
 	protected String getBaseGitRepositoryType() {
 		if (_jobName.startsWith("test-subrepository-acceptance-pullrequest")) {
 			return getBaseGitRepositoryName();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1679,10 +1679,19 @@ public abstract class BaseBuild implements Build {
 
 	@Override
 	public void saveBuildURLInBuildDatabase() {
+		String buildURL = getBuildURL();
+		String jobVariant = getJobVariant();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL) ||
+			JenkinsResultsParserUtil.isNullOrEmpty(jobVariant)) {
+
+			return;
+		}
+
 		BuildDatabase buildDatabase = getBuildDatabase();
 
 		buildDatabase.putProperty(
-			BUILD_URLS_PROPERTIES_KEY, getJobVariant(), getBuildURL(), false);
+			BUILD_URLS_PROPERTIES_KEY, jobVariant, buildURL, false);
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -183,8 +183,17 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 			return _axisName;
 		}
 
+		String axisVariable = getAxisVariable();
+		String jobVariant = getJobVariant();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(axisVariable) ||
+			JenkinsResultsParserUtil.isNullOrEmpty(jobVariant)) {
+
+			return null;
+		}
+
 		_axisName = JenkinsResultsParserUtil.combine(
-			getJobVariant(), "/", getAxisVariable());
+			jobVariant, "/", axisVariable);
 
 		return _axisName;
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -696,17 +696,29 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 
 	@Override
 	public void saveBuildURLInBuildDatabase() {
+		String buildURL = getBuildURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL)) {
+			return;
+		}
+
 		BuildDatabase buildDatabase = getBuildDatabase();
 
 		if (isBuildCached()) {
 			buildDatabase.putProperty(
-				CACHED_BUILD_URLS_PROPERTIES_KEY, getBuildURL(), "", false);
+				CACHED_BUILD_URLS_PROPERTIES_KEY, buildURL, "", false);
 
 			return;
 		}
 
+		String axisName = getAxisName();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(axisName)) {
+			return;
+		}
+
 		buildDatabase.putProperty(
-			BUILD_URLS_PROPERTIES_KEY, getAxisName(), getBuildURL(), false);
+			BUILD_URLS_PROPERTIES_KEY, axisName, buildURL, false);
 
 		_saveBadBuildURLsInBuildDatabase(getBadBuildURLs());
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -720,7 +720,7 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 		buildDatabase.putProperty(
 			BUILD_URLS_PROPERTIES_KEY, axisName, buildURL, false);
 
-		_saveBadBuildURLsInBuildDatabase(getBadBuildURLs());
+		_saveBadBuildURLsInBuildDatabase();
 	}
 
 	protected BaseDownstreamBuild(
@@ -1213,9 +1213,17 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 		return sb.toString();
 	}
 
-	private void _saveBadBuildURLsInBuildDatabase(List<String> badBuildURLs) {
-		if (badBuildURLs.isEmpty()) {
+	private void _saveBadBuildURLsInBuildDatabase() {
+		int badBuildCount = getBadBuildCount();
+
+		if (badBuildCount == 0) {
 			return;
+		}
+
+		List<String> badBuildURLs = new ArrayList<>(getBadBuildURLs());
+
+		while (badBuildURLs.size() < badBuildCount) {
+			badBuildURLs.add(_BAD_BUILD_URL_UNKNOWN);
 		}
 
 		BuildDatabase buildDatabase = getBuildDatabase();
@@ -1273,6 +1281,8 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 			JenkinsResultsParserUtil.delete(testrayUploadBaseDir);
 		}
 	}
+
+	private static final String _BAD_BUILD_URL_UNKNOWN = "unknown";
 
 	private static final FailureMessageGenerator[] _FAILURE_MESSAGE_GENERATORS =
 	{

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseDownstreamBuild.java
@@ -244,7 +244,7 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 
 	@Override
 	public String getBuildName() {
-		return getAxisName();
+		return getDisplayName();
 	}
 
 	@Override
@@ -278,7 +278,13 @@ public class BaseDownstreamBuild extends BaseBuild implements DownstreamBuild {
 
 	@Override
 	public String getDisplayName() {
-		return getAxisName();
+		String axisName = getAxisName();
+
+		if (axisName != null) {
+			return axisName;
+		}
+
+		return super.getDisplayName();
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -2256,12 +2256,21 @@ public abstract class BaseTopLevelBuild
 			return;
 		}
 
+		String buildURL = getBuildURL();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(buildURL)) {
+			System.out.println(
+				"Unable to archive properties to " + archiveFile);
+
+			return;
+		}
+
 		long start = JenkinsResultsParserUtil.getCurrentTimeMillis();
 
 		Properties archiveProperties = new Properties();
 
 		archiveProperties.setProperty(
-			"top.level.build.url", replaceBuildURL(getBuildURL()));
+			"top.level.build.url", replaceBuildURL(buildURL));
 
 		StringWriter sw = new StringWriter();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -282,6 +282,10 @@ public interface Build {
 			_buildURL = JenkinsResultsParserUtil.getBuildURL(
 				_build.getJobName(), getJenkinsMaster(), getQueueId());
 
+			if (_buildURL == null) {
+				return null;
+			}
+
 			String localBuildURL = JenkinsResultsParserUtil.getLocalURL(
 				_buildURL);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -45,4 +45,57 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 			Arrays.asList(firstBuildURL), baseBuild.getBadBuildURLs());
 	}
 
+	@Test
+	public void testSaveBuildURLInBuildDatabase() {
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), null, false);
+		_testSaveBuildURLInBuildDatabase(
+			null, RandomTestUtil.randomString(), false);
+	}
+
+	private void _testSaveBuildURLInBuildDatabase(
+		String buildURL, String jobVariant, boolean saved) {
+
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).saveBuildURLInBuildDatabase();
+
+		Mockito.when(
+			baseBuild.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			baseBuild.getBuildURL()
+		).thenReturn(
+			buildURL
+		);
+
+		Mockito.when(
+			baseBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		baseBuild.saveBuildURLInBuildDatabase();
+
+		if (saved) {
+			Mockito.verify(
+				buildDatabase
+			).putProperty(
+				BaseBuild.BUILD_URLS_PROPERTIES_KEY, jobVariant, buildURL, false
+			);
+		}
+		else {
+			Mockito.verifyNoInteractions(buildDatabase);
+		}
+	}
+
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetBadBuildURLs() {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		Build.Invocation firstInvocation = new Build.Invocation(baseBuild);
+		Build.Invocation lastInvocation = new Build.Invocation(baseBuild);
+
+		String firstBuildURL = "https://test-1-1.liferay.com/job/test/1";
+
+		firstInvocation.setBuildURL(firstBuildURL);
+
+		lastInvocation.setBuildURL("https://test-1-1.liferay.com/job/test/3");
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_invocations",
+			Arrays.asList(
+				firstInvocation, new Build.Invocation(baseBuild),
+				lastInvocation));
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).getBadBuildURLs();
+
+		Assert.assertEquals(
+			Arrays.asList(firstBuildURL), baseBuild.getBadBuildURLs());
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -5,7 +5,10 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,6 +19,23 @@ import org.mockito.Mockito;
  * @author Kenji Heigel
  */
 public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testBuildDisplayNameComparator() {
+		BaseDownstreamBuild firstBaseDownstreamBuild = _mockDownstreamBuild(
+			"mock-downstream-1");
+		BaseDownstreamBuild lastBaseDownstreamBuild = _mockDownstreamBuild(
+			"mock-downstream-2");
+
+		List<Build> builds = new ArrayList<>(
+			Arrays.asList(lastBaseDownstreamBuild, firstBaseDownstreamBuild));
+
+		Collections.sort(builds, new BaseBuild.BuildDisplayNameComparator());
+
+		Assert.assertEquals(
+			Arrays.asList(firstBaseDownstreamBuild, lastBaseDownstreamBuild),
+			builds);
+	}
 
 	@Test
 	public void testGetBadBuildURLs() {
@@ -53,6 +73,24 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 			RandomTestUtil.randomString(), null, false);
 		_testSaveBuildURLInBuildDatabase(
 			null, RandomTestUtil.randomString(), false);
+	}
+
+	private BaseDownstreamBuild _mockDownstreamBuild(String jobName) {
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+
+		Mockito.when(
+			baseDownstreamBuild.getJobName()
+		).thenReturn(
+			jobName
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getDisplayName();
+
+		return baseDownstreamBuild;
 	}
 
 	private void _testSaveBuildURLInBuildDatabase(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -121,6 +121,83 @@ public class BaseDownstreamBuildTest
 	}
 
 	@Test
+	public void testSaveBadBuildURLsInBuildDatabase() {
+		String axisVariable = RandomTestUtil.randomString();
+		String buildURL = RandomTestUtil.randomString();
+		String jobVariant = RandomTestUtil.randomString();
+
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getAxisName();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getBadBuildCount();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getBadBuildURLs();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).saveBuildURLInBuildDatabase();
+
+		Mockito.when(
+			baseDownstreamBuild.getAxisVariable()
+		).thenReturn(
+			axisVariable
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildURL()
+		).thenReturn(
+			buildURL
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		String firstBuildURL = "https://test-1-1.liferay.com/job/test/1";
+
+		Build.Invocation firstInvocation = new Build.Invocation(
+			baseDownstreamBuild);
+
+		firstInvocation.setBuildURL(firstBuildURL);
+
+		ReflectionTestUtil.setFieldValue(
+			baseDownstreamBuild, "_invocations",
+			Arrays.asList(
+				firstInvocation, new Build.Invocation(baseDownstreamBuild),
+				new Build.Invocation(baseDownstreamBuild)));
+
+		baseDownstreamBuild.saveBuildURLInBuildDatabase();
+
+		Mockito.verify(
+			buildDatabase
+		).putProperty(
+			BaseBuild.BAD_BUILD_URLS_PROPERTIES_KEY,
+			jobVariant + "/" + axisVariable, firstBuildURL + ",unknown", false
+		);
+	}
+
+	@Test
 	public void testSaveBuildURLInBuildDatabase() {
 		_testSaveBuildURLInBuildDatabase(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -21,6 +21,18 @@ public class BaseDownstreamBuildTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testGetAxisName() {
+		String axisVariable = RandomTestUtil.randomString();
+		String jobVariant = RandomTestUtil.randomString();
+
+		_testGetAxisName(
+			axisVariable, jobVariant + "/" + axisVariable, jobVariant);
+
+		_testGetAxisName(axisVariable, null, null);
+		_testGetAxisName(null, null, jobVariant);
+	}
+
+	@Test
 	public void testGetGitHubMessageElement() {
 		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
 			BaseDownstreamBuild.class);
@@ -106,6 +118,33 @@ public class BaseDownstreamBuildTest
 		Assert.assertTrue(
 			gitHubMessageUpstreamJobFailureXML.contains(
 				upstreamJobFailureMarker));
+	}
+
+	private void _testGetAxisName(
+		String axisVariable, String expectedAxisName, String jobVariant) {
+
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getAxisName();
+
+		Mockito.when(
+			baseDownstreamBuild.getAxisVariable()
+		).thenReturn(
+			axisVariable
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		Assert.assertEquals(
+			expectedAxisName, baseDownstreamBuild.getAxisName());
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -120,6 +120,16 @@ public class BaseDownstreamBuildTest
 				upstreamJobFailureMarker));
 	}
 
+	@Test
+	public void testSaveBuildURLInBuildDatabase() {
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), true);
+		_testSaveBuildURLInBuildDatabase(
+			RandomTestUtil.randomString(), null, false);
+		_testSaveBuildURLInBuildDatabase(
+			null, RandomTestUtil.randomString(), false);
+	}
+
 	private void _testGetAxisName(
 		String axisVariable, String expectedAxisName, String jobVariant) {
 
@@ -145,6 +155,64 @@ public class BaseDownstreamBuildTest
 
 		Assert.assertEquals(
 			expectedAxisName, baseDownstreamBuild.getAxisName());
+	}
+
+	private void _testSaveBuildURLInBuildDatabase(
+		String buildURL, String jobVariant, boolean saved) {
+
+		String axisVariable = RandomTestUtil.randomString();
+
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+		BuildDatabase buildDatabase = Mockito.mock(BuildDatabase.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getAxisName();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).saveBuildURLInBuildDatabase();
+
+		Mockito.when(
+			baseDownstreamBuild.getAxisVariable()
+		).thenReturn(
+			axisVariable
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildDatabase()
+		).thenReturn(
+			buildDatabase
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getBuildURL()
+		).thenReturn(
+			buildURL
+		);
+
+		Mockito.when(
+			baseDownstreamBuild.getJobVariant()
+		).thenReturn(
+			jobVariant
+		);
+
+		baseDownstreamBuild.saveBuildURLInBuildDatabase();
+
+		if (saved) {
+			Mockito.verify(
+				buildDatabase
+			).putProperty(
+				BaseBuild.BUILD_URLS_PROPERTIES_KEY,
+				jobVariant + "/" + axisVariable, buildURL, false
+			);
+		}
+		else {
+			Mockito.verifyNoInteractions(buildDatabase);
+		}
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseDownstreamBuildTest.java
@@ -33,6 +33,37 @@ public class BaseDownstreamBuildTest
 	}
 
 	@Test
+	public void testGetDisplayName() {
+		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
+			BaseDownstreamBuild.class);
+
+		String jobName = RandomTestUtil.randomString();
+
+		Mockito.when(
+			baseDownstreamBuild.getJobName()
+		).thenReturn(
+			jobName
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseDownstreamBuild
+		).getDisplayName();
+
+		Assert.assertEquals(jobName, baseDownstreamBuild.getDisplayName());
+
+		String axisName = RandomTestUtil.randomString();
+
+		Mockito.when(
+			baseDownstreamBuild.getAxisName()
+		).thenReturn(
+			axisName
+		);
+
+		Assert.assertEquals(axisName, baseDownstreamBuild.getDisplayName());
+	}
+
+	@Test
 	public void testGetGitHubMessageElement() {
 		BaseDownstreamBuild baseDownstreamBuild = Mockito.mock(
 			BaseDownstreamBuild.class);


### PR DESCRIPTION
[LRCI-7941](https://liferay.atlassian.net/browse/LRCI-7941)

Revises [#4471](https://github.com/pyoo47/liferay-portal/pull/4471) (opened by @kenjiheigel) with the following follow-up commits:

- [053f330a65a4](https://github.com/pyoo47/liferay-portal/commit/053f330a65a4a317c7b277b5511cb4d993396394) LRCI-7941 Never report a null display name for a downstream build
- [9ab00c75451c](https://github.com/pyoo47/liferay-portal/commit/9ab00c75451ce84568f118dba03f3f1eb1d99636) LRCI-7941 Add unit tests for the display name fallback

## Summary

Making `getAxisName` nullable made `getDisplayName` and `getBuildName` nullable with it, since both forwarded it. That turned a previously dead branch live in `BaseBuild.BuildDisplayNameComparator`, whose `isNullOrEmpty(axisName)` check could never fire for a downstream build while an unresolved axis name came back as `"null/null"`. The fallback it guards dereferences the display name it just fell back to, and `BaseParentBuild` sorts with that comparator during report generation.

`getDisplayName` now falls back to the job name from `BaseBuild.getDisplayName`, restoring the invariant the comparator relies on, so the comparator itself needs no null check.
