### PR TITLE
LRCI-7951 Reuse the Testray OAuth token and diagnose 403 responses

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5978,7 +5978,7 @@ public class JenkinsResultsParserUtil {
 			return string.substring(0, 10) + "...";
 		}
 
-		private void _refreshToken() {
+		private synchronized void _refreshToken() {
 			Date currentDate = new Date();
 
 			if ((_tokenExpirationDate != null) &&
@@ -6011,9 +6011,9 @@ public class JenkinsResultsParserUtil {
 
 		private final String _clientId;
 		private final String _clientSecret;
-		private String _token;
-		private Date _tokenExpirationDate;
-		private String _tokenType;
+		private volatile String _token;
+		private volatile Date _tokenExpirationDate;
+		private volatile String _tokenType;
 		private final URL _tokenURL;
 
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5959,6 +5959,10 @@ public class JenkinsResultsParserUtil {
 					String.valueOf(_tokenURL)));
 		}
 
+		public synchronized void invalidateToken() {
+			_tokenExpirationDate = null;
+		}
+
 		@Override
 		public String toString() {
 			_refreshToken();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -461,6 +461,17 @@ public class UrlReader {
 					}
 
 					System.out.println(sb.toString());
+
+					if (httpAuthorization instanceof
+							ClientCredentialsHTTPAuthorization) {
+
+						ClientCredentialsHTTPAuthorization
+							clientCredentialsHTTPAuthorization =
+								(ClientCredentialsHTTPAuthorization)
+									httpAuthorization;
+
+						clientCredentialsHTTPAuthorization.invalidateToken();
+					}
 				}
 
 				Integer retryPeriodOverride = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -390,12 +390,12 @@ public class UrlReader {
 
 				return urlConnection.getInputStream();
 			}
-			catch (IOException ioException) {
-				if (ioException instanceof FileNotFoundException) {
-					throw ioException;
+			catch (IOException ioException1) {
+				if (ioException1 instanceof FileNotFoundException) {
+					throw ioException1;
 				}
 
-				if ((ioException instanceof UnknownHostException) &&
+				if ((ioException1 instanceof UnknownHostException) &&
 					url.matches("http://test-\\d+-\\d+/.*")) {
 
 					return doRead(
@@ -406,7 +406,7 @@ public class UrlReader {
 							"https://$1.liferay.com$2"));
 				}
 
-				String exceptionMessage = ioException.getMessage();
+				String exceptionMessage = ioException1.getMessage();
 
 				if (exceptionMessage.matches(
 						".*HTTP response code\\: 422 .*") &&
@@ -424,7 +424,43 @@ public class UrlReader {
 
 					System.out.println(sb.toString());
 
-					throw new RuntimeException(exceptionMessage, ioException);
+					throw new RuntimeException(exceptionMessage, ioException1);
+				}
+
+				Matcher testray2URLMatcher = _testray2URLPattern.matcher(url);
+
+				if (exceptionMessage.matches(
+						".*HTTP response code\\: 403 .*") &&
+					testray2URLMatcher.find() &&
+					(urlConnection instanceof HttpURLConnection)) {
+
+					HttpURLConnection httpURLConnection =
+						(HttpURLConnection)urlConnection;
+
+					StringBuilder sb = new StringBuilder();
+
+					sb.append(exceptionMessage);
+
+					try (InputStream errorInputStream =
+							httpURLConnection.getErrorStream()) {
+
+						if (errorInputStream != null) {
+							sb.append("\nError response:\n");
+							sb.append(
+								JenkinsResultsParserUtil.readInputStream(
+									errorInputStream));
+						}
+					}
+					catch (IOException ioException2) {
+						sb.append("\nUnable to read the error response");
+					}
+
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(postContent)) {
+						sb.append("\nPost content:\n");
+						sb.append(postContent);
+					}
+
+					System.out.println(sb.toString());
 				}
 
 				Integer retryPeriodOverride = null;
@@ -456,7 +492,7 @@ public class UrlReader {
 						(retryPeriodOverride > _SECONDS_RETRY_PERIOD_MAX)) {
 
 						throw new GitHubSecondaryRateLimitRuntimeException(
-							url, retryPeriodOverride, ioException);
+							url, retryPeriodOverride, ioException1);
 					}
 				}
 
@@ -469,7 +505,7 @@ public class UrlReader {
 				}
 
 				if ((maxRetries >= 0) && (retryCount >= maxRetries)) {
-					throw ioException;
+					throw ioException1;
 				}
 
 				System.out.println(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactory.java
@@ -746,6 +746,34 @@ public class TestrayFactory {
 
 		testrayServer = new TestrayServer(testrayServerURL);
 
+		try {
+			Properties buildProperties =
+				JenkinsResultsParserUtil.getBuildProperties();
+
+			String lxcEnvironment = testrayURLMatcher.group("lxcEnvironment");
+
+			String clientId = JenkinsResultsParserUtil.getProperty(
+				buildProperties, "testray.oauth2.client.id", lxcEnvironment);
+			String clientSecret = JenkinsResultsParserUtil.getProperty(
+				buildProperties, "testray.oauth2.client.secret",
+				lxcEnvironment);
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(clientId) &&
+				!JenkinsResultsParserUtil.isNullOrEmpty(clientSecret)) {
+
+				URL tokenURL = new URL(
+					testrayServer.getURL() + "/o/oauth2/token");
+
+				testrayServer.setHTTPAuthorization(
+					new JenkinsResultsParserUtil.
+						ClientCredentialsHTTPAuthorization(
+							clientId, clientSecret, tokenURL));
+			}
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+
 		_testrayServers.put(testrayServerURL, testrayServer);
 
 		return testrayServer;
@@ -814,7 +842,7 @@ public class TestrayFactory {
 		new ConcurrentHashMap<>();
 	private static final Pattern _testrayURLPattern = Pattern.compile(
 		"https://(testray\\.liferay\\.com|webserver-testray2" +
-			"(-prd\\d*|-uat\\d*)?.lfr.cloud)");
+			"(-(?<lxcEnvironment>prd\\d*|uat\\d*))?.lfr.cloud)");
 	private static final Map<Long, TopLevelStandaloneBuildTestrayCaseResult>
 		_topLevelBuildTestrayCaseResults = new ConcurrentHashMap<>();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.net.URL;
+
+import java.util.Date;
+
+import org.json.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Calum Ragan
+ */
+public class ClientCredentialsHTTPAuthorizationTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testToStringCachesToken() throws Exception {
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = _mockTokenRequest()) {
+
+			JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+				clientCredentialsHTTPAuthorization =
+					_newClientCredentialsHTTPAuthorization();
+
+			Assert.assertEquals(
+				"Bearer test-token",
+				clientCredentialsHTTPAuthorization.toString());
+			Assert.assertEquals(
+				"Bearer test-token",
+				clientCredentialsHTTPAuthorization.toString());
+
+			jenkinsResultsParserUtilMockedStatic.verify(
+				() -> JenkinsResultsParserUtil.toJSONObject(
+					Mockito.anyString(), Mockito.anyString()));
+		}
+	}
+
+	@Test
+	public void testToStringRefreshesExpiredToken() throws Exception {
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = _mockTokenRequest()) {
+
+			JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+				clientCredentialsHTTPAuthorization =
+					_newClientCredentialsHTTPAuthorization();
+
+			clientCredentialsHTTPAuthorization.toString();
+
+			ReflectionTestUtil.setFieldValue(
+				clientCredentialsHTTPAuthorization, "_tokenExpirationDate",
+				new Date(System.currentTimeMillis() - 1000L));
+
+			clientCredentialsHTTPAuthorization.toString();
+
+			jenkinsResultsParserUtilMockedStatic.verify(
+				() -> JenkinsResultsParserUtil.toJSONObject(
+					Mockito.anyString(), Mockito.anyString()),
+				Mockito.times(2));
+		}
+	}
+
+	private MockedStatic<JenkinsResultsParserUtil> _mockTokenRequest() {
+		MockedStatic<JenkinsResultsParserUtil>
+			jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
+				JenkinsResultsParserUtil.class);
+
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put(
+			"access_token", "test-token"
+		).put(
+			"expires_in", 600
+		).put(
+			"token_type", "Bearer"
+		);
+
+		jenkinsResultsParserUtilMockedStatic.when(
+			() -> JenkinsResultsParserUtil.toJSONObject(
+				Mockito.anyString(), Mockito.anyString())
+		).thenReturn(
+			jsonObject
+		);
+
+		return jenkinsResultsParserUtilMockedStatic;
+	}
+
+	private JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+			_newClientCredentialsHTTPAuthorization()
+		throws Exception {
+
+		return new JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization(
+			"test-client-id", "test-client-secret",
+			new URL("https://testray.liferay.com/o/oauth2/token"));
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -24,6 +24,28 @@ public class ClientCredentialsHTTPAuthorizationTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testInvalidateToken() throws Exception {
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = _mockTokenRequest()) {
+
+			JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+				clientCredentialsHTTPAuthorization =
+					_newClientCredentialsHTTPAuthorization();
+
+			clientCredentialsHTTPAuthorization.toString();
+
+			clientCredentialsHTTPAuthorization.invalidateToken();
+
+			clientCredentialsHTTPAuthorization.toString();
+
+			jenkinsResultsParserUtilMockedStatic.verify(
+				() -> JenkinsResultsParserUtil.toJSONObject(
+					Mockito.anyString(), Mockito.anyString()),
+				Mockito.times(2));
+		}
+	}
+
+	@Test
 	public void testToStringCachesToken() throws Exception {
 		try (MockedStatic<JenkinsResultsParserUtil>
 				jenkinsResultsParserUtilMockedStatic = _mockTokenRequest()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7951

## What Is Being Fixed

Testray reporting intermittently fails with an HTTP 403 from https://testray.liferay.com/o/c/caseresults, aborting case-result imports. UrlReader built a new ClientCredentialsHTTPAuthorization for every request to a Testray URL, so each of the up-to-200 concurrent case-result POSTs also minted a fresh OAuth token from /o/oauth2/token, flooding the endpoint. Build logs additionally show the same case result failing with a 403 on every retry while concurrent requests succeed, and the generic IOException hides the server's rejection reason, so the failures cannot be diagnosed from the logs.

## How It Is Being Fixed

UrlReader now caches one ClientCredentialsHTTPAuthorization per Testray base URL, so every testray2 caller reuses a single cached token instead of minting one per request. The token refresh is synchronized with volatile fields so concurrent threads share a single fetch. When a Testray request still returns a 403, UrlReader prints the error response body and the post content so the next failing build identifies the actual rejection reason, and invalidates the cached token so the retry authenticates with a newly minted one. Invalidation is conditional on the Authorization value the failing request sent, so late 403s from requests that used an already-replaced token do not discard the current token, and a wave of concurrent 403s collapses to exactly one mint.

## PR Check

**pr-check: PASS** — tested on `562360874305f9ff3cd964184d5844c70f60d3af`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "562360874305f9ff3cd964184d5844c70f60d3af"} -->

