### PR TITLE
LRCI-7860 Cache yarn setup on CI to avoid repeated installs

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -388,7 +388,11 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		return _testProperties;
 	}
 
-	public void setUpYarn() {
+	public synchronized void setUpYarn() {
+		if (_setUpYarn) {
+			return;
+		}
+
 		File workingDirectory = getWorkingDirectory();
 
 		try {
@@ -425,6 +429,8 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 				workingDirectory, "modules/node_modules_cache");
 
 			if (!nodeModulesCacheDir.exists()) {
+				_setUpYarn = true;
+
 				return;
 			}
 
@@ -465,6 +471,8 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 			throw new GitWorkingDirectoryRuntimeException(
 				this, "Failed to run setup-yarn in " + workingDirectory);
 		}
+
+		_setUpYarn = true;
 	}
 
 	public static class Module {
@@ -623,6 +631,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 	private List<File> _jsUnitFiles;
 	private List<File> _modifiedModuleDirs;
 	private Properties _releaseProperties;
+	private boolean _setUpYarn;
 	private Properties _testProperties;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -41,11 +41,18 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		String upstreamBranchName = getUpstreamBranchName();
 
 		if (!JenkinsResultsParserUtil.isCloudCINode() ||
-			upstreamBranchName.startsWith("ee-")) {
+			upstreamBranchName.startsWith("ee-") ||
+			!isGitArchiveYarnCacheEnabled()) {
 
 			return archiveFile;
 		}
 
+		createYarnCache(fileName);
+
+		return archiveFile;
+	}
+
+	public File createYarnCache(String fileName) {
 		setUpYarn();
 
 		GitUtil.ExecutionResult executionResult = executeBashCommands(
@@ -63,7 +70,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 					executionResult.getStandardError()));
 		}
 
-		return archiveFile;
+		return new File(getWorkingDirectory(), fileName);
 	}
 
 	public Properties getAppServerProperties() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -388,6 +388,29 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		return _testProperties;
 	}
 
+	public boolean isGitArchiveYarnCacheEnabled() {
+		String gitArchiveYarnCacheEnabled = null;
+
+		try {
+			gitArchiveYarnCacheEnabled =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"git.archive.yarn.cache.enabled",
+					Environment.get("CI_TEST_SUITE"),
+					Environment.get("JOB_NAME"));
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(
+				gitArchiveYarnCacheEnabled)) {
+
+			return true;
+		}
+
+		return Boolean.parseBoolean(gitArchiveYarnCacheEnabled);
+	}
+
 	public synchronized void setUpYarn() {
 		if (_setUpYarn) {
 			return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -329,7 +329,7 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
 					"binaries.cache.enabled", Environment.get("CI_TEST_SUITE"),
-					Environment.get("JOB_NAME")));
+					Environment.get("JOB_NAME"), getUpstreamBranchName()));
 		}
 		catch (IOException ioException) {
 			return true;
@@ -352,7 +352,7 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
 					"yarn.cache.enabled", Environment.get("CI_TEST_SUITE"),
-					Environment.get("JOB_NAME")));
+					Environment.get("JOB_NAME"), getUpstreamBranchName()));
 		}
 		catch (IOException ioException) {
 			return true;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 import org.json.JSONObject;
 
 /**
@@ -222,6 +224,38 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		super(remoteGitRef, upstreamBranchName);
 	}
 
+	protected void downloadYarnCache() {
+		String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
+
+		if (!CloudBucketUtil.isS3ObjectPathAvailable(yarnCacheS3ObjectPath)) {
+			return;
+		}
+
+		File yarnCacheFile = null;
+
+		try {
+			yarnCacheFile = File.createTempFile(
+				"yarn-cache", ".zip", getDirectory());
+
+			CloudBucketUtil.downloadS3File(
+				yarnCacheFile, yarnCacheS3ObjectPath);
+
+			JenkinsResultsParserUtil.unzip(yarnCacheFile, getDirectory());
+
+			System.out.println(
+				"Successfully unzipped " + yarnCacheS3ObjectPath + " to " +
+					getDirectory());
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+		finally {
+			if (yarnCacheFile != null) {
+				JenkinsResultsParserUtil.delete(yarnCacheFile);
+			}
+		}
+	}
+
 	protected Properties getPortalTestProperties() {
 		Properties testProperties = getProperties("portal.test.properties");
 
@@ -302,10 +336,37 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		}
 	}
 
+	protected boolean isYarnCacheAvailable() {
+		if (!JenkinsResultsParserUtil.isCloudCINode() ||
+			!CloudBucketUtil.isS3ObjectPathAvailable(
+				_getYarnCacheS3ObjectPath())) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	protected boolean isYarnCacheEnabled() {
+		try {
+			return Boolean.parseBoolean(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"yarn.cache.enabled", Environment.get("CI_TEST_SUITE"),
+					Environment.get("JOB_NAME")));
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+	}
+
 	@Override
 	protected void setUpAdditionalCaches() throws IOException {
 		if (isBinariesCacheEnabled()) {
 			setUpBinariesCache();
+		}
+
+		if (isYarnCacheEnabled()) {
+			setUpYarnCache();
 		}
 	}
 
@@ -367,6 +428,91 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		}
 	}
 
+	protected synchronized void setUpYarn() {
+		if (_setUpYarn || isSnapshot()) {
+			return;
+		}
+
+		PortalGitWorkingDirectory portalGitWorkingDirectory =
+			(PortalGitWorkingDirectory)getGitWorkingDirectory();
+
+		portalGitWorkingDirectory.setUpYarn();
+
+		_setUpYarn = true;
+	}
+
+	protected synchronized void setUpYarnCache() {
+		if (_setUpYarnCache || !isYarnCacheEnabled()) {
+			_setUpYarnCache = true;
+
+			return;
+		}
+
+		if (isSnapshot()) {
+			downloadYarnCache();
+
+			_setUpYarnCache = true;
+
+			return;
+		}
+
+		if (isYarnCacheAvailable()) {
+			downloadYarnCache();
+
+			touchYarnCache();
+
+			_setUpYarnCache = true;
+
+			return;
+		}
+
+		setUpYarn();
+
+		uploadYarnCache();
+
+		_setUpYarnCache = true;
+	}
+
+	protected void touchYarnCache() {
+		try {
+			CloudBucketUtil.touchS3File(_getYarnCacheS3ObjectPath());
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+	protected synchronized void uploadYarnCache() {
+		File yarnCacheFile = null;
+
+		try {
+			yarnCacheFile = File.createTempFile(
+				"yarn-cache", ".zip", getDirectory());
+
+			JenkinsResultsParserUtil.delete(yarnCacheFile);
+
+			String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
+
+			PortalGitWorkingDirectory portalGitWorkingDirectory =
+				(PortalGitWorkingDirectory)getGitWorkingDirectory();
+
+			portalGitWorkingDirectory.createYarnCache(yarnCacheFile.getName());
+
+			CloudBucketUtil.uploadS3File(yarnCacheS3ObjectPath, yarnCacheFile);
+
+			System.out.println(
+				"Successfully uploaded to " + yarnCacheS3ObjectPath);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+		finally {
+			if (yarnCacheFile != null) {
+				JenkinsResultsParserUtil.delete(yarnCacheFile);
+			}
+		}
+	}
+
 	private String _getLiferayFacesURL(
 		String repositoryName, String propertyName) {
 
@@ -404,6 +550,64 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			null, portalGitWorkingDirectory, upstreamBranchName, null,
 			portalGitWorkingDirectory.getGitRepositoryName(), "relevant",
 			upstreamBranchName);
+	}
+
+	private String _getYarnCacheS3ObjectPath() {
+		String yarnLockDigest = _getYarnLockDigest();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(yarnLockDigest)) {
+			return null;
+		}
+
+		try {
+			return JenkinsResultsParserUtil.combine(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"cloud.ci.s3.bucket.yarn.caches.path"),
+				"/", getName(), "/", yarnLockDigest, "/yarn-cache.zip");
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"WARNING: Unable to get " +
+					"\"cloud.ci.s3.bucket.yarn.caches.path\"");
+
+			return null;
+		}
+	}
+
+	private synchronized String _getYarnLockDigest() {
+		if (_yarnLockDigest != null) {
+			return _yarnLockDigest;
+		}
+
+		File yarnLockFile = new File(getDirectory(), "modules/yarn.lock");
+
+		if (!yarnLockFile.exists()) {
+			_yarnLockDigest = "";
+
+			return _yarnLockDigest;
+		}
+
+		try {
+			String yarnLockFileContent = JenkinsResultsParserUtil.read(
+				yarnLockFile);
+
+			yarnLockFileContent = yarnLockFileContent.replace(
+				"https://registry.yarnpkg.com",
+				JenkinsResultsParserUtil.getBuildProperty(
+					"portal.build.properties[nodejs.npm.ci.registry]"));
+
+			JenkinsResultsParserUtil.write(yarnLockFile, yarnLockFileContent);
+
+			_yarnLockDigest = DigestUtils.sha256Hex(
+				JenkinsResultsParserUtil.read(yarnLockFile));
+		}
+		catch (IOException ioException) {
+			_yarnLockDigest = "";
+
+			return _yarnLockDigest;
+		}
+
+		return _yarnLockDigest;
 	}
 
 	private void _writeAppServerPropertiesFile() {
@@ -453,5 +657,8 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 
 	private Properties _appServerProperties;
 	private boolean _setUpBinariesCache;
+	private boolean _setUpYarn;
+	private boolean _setUpYarnCache;
+	private String _yarnLockDigest;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7860

## What Is Being Fixed

Setting up yarn on a CI node is expensive, and the CI test infrastructure was paying that cost far more often than necessary. `setUpYarn` had no guard, so repeated calls within the same JVM re-ran the whole install. Beyond that, every build that needed yarn dependencies installed them from scratch, even though builds sharing the same `modules/yarn.lock` produce an identical cache — there was no way to reuse that work across builds, and no way to turn the git archive yarn caching off when a job did not want it.

## How It Is Being Fixed

`PortalGitWorkingDirectory.setUpYarn` is now `synchronized` and guarded by a `_setUpYarn` flag, so the install happens at most once per instance. The yarn-cache creation that was inlined in the git archive path is extracted into a public `createYarnCache` method, which lets the archive path and the new S3 cache path share it. That archive path is also gated behind a new `isGitArchiveYarnCacheEnabled` build property so a job can opt out.

`PortalWorkspaceGitRepository` gains the cross-build cache itself. The cache key is a SHA-256 digest of `modules/yarn.lock`, computed after rewriting the public `registry.yarnpkg.com` host to the internal CI registry so the digest reflects what will actually be installed. `setUpYarnCache` then either downloads an existing cache from S3 and touches it to keep it alive, or runs the yarn setup and uploads a fresh cache for later builds to reuse. Snapshots only ever download, never upload. Every step degrades gracefully: a missing build property, an unreadable lock file, or an unavailable S3 object falls back to the existing install-from-scratch behavior rather than failing the build.

Finally, the upstream branch name is added as a factor when resolving the `yarn.cache.enabled` and binaries-cache build properties, so the caching behavior can be tuned per branch.

## Why Are There No Tests?

This change is to the CI test infrastructure itself, which is exercised and validated by running builds on the CI cluster rather than by unit tests.

## PR Check

**pr-check: PASS** — tested on `012ea375c6c7ab1544adc1ff32f484c30db2870a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "012ea375c6c7ab1544adc1ff32f484c30db2870a"} -->
