### PR TITLE
LRCI-7943 Stop duplicating downstream builds that are still alive

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
@@ -103,6 +103,18 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 			_missingReinvocationCount++;
 			_missingTickCount = 0;
 
+			if (_hasMatchingBuild()) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"[", _build.getBuildName(),
+						"] Skipped reinvoking a build that is already queued ",
+						"or running"));
+
+				_build.setStatus("queued");
+
+				return;
+			}
+
 			_build.reset();
 
 			reinvoke();
@@ -225,6 +237,33 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 		}
 
 		return _MISSING_REINVOKE_TICK_COUNT_DEFAULT;
+	}
+
+	private boolean _hasMatchingBuild() {
+		Build build = getBuild();
+
+		Build.Invocation currentInvocation = build.getCurrentInvocation();
+
+		if (currentInvocation == null) {
+			return false;
+		}
+
+		JenkinsMaster jenkinsMaster = currentInvocation.getJenkinsMaster();
+
+		if (jenkinsMaster == null) {
+			return false;
+		}
+
+		String jobName = build.getJobName();
+		Map<String, String> parameters = build.getParameters();
+
+		if (jenkinsMaster.isBuildInProgress(jobName, parameters) ||
+			jenkinsMaster.isBuildQueued(jobName, parameters)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _hasMaximumInvocationCount() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
@@ -181,6 +181,8 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 
 	@Override
 	protected boolean isBuildRunning() {
+		Build build = getBuild();
+
 		try {
 			JSONObject buildJSONObject = _getBuildJSONObject();
 
@@ -188,29 +190,35 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 				return false;
 			}
 
-			Build build = getBuild();
-
 			build.setBuildURL(buildJSONObject.getString("url"));
-
-			build.saveBuildURLInBuildDatabase();
 
 			Build.Invocation buildInvocation = build.getCurrentInvocation();
 
 			buildInvocation.setQueueId(buildJSONObject.getLong("queueId"));
-
-			return true;
 		}
 		catch (Exception exception) {
 			exception.printStackTrace();
 
-			Build build = getBuild();
-
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
 					"[", build.getBuildName(), "] Unable to get build item"));
+
+			return false;
 		}
 
-		return false;
+		try {
+			build.saveBuildURLInBuildDatabase();
+		}
+		catch (Exception exception) {
+			exception.printStackTrace();
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"[", build.getBuildName(),
+					"] Unable to save the running build URL"));
+		}
+
+		return true;
 	}
 
 	private JSONObject _getBuildJSONObject() {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildUpdaterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildUpdaterTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BaseBuildUpdaterTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testRunMissing() {
+		_testRunMissing(false, false, 1, false, 1);
+		_testRunMissing(false, true, 0, false, 1);
+		_testRunMissing(true, false, 0, false, 1);
+		_testRunMissing(true, false, 0, true, 100);
+	}
+
+	private BaseBuildUpdater _mockBaseBuildUpdater(
+		boolean buildInProgress, boolean buildQueued) {
+
+		String jobName = RandomTestUtil.randomString();
+
+		Map<String, String> parameters = Collections.singletonMap(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+		Mockito.when(
+			jenkinsMaster.isBuildInProgress(jobName, parameters)
+		).thenReturn(
+			buildInProgress
+		);
+
+		Mockito.when(
+			jenkinsMaster.isBuildQueued(jobName, parameters)
+		).thenReturn(
+			buildQueued
+		);
+
+		Build build = Mockito.mock(Build.class);
+
+		Mockito.when(
+			build.getCurrentInvocation()
+		).thenReturn(
+			new Build.Invocation(
+				build, jenkinsMaster, RandomTestUtil.randomLong())
+		);
+
+		Mockito.when(
+			build.getJobName()
+		).thenReturn(
+			jobName
+		);
+
+		Mockito.when(
+			build.getParameters()
+		).thenReturn(
+			parameters
+		);
+
+		BaseBuildUpdater baseBuildUpdater = Mockito.mock(
+			BaseBuildUpdater.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuildUpdater
+		).getBuild();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuildUpdater
+		).runMissing();
+
+		ReflectionTestUtil.setFieldValue(baseBuildUpdater, "_build", build);
+
+		return baseBuildUpdater;
+	}
+
+	private void _testRunMissing(
+		boolean buildInProgress, boolean buildQueued,
+		int expectedReinvocationCount, boolean expectedReporting,
+		int tickCount) {
+
+		BaseBuildUpdater baseBuildUpdater = _mockBaseBuildUpdater(
+			buildInProgress, buildQueued);
+
+		for (int i = 0; i < tickCount; i++) {
+			ReflectionTestUtil.setFieldValue(
+				baseBuildUpdater, "_missingTickCount", Integer.MAX_VALUE - 1);
+
+			baseBuildUpdater.runMissing();
+		}
+
+		Mockito.verify(
+			baseBuildUpdater, Mockito.times(expectedReinvocationCount)
+		).reinvoke();
+
+		VerificationMode verificationMode = Mockito.never();
+
+		if (expectedReporting) {
+			verificationMode = Mockito.atLeastOnce();
+		}
+
+		Mockito.verify(
+			baseBuildUpdater.getBuild(), verificationMode
+		).setStatus(
+			"reporting"
+		);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/DefaultBuildUpdaterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/DefaultBuildUpdaterTest.java
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class DefaultBuildUpdaterTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testIsBuildRunning() {
+		String buildURL = RandomTestUtil.randomString();
+		long queueId = RandomTestUtil.randomLong();
+
+		JSONObject buildJSONObject = new JSONObject();
+
+		buildJSONObject.put(
+			"queueId", queueId
+		).put(
+			"url", buildURL
+		);
+
+		_testIsBuildRunning(Arrays.asList(buildJSONObject), true, 0, false);
+		_testIsBuildRunning(
+			Arrays.asList(buildJSONObject), true, queueId, true);
+
+		_testIsBuildRunning(Collections.emptyList(), false, queueId, false);
+		_testIsBuildRunning(null, false, queueId, false);
+	}
+
+	private Build _mockBuild(
+		JenkinsMaster jenkinsMaster, String jobName, long queueId) {
+
+		Build build = Mockito.mock(Build.class);
+
+		Mockito.when(
+			build.getCurrentInvocation()
+		).thenReturn(
+			new Build.Invocation(build, jenkinsMaster, queueId)
+		);
+
+		Mockito.when(
+			build.getJobName()
+		).thenReturn(
+			jobName
+		);
+
+		return build;
+	}
+
+	private JenkinsMaster _mockJenkinsMaster(
+		List<JSONObject> buildJSONObjects, String jobName) {
+
+		JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+		if (buildJSONObjects == null) {
+			Mockito.when(
+				jenkinsMaster.getBuildJSONObjects(jobName)
+			).thenThrow(
+				new RuntimeException()
+			);
+
+			return jenkinsMaster;
+		}
+
+		Mockito.when(
+			jenkinsMaster.getBuildJSONObjects(jobName)
+		).thenReturn(
+			buildJSONObjects
+		);
+
+		return jenkinsMaster;
+	}
+
+	private void _testIsBuildRunning(
+		List<JSONObject> buildJSONObjects, boolean expectedBuildRunning,
+		long invocationQueueId, boolean saveFailure) {
+
+		String jobName = RandomTestUtil.randomString();
+
+		Build build = _mockBuild(
+			_mockJenkinsMaster(buildJSONObjects, jobName), jobName,
+			invocationQueueId);
+
+		if (saveFailure) {
+			Mockito.doThrow(
+				new NullPointerException()
+			).when(
+				build
+			).saveBuildURLInBuildDatabase();
+		}
+
+		DefaultBuildUpdater defaultBuildUpdater = new DefaultBuildUpdater(
+			build);
+
+		Assert.assertEquals(
+			expectedBuildRunning, defaultBuildUpdater.isBuildRunning());
+
+		if (!expectedBuildRunning) {
+			return;
+		}
+
+		JSONObject buildJSONObject = buildJSONObjects.get(0);
+
+		Build.Invocation buildInvocation = build.getCurrentInvocation();
+
+		Assert.assertEquals(
+			buildJSONObject.getLong("queueId"), buildInvocation.getQueueId());
+
+		Mockito.verify(
+			build
+		).setBuildURL(
+			buildJSONObject.getString("url")
+		);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7943

## What Is Being Fixed

The downstream build tracker reinvoked builds that were still alive, so one requested run produced several real builds. On the LRCI-7528 staged tests root-cause-analysis-tool ran three times for every requested run. The cause is in DefaultBuildUpdater.isBuildRunning, which found the running build, set its build URL, then threw a NullPointerException while saving that URL to the build database because the job variant was null. The catch swallowed the exception and the method returned false, so the tracker concluded the build was not running, marked it missing and reinvoked it. Recovery only ever happened at completion through isBuildCompleted, the one detector on that path that does not save the URL.

## How It Is Being Fixed

The first commit makes isBuildRunning decide from the lookup alone. Recording the build URL is a side effect that can no longer flip the verdict, so a failure to persist it is logged and the method still reports the build as running. The second commit adds a liveness check before the missing path reinvokes. The new _hasMatchingBuild asks the Jenkins master whether a build with the same job name and parameters is already in progress or queued, reusing the isBuildInProgress and isBuildQueued pair that BasePortalControllerBuildRunner already calls, and skips the reinvocation when one is found. Both of those master calls swallow their own exceptions and return false, so a network failure or a timeout falls through to the existing reinvoke path.

## Note

The fix replaces master's duplicate reinvocations with a single liveness check, so the outcome now depends on that check being accurate. When a matching build is found the reinvocation is skipped and the missing counter still advances, so a build that wrongly appears alive twice is reported rather than reinvoked. Master reached that same terminal state by reinvoking twice on the way, which gave it extra chances to latch onto a build tracking could not otherwise resolve. Giving up those chances is the trade being made for not creating duplicate builds. The loop stays bounded either way and ends at reporting after the existing maximum of two.

## PR Check

**pr-check: PASS** — tested on `ccdc2941d89185c55d148e771ea270533a2f2198`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ccdc2941d89185c55d148e771ea270533a2f2198"} -->
