### PR TITLE
LRCI-7951 Reuse the Testray OAuth token and diagnose 403 responses (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5970,7 +5970,7 @@ public class JenkinsResultsParserUtil {
 		}
 
 		@Override
-		public String toString() {
+		public synchronized String toString() {
 			_refreshToken();
 
 			return _tokenType + " " + _token;
@@ -6021,9 +6021,9 @@ public class JenkinsResultsParserUtil {
 
 		private final String _clientId;
 		private final String _clientSecret;
-		private volatile String _token;
-		private volatile Date _tokenExpirationDate;
-		private volatile String _tokenType;
+		private String _token;
+		private Date _tokenExpirationDate;
+		private String _tokenType;
 		private final URL _tokenURL;
 
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5978,7 +5978,7 @@ public class JenkinsResultsParserUtil {
 			return string.substring(0, 10) + "...";
 		}
 
-		private void _refreshToken() {
+		private synchronized void _refreshToken() {
 			Date currentDate = new Date();
 
 			if ((_tokenExpirationDate != null) &&
@@ -6011,9 +6011,9 @@ public class JenkinsResultsParserUtil {
 
 		private final String _clientId;
 		private final String _clientSecret;
-		private String _token;
-		private Date _tokenExpirationDate;
-		private String _tokenType;
+		private volatile String _token;
+		private volatile Date _tokenExpirationDate;
+		private volatile String _tokenType;
 		private final URL _tokenURL;
 
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5959,6 +5959,16 @@ public class JenkinsResultsParserUtil {
 					String.valueOf(_tokenURL)));
 		}
 
+		synchronized void invalidateToken(String authorization) {
+			if ((authorization == null) ||
+				!authorization.equals(_tokenType + " " + _token)) {
+
+				return;
+			}
+
+			_tokenExpirationDate = null;
+		}
+
 		@Override
 		public String toString() {
 			_refreshToken();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5959,7 +5959,7 @@ public class JenkinsResultsParserUtil {
 					String.valueOf(_tokenURL)));
 		}
 
-		synchronized void invalidateToken(String authorization) {
+		public synchronized void invalidateToken(String authorization) {
 			if ((authorization == null) ||
 				!authorization.equals(_tokenType + " " + _token)) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -395,12 +395,12 @@ public class UrlReader {
 
 				return urlConnection.getInputStream();
 			}
-			catch (IOException ioException) {
-				if (ioException instanceof FileNotFoundException) {
-					throw ioException;
+			catch (IOException ioException1) {
+				if (ioException1 instanceof FileNotFoundException) {
+					throw ioException1;
 				}
 
-				if ((ioException instanceof UnknownHostException) &&
+				if ((ioException1 instanceof UnknownHostException) &&
 					url.matches("http://test-\\d+-\\d+/.*")) {
 
 					return doRead(
@@ -411,7 +411,7 @@ public class UrlReader {
 							"https://$1.liferay.com$2"));
 				}
 
-				String exceptionMessage = ioException.getMessage();
+				String exceptionMessage = ioException1.getMessage();
 
 				if (exceptionMessage.matches(
 						".*HTTP response code\\: 422 .*") &&
@@ -429,7 +429,44 @@ public class UrlReader {
 
 					System.out.println(sb.toString());
 
-					throw new RuntimeException(exceptionMessage, ioException);
+					throw new RuntimeException(exceptionMessage, ioException1);
+				}
+
+				Matcher testray2URLMatcher = _testray2URLPattern.matcher(url);
+
+				if (exceptionMessage.matches(
+						".*HTTP response code\\: 403 .*") &&
+					testray2URLMatcher.find() &&
+					(urlConnection instanceof HttpURLConnection)) {
+
+					HttpURLConnection httpURLConnection =
+						(HttpURLConnection)urlConnection;
+
+					StringBuilder sb = new StringBuilder();
+
+					sb.append(exceptionMessage);
+
+					try (InputStream errorInputStream =
+							httpURLConnection.getErrorStream()) {
+
+						if (errorInputStream != null) {
+							sb.append("\nError response:\n");
+							sb.append(
+								JenkinsResultsParserUtil.readInputStream(
+									errorInputStream));
+						}
+					}
+					catch (IOException ioException2) {
+						sb.append("\nUnable to read the error response: ");
+						sb.append(ioException2.getMessage());
+					}
+
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(postContent)) {
+						sb.append("\nPost content:\n");
+						sb.append(postContent);
+					}
+
+					System.out.println(sb.toString());
 				}
 
 				Integer retryPeriodOverride = null;
@@ -461,7 +498,7 @@ public class UrlReader {
 						(retryPeriodOverride > _SECONDS_RETRY_PERIOD_MAX)) {
 
 						throw new GitHubSecondaryRateLimitRuntimeException(
-							url, retryPeriodOverride, ioException);
+							url, retryPeriodOverride, ioException1);
 					}
 				}
 
@@ -474,7 +511,7 @@ public class UrlReader {
 				}
 
 				if ((maxRetries >= 0) && (retryCount >= maxRetries)) {
-					throw ioException;
+					throw ioException1;
 				}
 
 				System.out.println(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -28,7 +28,9 @@ import java.security.NoSuchAlgorithmException;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -243,12 +245,12 @@ public class UrlReader {
 				if ((httpAuthorization == null) && testray2URLMatcher.find() &&
 					!url.contains("/o/oauth2/token")) {
 
+					String baseURL = testray2URLMatcher.group("baseURL");
+
 					Properties buildProperties =
 						JenkinsResultsParserUtil.getBuildProperties();
 
-					URL tokenURL = new URL(
-						testray2URLMatcher.group("baseURL") +
-							"/o/oauth2/token");
+					URL tokenURL = new URL(baseURL + "/o/oauth2/token");
 
 					String lxcEnvironment = testray2URLMatcher.group(
 						"lxcEnvironment");
@@ -260,8 +262,11 @@ public class UrlReader {
 						buildProperties, "testray.oauth2.client.secret",
 						lxcEnvironment);
 
-					httpAuthorization = new ClientCredentialsHTTPAuthorization(
-						clientId, clientSecret, tokenURL);
+					httpAuthorization = _testrayHTTPAuthorizations.computeIfAbsent(
+						baseURL,
+						testrayBaseURL ->
+							new ClientCredentialsHTTPAuthorization(
+								clientId, clientSecret, tokenURL));
 				}
 
 				URL urlObject = new URL(url);
@@ -492,6 +497,8 @@ public class UrlReader {
 	private static final Pattern _testray2URLPattern = Pattern.compile(
 		"(?<baseURL>https://webserver-testray2(-(?<lxcEnvironment>.+))?" +
 			"\\.lfr\\.cloud|https://testray\\.liferay\\.com).*");
+	private static final Map<String, HTTPAuthorization>
+		_testrayHTTPAuthorizations = new ConcurrentHashMap<>();
 	private static final List<HttpRequestMethod> _updatingHttpRequestMethods =
 		Arrays.asList(
 			HttpRequestMethod.POST, HttpRequestMethod.PATCH,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -263,11 +263,12 @@ public class UrlReader {
 						buildProperties, "testray.oauth2.client.secret",
 						lxcEnvironment);
 
-					httpAuthorization = _testrayHTTPAuthorizations.computeIfAbsent(
-						baseURL,
-						testrayBaseURL ->
-							new ClientCredentialsHTTPAuthorization(
-								clientId, clientSecret, tokenURL));
+					httpAuthorization =
+						_testrayHTTPAuthorizations.computeIfAbsent(
+							baseURL,
+							testrayBaseURL ->
+								new ClientCredentialsHTTPAuthorization(
+									clientId, clientSecret, tokenURL));
 				}
 
 				URL urlObject = new URL(url);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -164,6 +164,7 @@ public class UrlReader {
 		int retryCount = 0;
 
 		while (true) {
+			String authorization = null;
 			URLConnection urlConnection = null;
 
 			try {
@@ -319,10 +320,12 @@ public class UrlReader {
 					}
 
 					if (httpAuthorization != null) {
+						authorization = httpAuthorization.toString();
+
 						httpURLConnection.setRequestProperty(
 							"accept", "application/json");
 						httpURLConnection.setRequestProperty(
-							"Authorization", httpAuthorization.toString());
+							"Authorization", authorization);
 
 						if (!testray1Request) {
 							httpURLConnection.setRequestProperty(
@@ -467,6 +470,18 @@ public class UrlReader {
 					}
 
 					System.out.println(sb.toString());
+
+					if (httpAuthorization instanceof
+							ClientCredentialsHTTPAuthorization) {
+
+						ClientCredentialsHTTPAuthorization
+							clientCredentialsHTTPAuthorization =
+								(ClientCredentialsHTTPAuthorization)
+									httpAuthorization;
+
+						clientCredentialsHTTPAuthorization.invalidateToken(
+							authorization);
+					}
 				}
 
 				Integer retryPeriodOverride = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -465,7 +465,9 @@ public class UrlReader {
 						sb.append(ioException2.getMessage());
 					}
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(postContent)) {
+					if ((maxRetries >= 0) && (retryCount >= maxRetries) &&
+						!JenkinsResultsParserUtil.isNullOrEmpty(postContent)) {
+
 						sb.append("\nPost content:\n");
 						sb.append(postContent);
 					}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -141,7 +141,8 @@ public class ClientCredentialsHTTPAuthorizationTest
 					".liferay.com/o/oauth2/token"));
 	}
 
-	private void _verifyTokenRequestCount(int expectedCount, UrlReader urlReader)
+	private void _verifyTokenRequestCount(
+			int expectedCount, UrlReader urlReader)
 		throws Exception {
 
 		Mockito.verify(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.ByteArrayInputStream;
+
+import java.net.URL;
+
+import java.util.Date;
+
+import org.json.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Calum Ragan
+ */
+public class ClientCredentialsHTTPAuthorizationTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testInvalidateToken() throws Exception {
+		UrlReader urlReader = _mockTokenRequest();
+
+		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+			clientCredentialsHTTPAuthorization =
+				_newClientCredentialsHTTPAuthorization();
+
+		String authorization = clientCredentialsHTTPAuthorization.toString();
+
+		clientCredentialsHTTPAuthorization.invalidateToken(authorization);
+
+		Assert.assertNotEquals(
+			authorization, clientCredentialsHTTPAuthorization.toString());
+
+		_verifyTokenRequestCount(2, urlReader);
+	}
+
+	@Test
+	public void testInvalidateTokenWhenAuthorizationIsStale() throws Exception {
+		UrlReader urlReader = _mockTokenRequest();
+
+		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+			clientCredentialsHTTPAuthorization =
+				_newClientCredentialsHTTPAuthorization();
+
+		String authorization = clientCredentialsHTTPAuthorization.toString();
+
+		clientCredentialsHTTPAuthorization.invalidateToken(authorization);
+
+		String newAuthorization = clientCredentialsHTTPAuthorization.toString();
+
+		clientCredentialsHTTPAuthorization.invalidateToken(authorization);
+
+		Assert.assertEquals(
+			newAuthorization, clientCredentialsHTTPAuthorization.toString());
+
+		_verifyTokenRequestCount(2, urlReader);
+	}
+
+	@Test
+	public void testToStringCachesToken() throws Exception {
+		UrlReader urlReader = _mockTokenRequest();
+
+		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+			clientCredentialsHTTPAuthorization =
+				_newClientCredentialsHTTPAuthorization();
+
+		String authorization = clientCredentialsHTTPAuthorization.toString();
+
+		Assert.assertEquals(
+			authorization, clientCredentialsHTTPAuthorization.toString());
+
+		_verifyTokenRequestCount(1, urlReader);
+	}
+
+	@Test
+	public void testToStringRefreshesExpiredToken() throws Exception {
+		UrlReader urlReader = _mockTokenRequest();
+
+		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+			clientCredentialsHTTPAuthorization =
+				_newClientCredentialsHTTPAuthorization();
+
+		String authorization = clientCredentialsHTTPAuthorization.toString();
+
+		ReflectionTestUtil.setFieldValue(
+			clientCredentialsHTTPAuthorization, "_tokenExpirationDate",
+			new Date(System.currentTimeMillis() - 1000));
+
+		Assert.assertNotEquals(
+			authorization, clientCredentialsHTTPAuthorization.toString());
+
+		_verifyTokenRequestCount(2, urlReader);
+	}
+
+	private UrlReader _mockTokenRequest() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		Mockito.doAnswer(
+			invocation -> {
+				JSONObject jsonObject = new JSONObject();
+
+				jsonObject.put(
+					"access_token", RandomTestUtil.randomString()
+				).put(
+					"expires_in", 600
+				).put(
+					"token_type", "Bearer"
+				);
+
+				String jsonObjectString = jsonObject.toString();
+
+				return new ByteArrayInputStream(jsonObjectString.getBytes());
+			}
+		).when(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.contains("/o/oauth2/token")
+		);
+
+		return urlReader;
+	}
+
+	private JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
+			_newClientCredentialsHTTPAuthorization()
+		throws Exception {
+
+		return new JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new URL(
+				"https://" + RandomTestUtil.randomString() +
+					".liferay.com/o/oauth2/token"));
+	}
+
+	private void _verifyTokenRequestCount(int expectedCount, UrlReader urlReader)
+		throws Exception {
+
+		Mockito.verify(
+			urlReader, Mockito.times(expectedCount)
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.anyString()
+		);
+	}
+
+}


### PR DESCRIPTION
[LRCI-7951](https://liferay.atlassian.net/browse/LRCI-7951)

Revises [#4477](https://github.com/pyoo47/liferay-portal/pull/4477) (opened by @CalumR23) with the following follow-up commits:

- [e7bcacfa858b](https://github.com/pyoo47/liferay-portal/commit/e7bcacfa858b5f3f9b2ec86b68cb2dfed591de69) LRCI-7951 Print the 403 post content only on the final attempt
- [1ba44d77a220](https://github.com/pyoo47/liferay-portal/commit/1ba44d77a220f808621705ce548edca3030fdba0) LRCI-7951 Read the token pair under the lock

## Summary

The 403 diagnostic dump printed the full case-result post body on every retry attempt. With `maxRetries` of 2 across 20 `TestrayImporter` threads, one 403 wave could emit up to 60 copies of case-result JSON and bury the diagnostics under Jenkins' console truncation. The post body now prints only on the attempt that gives up, gated on the same predicate the `throw` below already uses. The error response still prints on every attempt.

`ClientCredentialsHTTPAuthorization.toString()` becomes `synchronized` so the token type and value are read under the lock that guards them, which also makes the three new `volatile` modifiers unnecessary.
