### PR TITLE
LRCI-7943 Stop duplicating downstream builds that are still alive (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
@@ -103,6 +103,18 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 			_missingReinvocationCount++;
 			_missingTickCount = 0;
 
+			if (_hasMatchingBuild()) {
+				System.out.println(
+					JenkinsResultsParserUtil.combine(
+						"[", _build.getBuildName(),
+						"] Skipped reinvoking a build that is already queued ",
+						"or running"));
+
+				_build.setStatus("queued");
+
+				return;
+			}
+
 			_build.reset();
 
 			reinvoke();
@@ -225,6 +237,33 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 		}
 
 		return _MISSING_REINVOKE_TICK_COUNT_DEFAULT;
+	}
+
+	private boolean _hasMatchingBuild() {
+		Build build = getBuild();
+
+		Build.Invocation currentInvocation = build.getCurrentInvocation();
+
+		if (currentInvocation == null) {
+			return false;
+		}
+
+		JenkinsMaster jenkinsMaster = currentInvocation.getJenkinsMaster();
+
+		if (jenkinsMaster == null) {
+			return false;
+		}
+
+		String jobName = build.getJobName();
+		Map<String, String> parameters = build.getParameters();
+
+		if (jenkinsMaster.isBuildInProgress(jobName, parameters) ||
+			jenkinsMaster.isBuildQueued(jobName, parameters)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _hasMaximumInvocationCount() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.json.JSONObject;
+
 /**
  * @author Michael Hashimoto
  */
@@ -100,24 +102,15 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 		}
 
 		if (_missingReinvocationCount < _getMissingMaximumReinvocationCount()) {
-			_missingReinvocationCount++;
 			_missingTickCount = 0;
 
-			if (_hasMatchingBuild()) {
-				System.out.println(
-					JenkinsResultsParserUtil.combine(
-						"[", _build.getBuildName(),
-						"] Skipped reinvoking a build that is already queued ",
-						"or running"));
+			if (!_reattachMatchingBuild()) {
+				_missingReinvocationCount++;
 
-				_build.setStatus("queued");
+				_build.reset();
 
-				return;
+				reinvoke();
 			}
-
-			_build.reset();
-
-			reinvoke();
 
 			_build.setStatus("queued");
 
@@ -239,33 +232,6 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 		return _MISSING_REINVOKE_TICK_COUNT_DEFAULT;
 	}
 
-	private boolean _hasMatchingBuild() {
-		Build build = getBuild();
-
-		Build.Invocation currentInvocation = build.getCurrentInvocation();
-
-		if (currentInvocation == null) {
-			return false;
-		}
-
-		JenkinsMaster jenkinsMaster = currentInvocation.getJenkinsMaster();
-
-		if (jenkinsMaster == null) {
-			return false;
-		}
-
-		String jobName = build.getJobName();
-		Map<String, String> parameters = build.getParameters();
-
-		if (jenkinsMaster.isBuildInProgress(jobName, parameters) ||
-			jenkinsMaster.isBuildQueued(jobName, parameters)) {
-
-			return true;
-		}
-
-		return false;
-	}
-
 	private boolean _hasMaximumInvocationCount() {
 		Build build = getBuild();
 
@@ -336,6 +302,61 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 			}
 
 			_takeSlaveOffline(slaveOfflineRule);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _reattachMatchingBuild() {
+		Build build = getBuild();
+
+		Build.Invocation currentInvocation = build.getCurrentInvocation();
+
+		if (currentInvocation == null) {
+			return false;
+		}
+
+		JenkinsMaster jenkinsMaster = currentInvocation.getJenkinsMaster();
+
+		if (jenkinsMaster == null) {
+			return false;
+		}
+
+		Map<String, String> parameters = build.getParameters();
+
+		if (parameters.isEmpty()) {
+			return false;
+		}
+
+		String jobName = build.getJobName();
+
+		JSONObject buildJSONObject = jenkinsMaster.getInProgressBuildJSONObject(
+			jobName, parameters);
+
+		if (buildJSONObject != null) {
+			currentInvocation.setQueueId(buildJSONObject.getLong("queueId"));
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"[", build.getBuildName(),
+					"] Reattached to the running build ",
+					buildJSONObject.getString("url")));
+
+			return true;
+		}
+
+		JSONObject queueItemJSONObject = jenkinsMaster.getQueuedBuildJSONObject(
+			jobName, parameters);
+
+		if (queueItemJSONObject != null) {
+			currentInvocation.setQueueId(queueItemJSONObject.getLong("id"));
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"[", build.getBuildName(),
+					"] Reattached to the queued build"));
 
 			return true;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DefaultBuildUpdater.java
@@ -181,6 +181,8 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 
 	@Override
 	protected boolean isBuildRunning() {
+		Build build = getBuild();
+
 		try {
 			JSONObject buildJSONObject = _getBuildJSONObject();
 
@@ -188,29 +190,35 @@ public class DefaultBuildUpdater extends BaseBuildUpdater {
 				return false;
 			}
 
-			Build build = getBuild();
-
 			build.setBuildURL(buildJSONObject.getString("url"));
-
-			build.saveBuildURLInBuildDatabase();
 
 			Build.Invocation buildInvocation = build.getCurrentInvocation();
 
 			buildInvocation.setQueueId(buildJSONObject.getLong("queueId"));
-
-			return true;
 		}
 		catch (Exception exception) {
 			exception.printStackTrace();
 
-			Build build = getBuild();
-
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
 					"[", build.getBuildName(), "] Unable to get build item"));
+
+			return false;
 		}
 
-		return false;
+		try {
+			build.saveBuildURLInBuildDatabase();
+		}
+		catch (Exception exception) {
+			exception.printStackTrace();
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"[", build.getBuildName(),
+					"] Unable to save the running build URL"));
+		}
+
+		return true;
 	}
 
 	private JSONObject _getBuildJSONObject() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -405,6 +405,61 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return idleSlavesCount;
 	}
 
+	public JSONObject getInProgressBuildJSONObject(
+		String jobName, Map<String, String> buildParameters) {
+
+		try {
+			JSONObject jobJSONObject = JenkinsResultsParserUtil.toJSONObject(
+				JenkinsResultsParserUtil.combine(
+					getURL(), "/job/", jobName, "/api/json?",
+					"tree=builds[actions[parameters[name,value]],queueId,",
+					"result,url]"),
+				false, 5000);
+
+			JSONArray buildsJSONArray = jobJSONObject.optJSONArray("builds");
+
+			for (int i = 0; i < buildsJSONArray.length(); i++) {
+				JSONObject buildJSONObject = buildsJSONArray.optJSONObject(i);
+
+				if ((buildJSONObject == JSONObject.NULL) ||
+					!JenkinsResultsParserUtil.isNullOrEmpty(
+						buildJSONObject.optString("result"))) {
+
+					continue;
+				}
+
+				Map<String, String> parameters = _getParameters(
+					buildJSONObject);
+
+				boolean matchingBuildParameters = true;
+
+				for (Map.Entry<String, String> buildParameter :
+						buildParameters.entrySet()) {
+
+					String parameterValue = parameters.get(
+						buildParameter.getKey());
+
+					if (!Objects.equals(
+							buildParameter.getValue(), parameterValue)) {
+
+						matchingBuildParameters = false;
+
+						break;
+					}
+				}
+
+				if (matchingBuildParameters) {
+					return buildJSONObject;
+				}
+			}
+		}
+		catch (Exception exception) {
+			return null;
+		}
+
+		return null;
+	}
+
 	@Override
 	public JenkinsCohort getJenkinsCohort() {
 		if (_jenkinsCohort != null) {
@@ -514,6 +569,65 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		return onlineJenkinsSlavesCount;
+	}
+
+	public JSONObject getQueuedBuildJSONObject(
+		String jobName, Map<String, String> buildParameters) {
+
+		try {
+			JSONObject queueJSONObject = JenkinsResultsParserUtil.toJSONObject(
+				JenkinsResultsParserUtil.combine(
+					getURL(), "/queue/api/json?",
+					"tree=items[actions[parameters[name,value]],id,task[url]]"),
+				false, 5000);
+
+			JSONArray itemsJSONArray = queueJSONObject.optJSONArray("items");
+
+			for (int i = 0; i < itemsJSONArray.length(); i++) {
+				JSONObject itemJSONObject = itemsJSONArray.optJSONObject(i);
+
+				if (itemJSONObject == JSONObject.NULL) {
+					continue;
+				}
+
+				JSONObject taskJSONObject = itemJSONObject.optJSONObject(
+					"task");
+
+				String taskURL = taskJSONObject.optString("url", "");
+
+				if (!taskURL.contains("/" + jobName + "/")) {
+					continue;
+				}
+
+				Map<String, String> parameters = _getParameters(itemJSONObject);
+
+				boolean matchingBuildParameters = true;
+
+				for (Map.Entry<String, String> buildParameter :
+						buildParameters.entrySet()) {
+
+					String parameterValue = parameters.get(
+						buildParameter.getKey());
+
+					if (!Objects.equals(
+							buildParameter.getValue(), parameterValue)) {
+
+						matchingBuildParameters = false;
+
+						break;
+					}
+				}
+
+				if (matchingBuildParameters) {
+					return itemJSONObject;
+				}
+			}
+		}
+		catch (Exception exception) {
+			return null;
+		}
+
+		return null;
 	}
 
 	public Map<String, JSONObject> getQueuedBuildURLs() {
@@ -766,52 +880,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	public boolean isBuildInProgress(
 		String jobName, Map<String, String> buildParameters) {
 
-		try {
-			JSONObject jobJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					getURL(), "/job/", jobName, "/api/json?",
-					"tree=builds[actions[parameters[name,value]],result,url]"),
-				false, 5000);
-
-			JSONArray buildsJSONArray = jobJSONObject.optJSONArray("builds");
-
-			for (int i = 0; i < buildsJSONArray.length(); i++) {
-				JSONObject buildJSONObject = buildsJSONArray.optJSONObject(i);
-
-				if ((buildJSONObject == JSONObject.NULL) ||
-					!JenkinsResultsParserUtil.isNullOrEmpty(
-						buildJSONObject.optString("result"))) {
-
-					continue;
-				}
-
-				Map<String, String> parameters = _getParameters(
-					buildJSONObject);
-
-				boolean matchingBuildParameters = true;
-
-				for (Map.Entry<String, String> buildParameter :
-						buildParameters.entrySet()) {
-
-					String parameterValue = parameters.get(
-						buildParameter.getKey());
-
-					if (!Objects.equals(
-							buildParameter.getValue(), parameterValue)) {
-
-						matchingBuildParameters = false;
-
-						break;
-					}
-				}
-
-				if (matchingBuildParameters) {
-					return true;
-				}
-			}
-		}
-		catch (Exception exception) {
-			return false;
+		if (getInProgressBuildJSONObject(jobName, buildParameters) != null) {
+			return true;
 		}
 
 		return false;
@@ -820,57 +890,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	public boolean isBuildQueued(
 		String jobName, Map<String, String> buildParameters) {
 
-		try {
-			JSONObject queueJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					getURL(), "/queue/api/json?",
-					"tree=items[actions[parameters[name,value]],task[url]]"),
-				false, 5000);
-
-			JSONArray itemsJSONArray = queueJSONObject.optJSONArray("items");
-
-			for (int i = 0; i < itemsJSONArray.length(); i++) {
-				JSONObject itemJSONObject = itemsJSONArray.optJSONObject(i);
-
-				if (itemJSONObject == JSONObject.NULL) {
-					continue;
-				}
-
-				JSONObject taskJSONObject = itemJSONObject.optJSONObject(
-					"task");
-
-				String taskURL = taskJSONObject.optString("url", "");
-
-				if (!taskURL.contains("/" + jobName + "/")) {
-					continue;
-				}
-
-				Map<String, String> parameters = _getParameters(itemJSONObject);
-
-				boolean matchingBuildParameters = true;
-
-				for (Map.Entry<String, String> buildParameter :
-						buildParameters.entrySet()) {
-
-					String parameterValue = parameters.get(
-						buildParameter.getKey());
-
-					if (!Objects.equals(
-							buildParameter.getValue(), parameterValue)) {
-
-						matchingBuildParameters = false;
-
-						break;
-					}
-				}
-
-				if (matchingBuildParameters) {
-					return true;
-				}
-			}
-		}
-		catch (Exception exception) {
-			return false;
+		if (getQueuedBuildJSONObject(jobName, buildParameters) != null) {
+			return true;
 		}
 
 		return false;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildUpdaterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildUpdaterTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
+
+/**
+ * @author Kenji Heigel
+ */
+public class BaseBuildUpdaterTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testRunMissing() {
+		_testRunMissing(false, false, 1, false, 1);
+		_testRunMissing(false, true, 0, false, 1);
+		_testRunMissing(true, false, 0, false, 1);
+		_testRunMissing(true, false, 0, true, 100);
+	}
+
+	private BaseBuildUpdater _mockBaseBuildUpdater(
+		boolean buildInProgress, boolean buildQueued) {
+
+		String jobName = RandomTestUtil.randomString();
+
+		Map<String, String> parameters = Collections.singletonMap(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+		Mockito.when(
+			jenkinsMaster.isBuildInProgress(jobName, parameters)
+		).thenReturn(
+			buildInProgress
+		);
+
+		Mockito.when(
+			jenkinsMaster.isBuildQueued(jobName, parameters)
+		).thenReturn(
+			buildQueued
+		);
+
+		Build build = Mockito.mock(Build.class);
+
+		Mockito.when(
+			build.getCurrentInvocation()
+		).thenReturn(
+			new Build.Invocation(
+				build, jenkinsMaster, RandomTestUtil.randomLong())
+		);
+
+		Mockito.when(
+			build.getJobName()
+		).thenReturn(
+			jobName
+		);
+
+		Mockito.when(
+			build.getParameters()
+		).thenReturn(
+			parameters
+		);
+
+		BaseBuildUpdater baseBuildUpdater = Mockito.mock(
+			BaseBuildUpdater.class);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuildUpdater
+		).getBuild();
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuildUpdater
+		).runMissing();
+
+		ReflectionTestUtil.setFieldValue(baseBuildUpdater, "_build", build);
+
+		return baseBuildUpdater;
+	}
+
+	private void _testRunMissing(
+		boolean buildInProgress, boolean buildQueued,
+		int expectedReinvocationCount, boolean expectedReporting,
+		int tickCount) {
+
+		BaseBuildUpdater baseBuildUpdater = _mockBaseBuildUpdater(
+			buildInProgress, buildQueued);
+
+		for (int i = 0; i < tickCount; i++) {
+			ReflectionTestUtil.setFieldValue(
+				baseBuildUpdater, "_missingTickCount", Integer.MAX_VALUE - 1);
+
+			baseBuildUpdater.runMissing();
+		}
+
+		Mockito.verify(
+			baseBuildUpdater, Mockito.times(expectedReinvocationCount)
+		).reinvoke();
+
+		VerificationMode verificationMode = Mockito.never();
+
+		if (expectedReporting) {
+			verificationMode = Mockito.atLeastOnce();
+		}
+
+		Mockito.verify(
+			baseBuildUpdater.getBuild(), verificationMode
+		).setStatus(
+			"reporting"
+		);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildUpdaterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildUpdaterTest.java
@@ -8,6 +8,9 @@ package com.liferay.jenkins.results.parser;
 import java.util.Collections;
 import java.util.Map;
 
+import org.json.JSONObject;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -22,31 +25,72 @@ public class BaseBuildUpdaterTest
 	@Test
 	public void testRunMissing() {
 		_testRunMissing(false, false, 1, false, 1);
+		_testRunMissing(false, false, 2, true, 100);
 		_testRunMissing(false, true, 0, false, 1);
+		_testRunMissing(false, true, 0, false, 100);
 		_testRunMissing(true, false, 0, false, 1);
-		_testRunMissing(true, false, 0, true, 100);
+		_testRunMissing(true, false, 0, false, 100);
+	}
+
+	@Test
+	public void testRunMissingReattaches() {
+		_testRunMissingReattaches(false, true, _BUILD_QUEUED_ITEM_ID);
+		_testRunMissingReattaches(true, false, _BUILD_IN_PROGRESS_QUEUE_ID);
+	}
+
+	@Test
+	public void testRunMissingWithoutBuildParameters() {
+		BaseBuildUpdater baseBuildUpdater = _mockBaseBuildUpdater(
+			true, true, Collections.emptyMap());
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuildUpdater, "_missingTickCount", Integer.MAX_VALUE - 1);
+
+		baseBuildUpdater.runMissing();
+
+		Mockito.verify(
+			baseBuildUpdater
+		).reinvoke();
 	}
 
 	private BaseBuildUpdater _mockBaseBuildUpdater(
-		boolean buildInProgress, boolean buildQueued) {
+		boolean buildInProgress, boolean buildQueued,
+		Map<String, String> parameters) {
 
 		String jobName = RandomTestUtil.randomString();
 
-		Map<String, String> parameters = Collections.singletonMap(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
-
 		JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
 
-		Mockito.when(
-			jenkinsMaster.isBuildInProgress(jobName, parameters)
-		).thenReturn(
-			buildInProgress
-		);
+		JSONObject inProgressBuildJSONObject = null;
+
+		if (buildInProgress) {
+			inProgressBuildJSONObject = new JSONObject();
+
+			inProgressBuildJSONObject.put(
+				"queueId", _BUILD_IN_PROGRESS_QUEUE_ID
+			).put(
+				"url", RandomTestUtil.randomString()
+			);
+		}
 
 		Mockito.when(
-			jenkinsMaster.isBuildQueued(jobName, parameters)
+			jenkinsMaster.getInProgressBuildJSONObject(jobName, parameters)
 		).thenReturn(
-			buildQueued
+			inProgressBuildJSONObject
+		);
+
+		JSONObject queuedBuildJSONObject = null;
+
+		if (buildQueued) {
+			queuedBuildJSONObject = new JSONObject();
+
+			queuedBuildJSONObject.put("id", _BUILD_QUEUED_ITEM_ID);
+		}
+
+		Mockito.when(
+			jenkinsMaster.getQueuedBuildJSONObject(jobName, parameters)
+		).thenReturn(
+			queuedBuildJSONObject
 		);
 
 		Build build = Mockito.mock(Build.class);
@@ -94,7 +138,9 @@ public class BaseBuildUpdaterTest
 		int tickCount) {
 
 		BaseBuildUpdater baseBuildUpdater = _mockBaseBuildUpdater(
-			buildInProgress, buildQueued);
+			buildInProgress, buildQueued,
+			Collections.singletonMap(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
 
 		for (int i = 0; i < tickCount; i++) {
 			ReflectionTestUtil.setFieldValue(
@@ -119,5 +165,33 @@ public class BaseBuildUpdaterTest
 			"reporting"
 		);
 	}
+
+	private void _testRunMissingReattaches(
+		boolean buildInProgress, boolean buildQueued, long expectedQueueId) {
+
+		BaseBuildUpdater baseBuildUpdater = _mockBaseBuildUpdater(
+			buildInProgress, buildQueued,
+			Collections.singletonMap(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuildUpdater, "_missingTickCount", Integer.MAX_VALUE - 1);
+
+		baseBuildUpdater.runMissing();
+
+		Build build = baseBuildUpdater.getBuild();
+
+		Build.Invocation currentInvocation = build.getCurrentInvocation();
+
+		Assert.assertEquals(expectedQueueId, currentInvocation.getQueueId());
+
+		Mockito.verify(
+			baseBuildUpdater, Mockito.never()
+		).reinvoke();
+	}
+
+	private static final long _BUILD_IN_PROGRESS_QUEUE_ID = 1234;
+
+	private static final long _BUILD_QUEUED_ITEM_ID = 5678;
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/DefaultBuildUpdaterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/DefaultBuildUpdaterTest.java
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Kenji Heigel
+ */
+public class DefaultBuildUpdaterTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testIsBuildRunning() {
+		String buildURL = RandomTestUtil.randomString();
+		long queueId = RandomTestUtil.randomLong();
+
+		JSONObject buildJSONObject = new JSONObject();
+
+		buildJSONObject.put(
+			"queueId", queueId
+		).put(
+			"url", buildURL
+		);
+
+		_testIsBuildRunning(Arrays.asList(buildJSONObject), true, 0, false);
+		_testIsBuildRunning(
+			Arrays.asList(buildJSONObject), true, queueId, true);
+
+		_testIsBuildRunning(Collections.emptyList(), false, queueId, false);
+		_testIsBuildRunning(null, false, queueId, false);
+	}
+
+	private Build _mockBuild(
+		JenkinsMaster jenkinsMaster, String jobName, long queueId) {
+
+		Build build = Mockito.mock(Build.class);
+
+		Mockito.when(
+			build.getCurrentInvocation()
+		).thenReturn(
+			new Build.Invocation(build, jenkinsMaster, queueId)
+		);
+
+		Mockito.when(
+			build.getJobName()
+		).thenReturn(
+			jobName
+		);
+
+		return build;
+	}
+
+	private JenkinsMaster _mockJenkinsMaster(
+		List<JSONObject> buildJSONObjects, String jobName) {
+
+		JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);
+
+		if (buildJSONObjects == null) {
+			Mockito.when(
+				jenkinsMaster.getBuildJSONObjects(jobName)
+			).thenThrow(
+				new RuntimeException()
+			);
+
+			return jenkinsMaster;
+		}
+
+		Mockito.when(
+			jenkinsMaster.getBuildJSONObjects(jobName)
+		).thenReturn(
+			buildJSONObjects
+		);
+
+		return jenkinsMaster;
+	}
+
+	private void _testIsBuildRunning(
+		List<JSONObject> buildJSONObjects, boolean expectedBuildRunning,
+		long invocationQueueId, boolean saveFailure) {
+
+		String jobName = RandomTestUtil.randomString();
+
+		Build build = _mockBuild(
+			_mockJenkinsMaster(buildJSONObjects, jobName), jobName,
+			invocationQueueId);
+
+		if (saveFailure) {
+			Mockito.doThrow(
+				new NullPointerException()
+			).when(
+				build
+			).saveBuildURLInBuildDatabase();
+		}
+
+		DefaultBuildUpdater defaultBuildUpdater = new DefaultBuildUpdater(
+			build);
+
+		Assert.assertEquals(
+			expectedBuildRunning, defaultBuildUpdater.isBuildRunning());
+
+		if (!expectedBuildRunning) {
+			return;
+		}
+
+		JSONObject buildJSONObject = buildJSONObjects.get(0);
+
+		Build.Invocation buildInvocation = build.getCurrentInvocation();
+
+		Assert.assertEquals(
+			buildJSONObject.getLong("queueId"), buildInvocation.getQueueId());
+
+		Mockito.verify(
+			build
+		).setBuildURL(
+			buildJSONObject.getString("url")
+		);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/DefaultBuildUpdaterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/DefaultBuildUpdaterTest.java
@@ -25,7 +25,7 @@ public class DefaultBuildUpdaterTest
 	@Test
 	public void testIsBuildRunning() {
 		String buildURL = RandomTestUtil.randomString();
-		long queueId = RandomTestUtil.randomLong();
+		long queueId = Math.abs(RandomTestUtil.randomLong());
 
 		JSONObject buildJSONObject = new JSONObject();
 


### PR DESCRIPTION
[LRCI-7943](https://liferay.atlassian.net/browse/LRCI-7943)

Revises [#4478](https://github.com/pyoo47/liferay-portal/pull/4478) (opened by @kenjiheigel) with the following follow-up commits:

- [45909568d722](https://github.com/pyoo47/liferay-portal/commit/45909568d7225deb7a812567480294f62709cf01) LRCI-7943 Reattach to a live build instead of spending a reinvocation
- [500ec4543ca6](https://github.com/pyoo47/liferay-portal/commit/500ec4543ca69afe26066f3c59334727525d2baa) LRCI-7943 Add unit tests for reattaching a live build

## Summary

The liveness check added in #4478 answered only yes or no, so a build the master confirmed was alive stayed unfindable: the tracker's queue ID was stale, and `_getBuildJSONObject` matches only on the queue ID once one is set. Each confirmation also spent a reinvocation, so after `build.missing.max.reinvocation.count` confirmations the build was reported as failed while still running.

These commits pass the found build back instead. `JenkinsMaster` gains `getInProgressBuildJSONObject` and `getQueuedBuildJSONObject`, and `isBuildInProgress`/`isBuildQueued` become null checks over them, so their signatures are unchanged. `_reattachMatchingBuild` writes the found build's queue ID onto the current invocation, which is what the existing detectors look up, so the next tick records the URL and advances to running through the normal path. A confirmation no longer spends a reinvocation, which removes the trade described in #4478's Note section.
