### PR TITLE
LRCI-7951 Pin build properties so the auth test survives a cache reset

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -10,10 +10,12 @@ import java.io.ByteArrayInputStream;
 import java.net.URL;
 
 import java.util.Date;
+import java.util.Properties;
 
 import org.json.JSONObject;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -23,6 +25,18 @@ import org.mockito.Mockito;
  */
 public class ClientCredentialsHTTPAuthorizationTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	public void setUpBuildProperties() {
+		JenkinsMasterTestUtil.resetCaches();
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"jenkins.local.url[test-1-1]", "http://test-1-1");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+	}
 
 	@Test
 	public void testInvalidateToken() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7951

## What Is Being Fixed

`ClientCredentialsHTTPAuthorizationTest` only passes because a static cache survives between its own test methods. The `ClientCredentialsHTTPAuthorization` constructor calls `isJenkinsMaster()`, which calls `JenkinsMaster.getInstance(...)`; on a cache miss `computeIfAbsent` runs the `JenkinsMaster` constructor, which reads `build.properties` through `UrlReader`. The test stubs only URLs containing `/o/oauth2/token`, so that read falls through to `mockUrlReader()`'s default answer and throws. The first test method to run populates `JenkinsMaster._jenkinsMasters`, so the remaining methods get a cache hit and never reach the constructor — which is the only reason they pass today.

Adding a cache reset to the shared base `Test.tearDown()` makes every method after the first fail with `AssertionError: No output set for URL: file:///<workspace>/liferay-jenkins-ee/build.properties`. Because the dependency is between test methods inside one class, test ordering across classes never exposes it, so it would bite the next person who tidies up `Test.tearDown()`. Note also that `isJenkinsMaster()` catches `Exception`, but the mock throws `AssertionError`, so the intended `return false` is bypassed and the failure surfaces instead of being swallowed.

## How It Is Being Fixed

Reset the `JenkinsMaster` caches and pin build properties in a `@Before`, following the pattern in `PortalWorkspaceGitRepositoryTest`. Pinning the properties makes `getBuildProperties()` return without reading a URL, and the reset means every method exercises the constructor path rather than passing on a warm cache, so the class is hermetic under either regime. The pinned properties are non-empty on purpose: `getBuildProperties()` only short-circuits when the cached map is non-empty, so an empty `Properties` still falls through to the URL read.

Reported by @pyoo47 while working LRCI-7936.

## PR Check

**pr-check: PASS** — tested on `ae4aa49b43fc0df9244b757b3d2f2cbed3b0079e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ae4aa49b43fc0df9244b757b3d2f2cbed3b0079e"} -->
