### PR TITLE
LRCI-7860 Cache yarn dependencies in S3 to speed up CI setup (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CloudBucketUtil.java
@@ -374,7 +374,7 @@ public class CloudBucketUtil {
 	}
 
 	public static boolean isS3ObjectPathAvailable(String s3ObjectPath) {
-		if (!_isValidS3ObjectPath(s3ObjectPath)) {
+		if (!isValidS3ObjectPath(s3ObjectPath)) {
 			return false;
 		}
 
@@ -396,7 +396,7 @@ public class CloudBucketUtil {
 	}
 
 	public static boolean isS3ObjectRefAvailable(String s3ObjectPath) {
-		if (!_isValidS3ObjectPath(s3ObjectPath)) {
+		if (!isValidS3ObjectPath(s3ObjectPath)) {
 			System.out.println(
 				"WARNING: Invalid s3 object path: " + s3ObjectPath);
 
@@ -406,6 +406,17 @@ public class CloudBucketUtil {
 		File s3ObjectRefFile = _getS3ObjectRefFile(s3ObjectPath);
 
 		return s3ObjectRefFile.exists();
+	}
+
+	public static boolean isValidS3ObjectPath(String s3ObjectPath) {
+		if (s3ObjectPath == null) {
+			return false;
+		}
+
+		Matcher s3ObjectPathMatcher = _s3ObjectPathPattern.matcher(
+			s3ObjectPath);
+
+		return s3ObjectPathMatcher.find();
 	}
 
 	public static String listGCPFiles(String path, String... args)
@@ -962,17 +973,6 @@ public class CloudBucketUtil {
 		return false;
 	}
 
-	private static boolean _isValidS3ObjectPath(String s3ObjectPath) {
-		if (s3ObjectPath == null) {
-			return false;
-		}
-
-		Matcher s3ObjectPathMatcher = _s3ObjectPathPattern.matcher(
-			s3ObjectPath);
-
-		return s3ObjectPathMatcher.find();
-	}
-
 	private static String _replaceS3ObjectPath(String s3ObjectPath) {
 		Matcher s3ObjectPathMatcher = _s3ObjectPathPattern.matcher(
 			s3ObjectPath);
@@ -1061,7 +1061,7 @@ public class CloudBucketUtil {
 	}
 
 	private static void _validateS3ObjectPath(String s3ObjectPath) {
-		if (!_isValidS3ObjectPath(s3ObjectPath)) {
+		if (!isValidS3ObjectPath(s3ObjectPath)) {
 			throw new RuntimeException(
 				"Invalid S3 object path: " + s3ObjectPath);
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -395,29 +395,6 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		return _testProperties;
 	}
 
-	public boolean isGitArchiveYarnCacheEnabled() {
-		String gitArchiveYarnCacheEnabled = null;
-
-		try {
-			gitArchiveYarnCacheEnabled =
-				JenkinsResultsParserUtil.getBuildProperty(
-					"git.archive.yarn.cache.enabled",
-					Environment.get("CI_TEST_SUITE"),
-					Environment.get("JOB_NAME"));
-		}
-		catch (IOException ioException) {
-			return true;
-		}
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(
-				gitArchiveYarnCacheEnabled)) {
-
-			return true;
-		}
-
-		return Boolean.parseBoolean(gitArchiveYarnCacheEnabled);
-	}
-
 	public synchronized void setUpYarn() {
 		if (_setUpYarn) {
 			return;
@@ -612,6 +589,29 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		}
 
 		return filteredEnv;
+	}
+
+	protected boolean isGitArchiveYarnCacheEnabled() {
+		String gitArchiveYarnCacheEnabled = null;
+
+		try {
+			gitArchiveYarnCacheEnabled =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"git.archive.yarn.cache.enabled",
+					Environment.get("CI_TEST_SUITE"),
+					Environment.get("JOB_NAME"), getUpstreamBranchName());
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(
+				gitArchiveYarnCacheEnabled)) {
+
+			return true;
+		}
+
+		return Boolean.parseBoolean(gitArchiveYarnCacheEnabled);
 	}
 
 	private boolean _isNPMTestModuleDir(File moduleDir) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -388,7 +388,11 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		return _testProperties;
 	}
 
-	public void setUpYarn() {
+	public synchronized void setUpYarn() {
+		if (_setUpYarn) {
+			return;
+		}
+
 		File workingDirectory = getWorkingDirectory();
 
 		try {
@@ -425,6 +429,8 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 				workingDirectory, "modules/node_modules_cache");
 
 			if (!nodeModulesCacheDir.exists()) {
+				_setUpYarn = true;
+
 				return;
 			}
 
@@ -465,6 +471,8 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 			throw new GitWorkingDirectoryRuntimeException(
 				this, "Failed to run setup-yarn in " + workingDirectory);
 		}
+
+		_setUpYarn = true;
 	}
 
 	public static class Module {
@@ -623,6 +631,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 	private List<File> _jsUnitFiles;
 	private List<File> _modifiedModuleDirs;
 	private Properties _releaseProperties;
+	private boolean _setUpYarn;
 	private Properties _testProperties;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -41,11 +41,18 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		String upstreamBranchName = getUpstreamBranchName();
 
 		if (!JenkinsResultsParserUtil.isCloudCINode() ||
-			upstreamBranchName.startsWith("ee-")) {
+			upstreamBranchName.startsWith("ee-") ||
+			!isGitArchiveYarnCacheEnabled()) {
 
 			return archiveFile;
 		}
 
+		createYarnCache(fileName);
+
+		return archiveFile;
+	}
+
+	public File createYarnCache(String fileName) {
 		setUpYarn();
 
 		GitUtil.ExecutionResult executionResult = executeBashCommands(
@@ -63,7 +70,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 					executionResult.getStandardError()));
 		}
 
-		return archiveFile;
+		return new File(getWorkingDirectory(), fileName);
 	}
 
 	public Properties getAppServerProperties() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -388,6 +388,29 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		return _testProperties;
 	}
 
+	public boolean isGitArchiveYarnCacheEnabled() {
+		String gitArchiveYarnCacheEnabled = null;
+
+		try {
+			gitArchiveYarnCacheEnabled =
+				JenkinsResultsParserUtil.getBuildProperty(
+					"git.archive.yarn.cache.enabled",
+					Environment.get("CI_TEST_SUITE"),
+					Environment.get("JOB_NAME"));
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(
+				gitArchiveYarnCacheEnabled)) {
+
+			return true;
+		}
+
+		return Boolean.parseBoolean(gitArchiveYarnCacheEnabled);
+	}
+
 	public synchronized void setUpYarn() {
 		if (_setUpYarn) {
 			return;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -42,7 +42,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 
 		if (!JenkinsResultsParserUtil.isCloudCINode() ||
 			upstreamBranchName.startsWith("ee-") ||
-			!isGitArchiveYarnCacheEnabled()) {
+			!_isGitArchiveYarnCacheEnabled()) {
 
 			return archiveFile;
 		}
@@ -591,7 +591,7 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 		return filteredEnv;
 	}
 
-	protected boolean isGitArchiveYarnCacheEnabled() {
+	private boolean _isGitArchiveYarnCacheEnabled() {
 		String gitArchiveYarnCacheEnabled = null;
 
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalGitWorkingDirectory.java
@@ -55,18 +55,26 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 	public File createYarnCache(String fileName) {
 		setUpYarn();
 
+		StringBuilder sb = new StringBuilder();
+
+		for (String excludeRegex : _BINARIES_CACHE_EXCLUDE_REGEXES) {
+			sb.append(" | grep -v '");
+			sb.append(excludeRegex);
+			sb.append("'");
+		}
+
 		GitUtil.ExecutionResult executionResult = executeBashCommands(
 			3, GitUtil.MILLIS_RETRY_DELAY, 1000 * 60 * 10,
 			JenkinsResultsParserUtil.combine(
-				"zip -r -y ", fileName,
-				" $(git ls-files --directory --no-empty-directory --others | ",
-				"grep -v \\\\.gradle/) modules/yarn.lock"));
+				"zip -q -r -y ", fileName,
+				" $(git ls-files --directory --no-empty-directory --others ",
+				sb.toString(), ") modules/yarn.lock"));
 
 		if (executionResult.getExitValue() != 0) {
 			throw new GitWorkingDirectoryRuntimeException(
 				this,
 				JenkinsResultsParserUtil.combine(
-					"Failed to add build/node to ", fileName, "\n",
+					"Unable to create the yarn cache ", fileName, "\n",
 					executionResult.getStandardError()));
 		}
 
@@ -653,6 +661,10 @@ public class PortalGitWorkingDirectory extends GitWorkingDirectory {
 
 		return false;
 	}
+
+	private static final String[] _BINARIES_CACHE_EXCLUDE_REGEXES = {
+		"\\.gradle/", "\\.yarn/", "modules/\\.tsc/", "node_modules_cache/"
+	};
 
 	private static final Pattern _esBuildFileNamePattern = Pattern.compile(
 		"@esbuild-(linux-.*?)-.*");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -329,7 +329,7 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
 					"binaries.cache.enabled", Environment.get("CI_TEST_SUITE"),
-					Environment.get("JOB_NAME")));
+					Environment.get("JOB_NAME"), getUpstreamBranchName()));
 		}
 		catch (IOException ioException) {
 			return true;
@@ -352,7 +352,7 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			return Boolean.parseBoolean(
 				JenkinsResultsParserUtil.getBuildProperty(
 					"yarn.cache.enabled", Environment.get("CI_TEST_SUITE"),
-					Environment.get("JOB_NAME")));
+					Environment.get("JOB_NAME"), getUpstreamBranchName()));
 		}
 		catch (IOException ioException) {
 			return true;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -444,8 +444,10 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 	}
 
 	protected synchronized void setUpYarnCache() {
-		if (_setUpYarnCache) {
-			_setUpYarnCache = true;
+		String upstreamBranchName = getUpstreamBranchName();
+
+		if (!JenkinsResultsParserUtil.isCloudCINode() || _setUpYarnCache ||
+			upstreamBranchName.startsWith("ee-")) {
 
 			return;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -243,8 +243,9 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			JenkinsResultsParserUtil.unzip(yarnCacheFile, getDirectory());
 
 			System.out.println(
-				"Successfully unzipped " + yarnCacheS3ObjectPath + " to " +
-					getDirectory());
+				JenkinsResultsParserUtil.combine(
+					"Successfully unzipped ", yarnCacheS3ObjectPath, " to ",
+					JenkinsResultsParserUtil.getCanonicalPath(getDirectory())));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
@@ -491,12 +492,12 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 
 			JenkinsResultsParserUtil.delete(yarnCacheFile);
 
-			String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
-
 			PortalGitWorkingDirectory portalGitWorkingDirectory =
 				(PortalGitWorkingDirectory)getGitWorkingDirectory();
 
 			portalGitWorkingDirectory.createYarnCache(yarnCacheFile.getName());
+
+			String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
 
 			CloudBucketUtil.uploadS3File(yarnCacheS3ObjectPath, yarnCacheFile);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -605,13 +605,9 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(nodejsNpmCiRegistry)) {
 				yarnLockFileContent = yarnLockFileContent.replace(
 					"https://registry.yarnpkg.com", nodejsNpmCiRegistry);
-
-				JenkinsResultsParserUtil.write(
-					yarnLockFile, yarnLockFileContent);
 			}
 
-			_yarnLockDigest = DigestUtils.sha256Hex(
-				JenkinsResultsParserUtil.read(yarnLockFile));
+			_yarnLockDigest = DigestUtils.sha256Hex(yarnLockFileContent);
 		}
 		catch (IOException ioException) {
 			_yarnLockDigest = "";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -596,12 +596,17 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			String yarnLockFileContent = JenkinsResultsParserUtil.read(
 				yarnLockFile);
 
-			yarnLockFileContent = yarnLockFileContent.replace(
-				"https://registry.yarnpkg.com",
+			String nodejsNpmCiRegistry =
 				JenkinsResultsParserUtil.getBuildProperty(
-					"portal.build.properties[nodejs.npm.ci.registry]"));
+					"portal.build.properties[nodejs.npm.ci.registry]");
 
-			JenkinsResultsParserUtil.write(yarnLockFile, yarnLockFileContent);
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(nodejsNpmCiRegistry)) {
+				yarnLockFileContent = yarnLockFileContent.replace(
+					"https://registry.yarnpkg.com", nodejsNpmCiRegistry);
+
+				JenkinsResultsParserUtil.write(
+					yarnLockFile, yarnLockFileContent);
+			}
 
 			_yarnLockDigest = DigestUtils.sha256Hex(
 				JenkinsResultsParserUtil.read(yarnLockFile));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -443,7 +443,7 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 	}
 
 	protected synchronized void setUpYarnCache() {
-		if (_setUpYarnCache || !isYarnCacheEnabled()) {
+		if (_setUpYarnCache) {
 			_setUpYarnCache = true;
 
 			return;
@@ -495,8 +495,6 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		try {
 			yarnCacheFile = File.createTempFile(
 				"yarn-cache", ".zip", getDirectory());
-
-			JenkinsResultsParserUtil.delete(yarnCacheFile);
 
 			PortalGitWorkingDirectory portalGitWorkingDirectory =
 				(PortalGitWorkingDirectory)getGitWorkingDirectory();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -228,7 +228,8 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
 
 		if (!CloudBucketUtil.isS3ObjectPathAvailable(yarnCacheS3ObjectPath)) {
-			return;
+			throw new RuntimeException(
+				"Unable to download " + yarnCacheS3ObjectPath);
 		}
 
 		File yarnCacheFile = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -496,10 +496,13 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			yarnCacheFile = File.createTempFile(
 				"yarn-cache", ".zip", getDirectory());
 
+			JenkinsResultsParserUtil.delete(yarnCacheFile);
+
 			PortalGitWorkingDirectory portalGitWorkingDirectory =
 				(PortalGitWorkingDirectory)getGitWorkingDirectory();
 
-			portalGitWorkingDirectory.createYarnCache(yarnCacheFile.getName());
+			yarnCacheFile = portalGitWorkingDirectory.createYarnCache(
+				yarnCacheFile.getName());
 
 			CloudBucketUtil.uploadS3File(yarnCacheS3ObjectPath, yarnCacheFile);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -484,6 +484,12 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 	}
 
 	protected synchronized void uploadYarnCache() {
+		String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
+
+		if (!CloudBucketUtil.isValidS3ObjectPath(yarnCacheS3ObjectPath)) {
+			return;
+		}
+
 		File yarnCacheFile = null;
 
 		try {
@@ -496,8 +502,6 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 				(PortalGitWorkingDirectory)getGitWorkingDirectory();
 
 			portalGitWorkingDirectory.createYarnCache(yarnCacheFile.getName());
-
-			String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
 
 			CloudBucketUtil.uploadS3File(yarnCacheS3ObjectPath, yarnCacheFile);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PortalWorkspaceGitRepository.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 import org.json.JSONObject;
 
 /**
@@ -222,6 +224,38 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		super(remoteGitRef, upstreamBranchName);
 	}
 
+	protected void downloadYarnCache() {
+		String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
+
+		if (!CloudBucketUtil.isS3ObjectPathAvailable(yarnCacheS3ObjectPath)) {
+			return;
+		}
+
+		File yarnCacheFile = null;
+
+		try {
+			yarnCacheFile = File.createTempFile(
+				"yarn-cache", ".zip", getDirectory());
+
+			CloudBucketUtil.downloadS3File(
+				yarnCacheFile, yarnCacheS3ObjectPath);
+
+			JenkinsResultsParserUtil.unzip(yarnCacheFile, getDirectory());
+
+			System.out.println(
+				"Successfully unzipped " + yarnCacheS3ObjectPath + " to " +
+					getDirectory());
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+		finally {
+			if (yarnCacheFile != null) {
+				JenkinsResultsParserUtil.delete(yarnCacheFile);
+			}
+		}
+	}
+
 	protected Properties getPortalTestProperties() {
 		Properties testProperties = getProperties("portal.test.properties");
 
@@ -302,10 +336,37 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		}
 	}
 
+	protected boolean isYarnCacheAvailable() {
+		if (!JenkinsResultsParserUtil.isCloudCINode() ||
+			!CloudBucketUtil.isS3ObjectPathAvailable(
+				_getYarnCacheS3ObjectPath())) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	protected boolean isYarnCacheEnabled() {
+		try {
+			return Boolean.parseBoolean(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"yarn.cache.enabled", Environment.get("CI_TEST_SUITE"),
+					Environment.get("JOB_NAME")));
+		}
+		catch (IOException ioException) {
+			return true;
+		}
+	}
+
 	@Override
 	protected void setUpAdditionalCaches() throws IOException {
 		if (isBinariesCacheEnabled()) {
 			setUpBinariesCache();
+		}
+
+		if (isYarnCacheEnabled()) {
+			setUpYarnCache();
 		}
 	}
 
@@ -367,6 +428,91 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		}
 	}
 
+	protected synchronized void setUpYarn() {
+		if (_setUpYarn || isSnapshot()) {
+			return;
+		}
+
+		PortalGitWorkingDirectory portalGitWorkingDirectory =
+			(PortalGitWorkingDirectory)getGitWorkingDirectory();
+
+		portalGitWorkingDirectory.setUpYarn();
+
+		_setUpYarn = true;
+	}
+
+	protected synchronized void setUpYarnCache() {
+		if (_setUpYarnCache || !isYarnCacheEnabled()) {
+			_setUpYarnCache = true;
+
+			return;
+		}
+
+		if (isSnapshot()) {
+			downloadYarnCache();
+
+			_setUpYarnCache = true;
+
+			return;
+		}
+
+		if (isYarnCacheAvailable()) {
+			downloadYarnCache();
+
+			touchYarnCache();
+
+			_setUpYarnCache = true;
+
+			return;
+		}
+
+		setUpYarn();
+
+		uploadYarnCache();
+
+		_setUpYarnCache = true;
+	}
+
+	protected void touchYarnCache() {
+		try {
+			CloudBucketUtil.touchS3File(_getYarnCacheS3ObjectPath());
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
+	protected synchronized void uploadYarnCache() {
+		File yarnCacheFile = null;
+
+		try {
+			yarnCacheFile = File.createTempFile(
+				"yarn-cache", ".zip", getDirectory());
+
+			JenkinsResultsParserUtil.delete(yarnCacheFile);
+
+			String yarnCacheS3ObjectPath = _getYarnCacheS3ObjectPath();
+
+			PortalGitWorkingDirectory portalGitWorkingDirectory =
+				(PortalGitWorkingDirectory)getGitWorkingDirectory();
+
+			portalGitWorkingDirectory.createYarnCache(yarnCacheFile.getName());
+
+			CloudBucketUtil.uploadS3File(yarnCacheS3ObjectPath, yarnCacheFile);
+
+			System.out.println(
+				"Successfully uploaded to " + yarnCacheS3ObjectPath);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+		finally {
+			if (yarnCacheFile != null) {
+				JenkinsResultsParserUtil.delete(yarnCacheFile);
+			}
+		}
+	}
+
 	private String _getLiferayFacesURL(
 		String repositoryName, String propertyName) {
 
@@ -404,6 +550,64 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			null, portalGitWorkingDirectory, upstreamBranchName, null,
 			portalGitWorkingDirectory.getGitRepositoryName(), "relevant",
 			upstreamBranchName);
+	}
+
+	private String _getYarnCacheS3ObjectPath() {
+		String yarnLockDigest = _getYarnLockDigest();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(yarnLockDigest)) {
+			return null;
+		}
+
+		try {
+			return JenkinsResultsParserUtil.combine(
+				JenkinsResultsParserUtil.getBuildProperty(
+					"cloud.ci.s3.bucket.yarn.caches.path"),
+				"/", getName(), "/", yarnLockDigest, "/yarn-cache.zip");
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"WARNING: Unable to get " +
+					"\"cloud.ci.s3.bucket.yarn.caches.path\"");
+
+			return null;
+		}
+	}
+
+	private synchronized String _getYarnLockDigest() {
+		if (_yarnLockDigest != null) {
+			return _yarnLockDigest;
+		}
+
+		File yarnLockFile = new File(getDirectory(), "modules/yarn.lock");
+
+		if (!yarnLockFile.exists()) {
+			_yarnLockDigest = "";
+
+			return _yarnLockDigest;
+		}
+
+		try {
+			String yarnLockFileContent = JenkinsResultsParserUtil.read(
+				yarnLockFile);
+
+			yarnLockFileContent = yarnLockFileContent.replace(
+				"https://registry.yarnpkg.com",
+				JenkinsResultsParserUtil.getBuildProperty(
+					"portal.build.properties[nodejs.npm.ci.registry]"));
+
+			JenkinsResultsParserUtil.write(yarnLockFile, yarnLockFileContent);
+
+			_yarnLockDigest = DigestUtils.sha256Hex(
+				JenkinsResultsParserUtil.read(yarnLockFile));
+		}
+		catch (IOException ioException) {
+			_yarnLockDigest = "";
+
+			return _yarnLockDigest;
+		}
+
+		return _yarnLockDigest;
 	}
 
 	private void _writeAppServerPropertiesFile() {
@@ -453,5 +657,8 @@ public class PortalWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 
 	private Properties _appServerProperties;
 	private boolean _setUpBinariesCache;
+	private boolean _setUpYarn;
+	private boolean _setUpYarnCache;
+	private String _yarnLockDigest;
 
 }


### PR DESCRIPTION
[LRCI-7860](https://liferay.atlassian.net/browse/LRCI-7860)

Revises [#4481](https://github.com/pyoo47/liferay-portal/pull/4481) (opened by @michaelhashimoto) with the following follow-up commits:

- [84c9001c85d2](https://github.com/pyoo47/liferay-portal/commit/84c9001c85d29c5cf17774a222aac880a4dfa41c) LRCI-7860 Fail when the yarn cache cannot be downloaded
- [28d378ff5d9e](https://github.com/pyoo47/liferay-portal/commit/28d378ff5d9ead0f57d7f517250b98b8ab3604d4) LRCI-7860 Hash the yarn lock content without rewriting the file
- [227fad8a4b62](https://github.com/pyoo47/liferay-portal/commit/227fad8a4b629df73f84d3250180caf2340e9b42) LRCI-7860 Skip the yarn cache on non-cloud nodes and ee- branches
