### PR TITLE
LRCI-7951 Pin build properties so the auth test survives a cache reset (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -10,10 +10,12 @@ import java.io.ByteArrayInputStream;
 import java.net.URL;
 
 import java.util.Date;
+import java.util.Properties;
 
 import org.json.JSONObject;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.mockito.Mockito;
@@ -23,6 +25,18 @@ import org.mockito.Mockito;
  */
 public class ClientCredentialsHTTPAuthorizationTest
 	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	public void setUpBuildProperties() {
+		JenkinsMasterTestUtil.resetCaches();
+
+		Properties buildProperties = new Properties();
+
+		buildProperties.setProperty(
+			"jenkins.local.url[test-1-1]", "http://test-1-1");
+
+		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+	}
 
 	@Test
 	public void testInvalidateToken() throws Exception {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 
 import org.json.JSONObject;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,14 +29,20 @@ public class ClientCredentialsHTTPAuthorizationTest
 
 	@Before
 	public void setUpBuildProperties() {
-		JenkinsMasterTestUtil.resetCaches();
-
 		Properties buildProperties = new Properties();
 
 		buildProperties.setProperty(
 			"jenkins.local.url[test-1-1]", "http://test-1-1");
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayInputStream;
 import java.net.URL;
 
 import java.util.Date;
-import java.util.Properties;
 
 import org.json.JSONObject;
 
@@ -29,12 +28,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 
 	@Before
 	public void setUpBuildProperties() {
-		Properties buildProperties = new Properties();
-
-		buildProperties.setProperty(
-			"jenkins.local.url[test-1-1]", "http://test-1-1");
-
-		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
+		JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 1);
 	}
 
 	@After


### PR DESCRIPTION
[LRCI-7951](https://liferay.atlassian.net/browse/LRCI-7951)

Revises [#4483](https://github.com/pyoo47/liferay-portal/pull/4483) (opened by @CalumR23) with the following follow-up commits:

- [d65b9e6007d1](https://github.com/pyoo47/liferay-portal/commit/d65b9e6007d1c4124d4c026219f3d168cb9cc6ed) LRCI-7951 Reset the Jenkins master caches in tearDown
- [688826e4f5d4](https://github.com/pyoo47/liferay-portal/commit/688826e4f5d4e0c9fac9233d20c380c6d016fded) LRCI-7951 Build the test properties with JenkinsMasterTestUtil

## Summary

Aligns the new `@Before` in `ClientCredentialsHTTPAuthorizationTest` with the conventions its two sibling tests already establish. `JenkinsMasterTestUtil.resetCaches()` moves into an `@After` `tearDown()` override that calls `super.tearDown()` first, matching `LoadBalancerUtilTest` and `JenkinsMasterTest`, so the class no longer hands dirty static `JenkinsMaster` state to whatever runs next.

The hand-rolled one-entry `Properties` is replaced by `JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 1)`. That retires the `jenkins.local.url[test-1-1]` literal, which could never satisfy a lookup anyway since `JenkinsMaster` also requires a matching `jenkins.remote.url[...]`, and it standardizes on the `test-9` fixture cohort used elsewhere.
