### PR TITLE
LRCI-7958 Add the metrics emitter MonitorMetricsWriter

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
@@ -7,10 +7,8 @@ package com.liferay.jenkins.results.parser.monitor;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Brittney Nguyen
@@ -20,16 +18,7 @@ public class MonitorEngine {
 	public MonitorEngine(
 		MonitorResultStore monitorResultStore, List<Monitor> monitors) {
 
-		Set<String> ids = new HashSet<>();
-
-		for (Monitor monitor : monitors) {
-			String id = monitor.getId();
-
-			if (!ids.add(id)) {
-				throw new IllegalArgumentException(
-					"Duplicate monitor ID: " + id);
-			}
-		}
+		MonitorIdValidator.validate(monitors);
 
 		_monitorResultStore = monitorResultStore;
 		_monitors = monitors;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorEngine.java
@@ -7,8 +7,10 @@ package com.liferay.jenkins.results.parser.monitor;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Brittney Nguyen
@@ -17,6 +19,17 @@ public class MonitorEngine {
 
 	public MonitorEngine(
 		MonitorResultStore monitorResultStore, List<Monitor> monitors) {
+
+		Set<String> ids = new HashSet<>();
+
+		for (Monitor monitor : monitors) {
+			String id = monitor.getId();
+
+			if (!ids.add(id)) {
+				throw new IllegalArgumentException(
+					"Duplicate monitor ID: " + id);
+			}
+		}
 
 		_monitorResultStore = monitorResultStore;
 		_monitors = monitors;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidator.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorIdValidator {
+
+	public static void validate(List<Monitor> monitors) {
+		Set<String> ids = new HashSet<>();
+
+		for (Monitor monitor : monitors) {
+			String id = monitor.getId();
+
+			if (!ids.add(id)) {
+				throw new IllegalArgumentException(
+					"Duplicate monitor ID: " + id);
+			}
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorMetricsWriter {
+
+	public MonitorMetricsWriter(
+		File metricsFile, MonitorResultStore monitorResultStore,
+		List<Monitor> monitors) {
+
+		_metricsFile = metricsFile;
+		_monitorResultStore = monitorResultStore;
+		_monitors = monitors;
+	}
+
+	public void write() throws IOException {
+		File temporaryFile = new File(
+			_metricsFile.getParentFile(), _metricsFile.getName() + ".tmp");
+
+		JenkinsResultsParserUtil.write(temporaryFile, _getContent());
+
+		Files.move(
+			temporaryFile.toPath(), _metricsFile.toPath(),
+			StandardCopyOption.ATOMIC_MOVE);
+	}
+
+	private String _escapeLabelValue(String labelValue) {
+		labelValue = labelValue.replace("\\", "\\\\");
+
+		labelValue = labelValue.replace("\"", "\\\"");
+
+		return labelValue.replace("\n", "\\n");
+	}
+
+	private String _getCheckLastRunTimestampLine(
+		Monitor monitor, MonitorResult monitorResult) {
+
+		return JenkinsResultsParserUtil.combine(
+			"monitor_check_last_run_timestamp_seconds{", _getLabels(monitor),
+			"} ", String.valueOf(_getLastRunTimestamp(monitorResult)));
+	}
+
+	private String _getCheckStatusLine(
+		Monitor monitor, MonitorResult monitorResult) {
+
+		return JenkinsResultsParserUtil.combine(
+			"monitor_check_status{", _getLabels(monitor), "} ",
+			String.valueOf(_getSeverityRank(monitorResult)));
+	}
+
+	private String _getContent() {
+		Map<Monitor, MonitorResult> monitorResultsMap = new LinkedHashMap<>();
+
+		for (Monitor monitor : _monitors) {
+			monitorResultsMap.put(
+				monitor,
+				_monitorResultStore.getLatestMonitorResult(monitor.getId()));
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(
+			"# HELP monitor_check_status Monitor status severity rank, 0 OK, " +
+				"1 UNKNOWN, 2 WARN, 3 CRITICAL\n");
+		sb.append("# TYPE monitor_check_status gauge\n");
+
+		for (Map.Entry<Monitor, MonitorResult> entry :
+				monitorResultsMap.entrySet()) {
+
+			sb.append(_getCheckStatusLine(entry.getKey(), entry.getValue()));
+			sb.append("\n");
+		}
+
+		sb.append(
+			"# HELP monitor_check_last_run_timestamp_seconds Unix timestamp " +
+				"of the last check run, 0 if never run\n");
+		sb.append("# TYPE monitor_check_last_run_timestamp_seconds gauge\n");
+
+		for (Map.Entry<Monitor, MonitorResult> entry :
+				monitorResultsMap.entrySet()) {
+
+			sb.append(
+				_getCheckLastRunTimestampLine(
+					entry.getKey(), entry.getValue()));
+			sb.append("\n");
+		}
+
+		sb.append(
+			"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of " +
+				"the last completed monitor cycle\n");
+		sb.append("# TYPE monitor_heartbeat_timestamp_seconds gauge\n");
+		sb.append("monitor_heartbeat_timestamp_seconds ");
+		sb.append(JenkinsResultsParserUtil.getCurrentTimeMillis() / 1000);
+		sb.append("\n");
+
+		return sb.toString();
+	}
+
+	private String _getLabels(Monitor monitor) {
+		MonitorConfig monitorConfig = monitor.getMonitorConfig();
+
+		MonitorConfig.Severity severity = monitorConfig.getSeverity();
+
+		String severityName = severity.name();
+
+		return JenkinsResultsParserUtil.combine(
+			"check=\"", _escapeLabelValue(monitor.getId()), "\",severity=\"",
+			severityName.toLowerCase(Locale.ENGLISH), "\",type=\"",
+			_escapeLabelValue(monitorConfig.getType()), "\"");
+	}
+
+	private long _getLastRunTimestamp(MonitorResult monitorResult) {
+		if (monitorResult == null) {
+			return 0;
+		}
+
+		return monitorResult.getTimestamp() / 1000;
+	}
+
+	private int _getSeverityRank(MonitorResult monitorResult) {
+		if (monitorResult == null) {
+			return MonitorResult.Status.UNKNOWN.getSeverityRank();
+		}
+
+		MonitorResult.Status status = monitorResult.getStatus();
+
+		if (status == null) {
+			return MonitorResult.Status.UNKNOWN.getSeverityRank();
+		}
+
+		return status.getSeverityRank();
+	}
+
+	private final File _metricsFile;
+	private final MonitorResultStore _monitorResultStore;
+	private final List<Monitor> _monitors;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -88,7 +88,7 @@ public class MonitorMetricsWriter {
 
 		sb.append(
 			"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of " +
-				"the last completed monitor cycle\n");
+				"the last metrics write\n");
 		sb.append("# TYPE monitor_heartbeat_timestamp_seconds gauge\n");
 		sb.append("monitor_heartbeat_timestamp_seconds ");
 		sb.append(JenkinsResultsParserUtil.getCurrentTimeMillis() / 1000);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -27,6 +27,8 @@ public class MonitorMetricsWriter {
 		File metricsFile, MonitorResultStore monitorResultStore,
 		List<Monitor> monitors) {
 
+		MonitorIdValidator.validate(monitors);
+
 		_metricsFile = metricsFile;
 		_monitorResultStore = monitorResultStore;
 		_monitors = monitors;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -122,12 +122,22 @@ public class MonitorMetricsWriter {
 
 		MonitorConfig.Severity severity = monitorConfig.getSeverity();
 
+		if (severity == null) {
+			severity = MonitorConfig.Severity.MEDIUM;
+		}
+
 		String severityName = severity.name();
+
+		String type = monitorConfig.getType();
+
+		if (type == null) {
+			type = "unknown";
+		}
 
 		return JenkinsResultsParserUtil.combine(
 			"check=\"", _escapeLabelValue(monitor.getId()), "\",severity=\"",
 			severityName.toLowerCase(Locale.ENGLISH), "\",type=\"",
-			_escapeLabelValue(monitorConfig.getType()), "\"");
+			_escapeLabelValue(type), "\"");
 	}
 
 	private long _getLastRunTimestamp(MonitorResult monitorResult) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -13,10 +13,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author Brittney Nguyen
@@ -53,31 +51,19 @@ public class MonitorMetricsWriter {
 		return labelValue.replace("\n", "\\n");
 	}
 
-	private String _getCheckLastRunTimestampLine(
-		Monitor monitor, MonitorResult monitorResult) {
-
+	private String _getCheckLastRunTimestampLine(Monitor monitor) {
 		return JenkinsResultsParserUtil.combine(
 			"monitor_check_last_run_timestamp_seconds{", _getLabels(monitor),
-			"} ", String.valueOf(_getLastRunTimestampSeconds(monitorResult)));
+			"} ", String.valueOf(_getLastRunTimestampSeconds(monitor)));
 	}
 
-	private String _getCheckStatusLine(
-		Monitor monitor, MonitorResult monitorResult) {
-
+	private String _getCheckStatusLine(Monitor monitor) {
 		return JenkinsResultsParserUtil.combine(
 			"monitor_check_status{", _getLabels(monitor), "} ",
-			String.valueOf(_getSeverityRank(monitorResult)));
+			String.valueOf(_getSeverityRank(monitor)));
 	}
 
 	private String _getContent() {
-		Map<Monitor, MonitorResult> monitorResultsMap = new LinkedHashMap<>();
-
-		for (Monitor monitor : _monitors) {
-			monitorResultsMap.put(
-				monitor,
-				_monitorResultStore.getLatestMonitorResult(monitor.getId()));
-		}
-
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(
@@ -85,10 +71,8 @@ public class MonitorMetricsWriter {
 				"1 UNKNOWN, 2 WARN, 3 CRITICAL\n");
 		sb.append("# TYPE monitor_check_status gauge\n");
 
-		for (Map.Entry<Monitor, MonitorResult> entry :
-				monitorResultsMap.entrySet()) {
-
-			sb.append(_getCheckStatusLine(entry.getKey(), entry.getValue()));
+		for (Monitor monitor : _monitors) {
+			sb.append(_getCheckStatusLine(monitor));
 			sb.append("\n");
 		}
 
@@ -97,12 +81,8 @@ public class MonitorMetricsWriter {
 				"of the last check run, 0 if never run\n");
 		sb.append("# TYPE monitor_check_last_run_timestamp_seconds gauge\n");
 
-		for (Map.Entry<Monitor, MonitorResult> entry :
-				monitorResultsMap.entrySet()) {
-
-			sb.append(
-				_getCheckLastRunTimestampLine(
-					entry.getKey(), entry.getValue()));
+		for (Monitor monitor : _monitors) {
+			sb.append(_getCheckLastRunTimestampLine(monitor));
 			sb.append("\n");
 		}
 
@@ -140,7 +120,10 @@ public class MonitorMetricsWriter {
 			_escapeLabelValue(type), "\"");
 	}
 
-	private long _getLastRunTimestampSeconds(MonitorResult monitorResult) {
+	private long _getLastRunTimestampSeconds(Monitor monitor) {
+		MonitorResult monitorResult =
+			_monitorResultStore.getLatestMonitorResult(monitor.getId());
+
 		if (monitorResult == null) {
 			return 0;
 		}
@@ -148,7 +131,10 @@ public class MonitorMetricsWriter {
 		return monitorResult.getTimestamp() / 1000;
 	}
 
-	private int _getSeverityRank(MonitorResult monitorResult) {
+	private int _getSeverityRank(Monitor monitor) {
+		MonitorResult monitorResult =
+			_monitorResultStore.getLatestMonitorResult(monitor.getId());
+
 		if (monitorResult == null) {
 			return MonitorResult.Status.UNKNOWN.getSeverityRank();
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -58,7 +58,7 @@ public class MonitorMetricsWriter {
 
 		return JenkinsResultsParserUtil.combine(
 			"monitor_check_last_run_timestamp_seconds{", _getLabels(monitor),
-			"} ", String.valueOf(_getLastRunTimestamp(monitorResult)));
+			"} ", String.valueOf(_getLastRunTimestampSeconds(monitorResult)));
 	}
 
 	private String _getCheckStatusLine(
@@ -140,7 +140,7 @@ public class MonitorMetricsWriter {
 			_escapeLabelValue(type), "\"");
 	}
 
-	private long _getLastRunTimestamp(MonitorResult monitorResult) {
+	private long _getLastRunTimestampSeconds(MonitorResult monitorResult) {
 		if (monitorResult == null) {
 			return 0;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorResult.java
@@ -61,6 +61,10 @@ public class MonitorResult {
 			return mostSevereStatus;
 		}
 
+		public int getSeverityRank() {
+			return _severityRank;
+		}
+
 		private Status(int severityRank) {
 			_severityRank = severityRank;
 		}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorEngineTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import org.mockito.MockedStatic;
@@ -21,6 +22,29 @@ import org.mockito.Mockito;
  * @author Brittney Nguyen
  */
 public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testMonitorEngineDuplicateIds() {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		new MonitorEngine(
+			monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(_newMonitorConfig("a")),
+				new TestMonitor(_newMonitorConfig("b"))));
+
+		try {
+			new MonitorEngine(
+				monitorResultStore,
+				Arrays.<Monitor>asList(
+					new TestMonitor(_newMonitorConfig("a")),
+					new TestMonitor(_newMonitorConfig("a"))));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
 
 	@Test(timeout = 10000)
 	public void testRunCycle() {
@@ -151,6 +175,11 @@ public class MonitorEngineTest extends com.liferay.jenkins.results.parser.Test {
 
 			testEquals(2, monitorResults.size());
 		}
+	}
+
+	private MonitorConfig _newMonitorConfig(String id) {
+		return _newMonitorConfig(
+			id, RandomTestUtil.randomLong(), RandomTestUtil.randomLong());
 	}
 
 	private MonitorConfig _newMonitorConfig(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidatorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorIdValidatorTest.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorIdValidatorTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testValidate() {
+		MonitorIdValidator.validate(Collections.<Monitor>emptyList());
+
+		MonitorIdValidator.validate(
+			Arrays.<Monitor>asList(_newMonitor("a"), _newMonitor("b")));
+
+		try {
+			MonitorIdValidator.validate(
+				Arrays.<Monitor>asList(_newMonitor("a"), _newMonitor("a")));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	private Monitor _newMonitor(String id) {
+		return new TestMonitor(
+			new MonitorConfig(
+				id, RandomTestUtil.randomLong(), null,
+				MonitorConfig.Severity.MEDIUM, null,
+				RandomTestUtil.randomLong(), RandomTestUtil.randomString()));
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -28,6 +28,29 @@ public class MonitorMetricsWriterTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testMonitorMetricsWriterDuplicateIds() {
+		try {
+			new MonitorMetricsWriter(
+				new File(
+					temporaryFolder.getRoot(), RandomTestUtil.randomString()),
+				new MonitorResultStore(),
+				Arrays.<Monitor>asList(
+					new TestMonitor(
+						_newMonitorConfig(
+							"disk", MonitorConfig.Severity.MEDIUM,
+							RandomTestUtil.randomString())),
+					new TestMonitor(
+						_newMonitorConfig(
+							"disk", MonitorConfig.Severity.MEDIUM,
+							RandomTestUtil.randomString()))));
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	@Test
 	public void testWrite() throws Exception {
 		MonitorResultStore monitorResultStore = new MonitorResultStore();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -1,0 +1,206 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import java.io.File;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class MonitorMetricsWriterTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testWrite() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk",
+			_newMonitorResult(MonitorResult.Status.CRITICAL, 1750000000000L));
+		monitorResultStore.store(
+			"queue",
+			_newMonitorResult(MonitorResult.Status.OK, 1749999000000L));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(),
+			RandomTestUtil.randomString() + "/" +
+				RandomTestUtil.randomString());
+
+		_write(metricsFile, monitorResultStore, _newMonitors());
+
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"# HELP monitor_check_status Monitor status severity rank, ",
+				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
+				"# TYPE monitor_check_status gauge\n",
+				"monitor_check_status{check=\"disk\",severity=\"high\",",
+				"type=\"resource-threshold\"} 3\n",
+				"monitor_check_status{check=\"queue\",severity=\"medium\",",
+				"type=\"job-health\"} 0\n",
+				"monitor_check_status{check=\"testray\",severity=\"low\",",
+				"type=\"external-status\"} 1\n",
+				"# HELP monitor_check_last_run_timestamp_seconds Unix ",
+				"timestamp of the last check run, 0 if never run\n",
+				"# TYPE monitor_check_last_run_timestamp_seconds gauge\n",
+				"monitor_check_last_run_timestamp_seconds{check=\"disk\",",
+				"severity=\"high\",type=\"resource-threshold\"} 1750000000\n",
+				"monitor_check_last_run_timestamp_seconds{check=\"queue\",",
+				"severity=\"medium\",type=\"job-health\"} 1749999000\n",
+				"monitor_check_last_run_timestamp_seconds{check=\"testray\",",
+				"severity=\"low\",type=\"external-status\"} 0\n",
+				"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of ",
+				"the last completed monitor cycle\n",
+				"# TYPE monitor_heartbeat_timestamp_seconds gauge\n",
+				"monitor_heartbeat_timestamp_seconds 1750000000\n"),
+			read(metricsFile));
+	}
+
+	@Test
+	public void testWriteEscapesLabelValues() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"a\"b\\c",
+			_newMonitorResult(
+				MonitorResult.Status.WARN, RandomTestUtil.randomLong()));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		_write(
+			metricsFile, monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(
+					_newMonitorConfig(
+						"a\"b\\c", MonitorConfig.Severity.MEDIUM, "d\ne"))));
+
+		String content = read(metricsFile);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				"monitor_check_status{check=\"a\\\"b\\\\c\"," +
+					"severity=\"medium\",type=\"d\\ne\"} 2\n"));
+	}
+
+	@Test
+	public void testWriteNullStatus() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk", _newMonitorResult(null, RandomTestUtil.randomLong()));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		_write(
+			metricsFile, monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(
+					_newMonitorConfig(
+						"disk", MonitorConfig.Severity.HIGH,
+						"resource-threshold"))));
+
+		String content = read(metricsFile);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				"monitor_check_status{check=\"disk\",severity=\"high\"," +
+					"type=\"resource-threshold\"} 1\n"));
+	}
+
+	@Test
+	public void testWriteReplacesContent() throws Exception {
+		String metricsFileName = RandomTestUtil.randomString();
+
+		File metricsFile = new File(temporaryFolder.getRoot(), metricsFileName);
+
+		String randomString = RandomTestUtil.randomString();
+
+		JenkinsResultsParserUtil.write(metricsFile, randomString);
+
+		_write(metricsFile, new MonitorResultStore(), _newMonitors());
+
+		String content = read(metricsFile);
+
+		Assert.assertFalse(content, content.contains(randomString));
+
+		File temporaryFile = new File(
+			temporaryFolder.getRoot(), metricsFileName + ".tmp");
+
+		Assert.assertFalse(temporaryFile.exists());
+	}
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private MonitorConfig _newMonitorConfig(
+		String id, MonitorConfig.Severity severity, String type) {
+
+		return new MonitorConfig(
+			id, RandomTestUtil.randomLong(), null, severity, null,
+			RandomTestUtil.randomLong(), type);
+	}
+
+	private MonitorResult _newMonitorResult(
+		MonitorResult.Status status, long timestamp) {
+
+		return new MonitorResult(
+			RandomTestUtil.randomString(), null, status, timestamp);
+	}
+
+	private List<Monitor> _newMonitors() {
+		return Arrays.<Monitor>asList(
+			new TestMonitor(
+				_newMonitorConfig(
+					"disk", MonitorConfig.Severity.HIGH, "resource-threshold")),
+			new TestMonitor(
+				_newMonitorConfig(
+					"queue", MonitorConfig.Severity.MEDIUM, "job-health")),
+			new TestMonitor(
+				_newMonitorConfig(
+					"testray", MonitorConfig.Severity.LOW, "external-status")));
+	}
+
+	private void _write(
+			File metricsFile, MonitorResultStore monitorResultStore,
+			List<Monitor> monitors)
+		throws Exception {
+
+		MonitorMetricsWriter monitorMetricsWriter = new MonitorMetricsWriter(
+			metricsFile, monitorResultStore, monitors);
+
+		try (MockedStatic<JenkinsResultsParserUtil>
+				jenkinsResultsParserUtilMockedStatic = Mockito.mockStatic(
+					JenkinsResultsParserUtil.class,
+					Mockito.CALLS_REAL_METHODS)) {
+
+			jenkinsResultsParserUtilMockedStatic.when(
+				JenkinsResultsParserUtil::getCurrentTimeMillis
+			).thenReturn(
+				1750000000123L
+			);
+
+			monitorMetricsWriter.write();
+		}
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -89,7 +89,7 @@ public class MonitorMetricsWriterTest
 				"monitor_check_last_run_timestamp_seconds{check=\"testray\",",
 				"severity=\"low\",type=\"external-status\"} 0\n",
 				"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of ",
-				"the last completed monitor cycle\n",
+				"the last metrics write\n",
 				"# TYPE monitor_heartbeat_timestamp_seconds gauge\n",
 				"monitor_heartbeat_timestamp_seconds 1750000000\n"),
 			read(metricsFile));

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -124,6 +124,35 @@ public class MonitorMetricsWriterTest
 	}
 
 	@Test
+	public void testWriteNullSeverityAndType() throws Exception {
+		MonitorResultStore monitorResultStore = new MonitorResultStore();
+
+		monitorResultStore.store(
+			"disk",
+			_newMonitorResult(
+				MonitorResult.Status.OK, RandomTestUtil.randomLong()));
+
+		File metricsFile = new File(
+			temporaryFolder.getRoot(), RandomTestUtil.randomString());
+
+		_write(
+			metricsFile, monitorResultStore,
+			Arrays.<Monitor>asList(
+				new TestMonitor(
+					new MonitorConfig(
+						"disk", RandomTestUtil.randomLong(), null, null, null,
+						RandomTestUtil.randomLong(), null))));
+
+		String content = read(metricsFile);
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				"monitor_check_status{check=\"disk\"," +
+					"severity=\"medium\",type=\"unknown\"} 0\n"));
+	}
+
+	@Test
 	public void testWriteNullStatus() throws Exception {
 		MonitorResultStore monitorResultStore = new MonitorResultStore();
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorResultTest.java
@@ -69,4 +69,12 @@ public class MonitorResultTest extends com.liferay.jenkins.results.parser.Test {
 				Collections.<MonitorResult.Status>emptyList()));
 	}
 
+	@Test
+	public void testGetSeverityRank() {
+		testEquals(0, MonitorResult.Status.OK.getSeverityRank());
+		testEquals(1, MonitorResult.Status.UNKNOWN.getSeverityRank());
+		testEquals(2, MonitorResult.Status.WARN.getSeverityRank());
+		testEquals(3, MonitorResult.Status.CRITICAL.getSeverityRank());
+	}
+
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7958

## What Is Being Fixed

The check engine from LRCI-7816 produces `MonitorResult` objects, but nothing turns them into metrics, so the monitoring pipeline cannot see check state and cannot tell whether the monitor itself is alive.

## How It Is Being Fixed

`MonitorResult.Status` gains `getSeverityRank`, exposing the rank field the enum already carried. `MonitorMetricsWriter` takes a target file, a `MonitorResultStore`, and the registered monitor list, and `write()` emits three gauge families labeled with the check ID, type, and severity: `monitor_check_status` valued from the status rank, `monitor_check_last_run_timestamp_seconds`, and `monitor_heartbeat_timestamp_seconds`. Both timestamps are in seconds so the LRCI-7818 rules can compare them against `time()`. Publication is atomic, writing a sibling temp file and moving it over the target, so a scraper never reads a partial file.

Status comes from the result store rather than from what a cycle returned, so a check that was not due keeps its last known value and its series never disappears. The emitter is standalone rather than wired into `MonitorEngine`; LRCI-7821 composes `runCycle` and `write` and owns the file path.

`MonitorIdValidator` holds the unique monitor ID invariant, called from both `MonitorEngine`'s and `MonitorMetricsWriter`'s constructors. Duplicate IDs matter because `MonitorResultStore` is keyed on the ID alone, so two monitors sharing one share a single result slot and both would emit whichever result landed last, letting a critical check report as healthy. Rejecting at construction means no file is written at all rather than an invalid exposition with two identical label sets.

Two further robustness fixes. A monitor returning a null status is treated as unknown rather than throwing, and a config with a null severity or type falls back to `medium` and `unknown`; previously either would throw out of `write()` before the atomic move, leaving the last published file frozen and the heartbeat stalled, which alerting reads as staleness rather than as a loud failure.

## PR Check

**pr-check: PASS** — tested on `4ae492b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4ae492b5733c6edd5e7b5eee6f232375a0b57818"} -->
