### PR TITLE
LRCI-7931 Stop logging failed REST API calls for queued items (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
@@ -71,18 +71,18 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 	}
 
 	protected void runMissing() {
-		if (isBuildQueued()) {
-			_missingTickCount = 0;
-
-			_build.setStatus("queued");
-
-			return;
-		}
-
 		if (isBuildRunning()) {
 			_missingTickCount = 0;
 
 			_build.setStatus("running");
+
+			return;
+		}
+
+		if (isBuildQueued()) {
+			_missingTickCount = 0;
+
+			_build.setStatus("queued");
 
 			return;
 		}
@@ -123,13 +123,13 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 	}
 
 	protected void runQueued() {
-		if (isBuildQueued()) {
-			return;
-		}
-
 		if (isBuildRunning()) {
 			_build.setStatus("running");
 
+			return;
+		}
+
+		if (isBuildQueued()) {
 			return;
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -657,18 +657,23 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public QueueItem getQueueItem(long queueId) {
+		String queueItemAPIURL = JenkinsResultsParserUtil.combine(
+			getURL(), "/queue/item/", String.valueOf(queueId),
+			"/api/json?tree=actions[parameters[name,value]],",
+			"id,inQueueSince,task[name,url],url,why");
+
 		try {
+			String response = JenkinsResultsParserUtil.toString(
+				queueItemAPIURL, false, 0, 0, 5000);
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(response)) {
+				return null;
+			}
+
 			JSONObject queueItemJSONObject =
-				JenkinsResultsParserUtil.toJSONObject(
-					JenkinsResultsParserUtil.combine(
-						getURL(), "/queue/item/", String.valueOf(queueId),
-						"/api/json?tree=actions[parameters[name,value]],",
-						"id,inQueueSince,task[name,url],url,why"),
-					false, 5000);
+				JenkinsResultsParserUtil.createJSONObject(response);
 
-			if ((queueItemJSONObject == null) ||
-				!queueItemJSONObject.has("id")) {
-
+			if (!queueItemJSONObject.has("id")) {
 				return null;
 			}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -5,7 +5,10 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
 
 import java.util.Map;
 
@@ -88,6 +91,48 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertEquals(
 			availableSlavesCount, _jenkinsMaster.getAvailableSlavesCount(null));
+	}
+
+	@Test
+	public void testGetQueueItem() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"id", 7800
+			).toString(),
+			"http://test-9-1/queue/item/7800/api/json", urlReader);
+
+		JenkinsMaster.QueueItem queueItem = _jenkinsMaster.getQueueItem(7800);
+
+		Assert.assertEquals(7800, queueItem.getId());
+	}
+
+	@Test
+	public void testGetQueueItemNotFound() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		String queueItemAPIURL = "http://test-9-1/queue/item/7800/api/json";
+
+		setUrlReaderException(
+			new FileNotFoundException(queueItemAPIURL), queueItemAPIURL,
+			urlReader);
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+		PrintStream printStream = System.out;
+
+		System.setOut(new PrintStream(byteArrayOutputStream, true));
+
+		try {
+			Assert.assertNull(_jenkinsMaster.getQueueItem(7800));
+		}
+		finally {
+			System.setOut(printStream);
+		}
+
+		Assert.assertEquals("", byteArrayOutputStream.toString());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -197,6 +197,22 @@ public class Test {
 		);
 	}
 
+	protected void setUrlReaderException(
+			Exception exception, String url, UrlReader urlReader)
+		throws Exception {
+
+		Mockito.doThrow(
+			exception
+		).when(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.argThat(
+				readURL -> (readURL != null) && readURL.contains(url))
+		);
+	}
+
 	protected void setUrlReaderOutput(
 			String standardOut, String url, UrlReader urlReader)
 		throws Exception {


### PR DESCRIPTION
[LRCI-7931](https://liferay.atlassian.net/browse/LRCI-7931)

Revises [#4486](https://github.com/pyoo47/liferay-portal/pull/4486) (opened by @CalumR23). No code changes: the single commit is split so the tests follow the implementation, per team convention. Both commits remain authored by @CalumR23.

- [9f218cb2a3ec](https://github.com/pyoo47/liferay-portal/commit/9f218cb2a3ec6) LRCI-7931 Stop logging failed REST API calls for queued items
- [fa1e9e3c456e](https://github.com/pyoo47/liferay-portal/commit/fa1e9e3c456e0) LRCI-7931 Add unit tests for the queue item lookup
