### PR TITLE
LRCI-7984 Remove the Jenkins authentication token from build invocations

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ArchiveBinariesCachePortalControllerBuildRunner.java
@@ -5,11 +5,8 @@
 
 package com.liferay.jenkins.results.parser;
 
-import java.io.IOException;
-
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  * @author Michael Hashimoto
@@ -28,31 +25,7 @@ public class ArchiveBinariesCachePortalControllerBuildRunner
 
 	@Override
 	protected void invokeBuild() {
-		StringBuilder sb = new StringBuilder();
-
-		String invocationJobURL = _getInvocationJobURL();
-
-		sb.append(invocationJobURL);
-
-		sb.append("/buildWithParameters?");
-
-		String jenkinsAuthenticationToken;
-
-		try {
-			Properties buildProperties =
-				JenkinsResultsParserUtil.getBuildProperties();
-
-			jenkinsAuthenticationToken = buildProperties.getProperty(
-				"jenkins.authentication.token");
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
 		S buildData = getBuildData();
-
-		sb.append("token=");
-		sb.append(jenkinsAuthenticationToken);
 
 		Map<String, String> invocationParameters = new HashMap<>();
 
@@ -84,33 +57,18 @@ public class ArchiveBinariesCachePortalControllerBuildRunner
 		invocationParameters.put(
 			"TEST_PORTAL_BUILD_PROFILE", _TEST_PORTAL_BUILD_PROFILE);
 
-		for (Map.Entry<String, String> invocationParameter :
-				invocationParameters.entrySet()) {
+		String invocationJobURL = _getInvocationJobURL();
 
-			String invocationParameterValue = invocationParameter.getValue();
+		long queueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
+			invocationJobURL, invocationParameters);
 
-			if (JenkinsResultsParserUtil.isNullOrEmpty(
-					invocationParameterValue)) {
-
-				continue;
-			}
-
-			sb.append("&");
-			sb.append(invocationParameter.getKey());
-			sb.append("=");
-			sb.append(invocationParameterValue);
+		if (queueId == 0) {
+			throw new RuntimeException("Unable to invoke " + invocationJobURL);
 		}
 
-		try {
-			JenkinsResultsParserUtil.toString(sb.toString());
+		keepJenkinsBuild(true);
 
-			keepJenkinsBuild(true);
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		sb = new StringBuilder();
+		StringBuilder sb = new StringBuilder();
 
 		sb.append("<a href=\"");
 		sb.append(invocationJobURL);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -806,17 +806,6 @@ public abstract class BaseBuild implements Build {
 
 		Map<String, String> parameters = new HashMap<>(getParameters());
 
-		try {
-			parameters.put(
-				"token",
-				JenkinsResultsParserUtil.getBuildProperty(
-					"jenkins.authentication.token"));
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(
-				"Unable to get Jenkins authentication token", ioException);
-		}
-
 		for (Map.Entry<String, String> parameter : parameters.entrySet()) {
 			sb.append(parameter.getKey());
 			sb.append("=");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
@@ -230,58 +230,29 @@ public class GenerateReportsControllerBuildRunner
 
 		invocationParameters.put("PARENT_BUILD_URL", buildData.getBuildURL());
 
-		Properties buildProperties = null;
-
-		try {
-			buildProperties = JenkinsResultsParserUtil.getBuildProperties();
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		StringBuilder sb = new StringBuilder();
-
 		String jobURL = JenkinsResultsParserUtil.combine(
 			JenkinsResultsParserUtil.getMostAvailableMasterURL(
 				"http://" + buildData.getCohortName() + ".liferay.com", null, 1,
 				"generate-reports"),
 			"/job/generate-reports");
 
-		sb.append(jobURL);
-
-		sb.append("/buildWithParameters?token=");
-
-		sb.append(buildProperties.getProperty("jenkins.authentication.token"));
-
-		for (Map.Entry<String, String> invocationParameter :
-				invocationParameters.entrySet()) {
-
-			String invocationParameterValue = invocationParameter.getValue();
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(
-					invocationParameterValue)) {
-
-				continue;
-			}
-
-			sb.append("&");
-			sb.append(invocationParameter.getKey());
-			sb.append("=");
-			sb.append(invocationParameterValue);
-		}
-
 		try {
-			JenkinsResultsParserUtil.toString(sb.toString());
+			long queueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
+				jobURL, invocationParameters);
+
+			if (queueId == 0) {
+				throw new RuntimeException("Unable to invoke " + jobURL);
+			}
 
 			System.out.println(
 				"The " + invocationParameters.get("REPORT_NAMES") +
 					" report(s) will be generated at: " + jobURL);
 		}
-		catch (IOException ioException) {
+		catch (Exception exception) {
 			System.out.println(
 				"Unable to invoke a new build to generate reports");
 
-			ioException.printStackTrace();
+			exception.printStackTrace();
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -3687,34 +3687,42 @@ public class JenkinsResultsParserUtil {
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(jenkinsMaster.getRemoteURL());
-		sb.append("job/");
-		sb.append(jenkinsJobName);
-		sb.append("/buildWithParameters?");
+		try {
+			if (buildParameters != null) {
+				for (Map.Entry<String, String> buildParameter :
+						buildParameters.entrySet()) {
 
-		for (Map.Entry<String, String> buildParameter :
-				buildParameters.entrySet()) {
+					String value = buildParameter.getValue();
 
-			String value = buildParameter.getValue();
+					if (isNullOrEmpty(value)) {
+						continue;
+					}
 
-			if (isNullOrEmpty(value)) {
-				continue;
+					sb.append(
+						URLEncoder.encode(buildParameter.getKey(), "UTF-8"));
+					sb.append("=");
+					sb.append(URLEncoder.encode(value, "UTF-8"));
+					sb.append("&");
+				}
 			}
 
-			sb.append(buildParameter.getKey());
-			sb.append("=");
-			sb.append(value);
-			sb.append("&");
-		}
+			if (sb.length() > 0) {
+				sb.deleteCharAt(sb.length() - 1);
+			}
 
-		try {
-			sb.append("token=");
-			sb.append(getBuildProperty("jenkins.authentication.token"));
+			Map<String, String> requestHeaders = new HashMap<>();
+
+			requestHeaders.put(
+				"Content-Type", "application/x-www-form-urlencoded");
 
 			return getJenkinsBuildQueueId(
 				UrlReader.getResponseHeader(
 					"Location", getJenkinsHTTPAuthorization(),
-					HttpRequestMethod.GET, null, timeout, sb.toString()));
+					HttpRequestMethod.POST, sb.toString(), requestHeaders,
+					timeout,
+					combine(
+						jenkinsMaster.getRemoteURL(), "job/", jenkinsJobName,
+						"/buildWithParameters")));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -3685,6 +3685,22 @@ public class JenkinsResultsParserUtil {
 		JenkinsMaster jenkinsMaster, String jenkinsJobName,
 		Map<String, String> buildParameters, int timeout) {
 
+		return invokeJenkinsBuild(
+			combine(jenkinsMaster.getRemoteURL(), "job/", jenkinsJobName),
+			buildParameters, timeout);
+	}
+
+	public static long invokeJenkinsBuild(
+		String jenkinsJobURL, Map<String, String> buildParameters) {
+
+		return invokeJenkinsBuild(
+			jenkinsJobURL, buildParameters, _MILLIS_TIMEOUT_DEFAULT);
+	}
+
+	public static long invokeJenkinsBuild(
+		String jenkinsJobURL, Map<String, String> buildParameters,
+		int timeout) {
+
 		StringBuilder sb = new StringBuilder();
 
 		try {
@@ -3719,10 +3735,7 @@ public class JenkinsResultsParserUtil {
 				UrlReader.getResponseHeader(
 					"Location", getJenkinsHTTPAuthorization(),
 					HttpRequestMethod.POST, sb.toString(), requestHeaders,
-					timeout,
-					combine(
-						jenkinsMaster.getRemoteURL(), "job/", jenkinsJobName,
-						"/buildWithParameters")));
+					timeout, combine(jenkinsJobURL, "/buildWithParameters")));
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
@@ -246,13 +246,9 @@ public class PoshiReleasePortalTopLevelBuildRunner
 
 		sb.append("/job/");
 		sb.append(jobName);
-		sb.append("/buildWithParameters?token=");
+		sb.append("/buildWithParameters?");
 
 		try {
-			sb.append(
-				JenkinsResultsParserUtil.getBuildProperty(
-					"jenkins.authentication.token"));
-
 			Map<String, String> invocationParameters = new HashMap<>();
 
 			invocationParameters.put(
@@ -321,14 +317,18 @@ public class PoshiReleasePortalTopLevelBuildRunner
 					continue;
 				}
 
-				sb.append("&");
 				sb.append(invocationParameter.getKey());
 				sb.append("=");
 				sb.append(invocationParameterValue);
+				sb.append("&");
 			}
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
+		}
+
+		if (sb.charAt(sb.length() - 1) == '&') {
+			sb.deleteCharAt(sb.length() - 1);
 		}
 
 		return sb.toString();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
@@ -100,23 +100,7 @@ public class QAWebsitesControllerBuildRunner
 	}
 
 	protected void invokeBuild() {
-		StringBuilder sb = new StringBuilder();
-
 		String jobInvocationURL = getJobInvocationURL();
-
-		sb.append(jobInvocationURL);
-
-		sb.append("/buildWithParameters?");
-		sb.append("token=");
-
-		try {
-			sb.append(
-				JenkinsResultsParserUtil.getBuildProperty(
-					"jenkins.authentication.token"));
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
 
 		BuildData buildData = getBuildData();
 
@@ -155,41 +139,22 @@ public class QAWebsitesControllerBuildRunner
 
 		invocationParameters.putAll(buildData.getBuildParameters());
 
-		for (Map.Entry<String, String> invocationParameter :
-				invocationParameters.entrySet()) {
+		long queueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
+			jobInvocationURL, invocationParameters);
 
-			String invocationParameterValue = invocationParameter.getValue();
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(
-					invocationParameterValue)) {
-
-				continue;
-			}
-
-			sb.append("&");
-			sb.append(invocationParameter.getKey());
-			sb.append("=");
-			sb.append(invocationParameterValue);
+		if (queueId == 0) {
+			throw new RuntimeException("Unable to invoke " + jobInvocationURL);
 		}
 
-		try {
-			System.out.println(sb.toString());
+		StringBuilder sb = new StringBuilder();
 
-			JenkinsResultsParserUtil.toString(sb.toString());
+		sb.append("<a href=\"");
+		sb.append(JenkinsResultsParserUtil.getRemoteURL(jobInvocationURL));
+		sb.append("\"><strong>IN QUEUE</strong></a>");
 
-			sb = new StringBuilder();
+		buildData.setBuildDescription(sb.toString());
 
-			sb.append("<a href=\"");
-			sb.append(JenkinsResultsParserUtil.getRemoteURL(jobInvocationURL));
-			sb.append("\"><strong>IN QUEUE</strong></a>");
-
-			buildData.setBuildDescription(sb.toString());
-
-			updateBuildDescription();
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+		updateBuildDescription();
 	}
 
 	private boolean _allowConcurrentBuilds() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SingleUpstreamPortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SingleUpstreamPortalControllerBuildRunner.java
@@ -5,11 +5,8 @@
 
 package com.liferay.jenkins.results.parser;
 
-import java.io.IOException;
-
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  * @author Michael Hashimoto
@@ -34,28 +31,6 @@ public class SingleUpstreamPortalControllerBuildRunner
 		String testSuiteName = buildData.getTestSuiteName();
 
 		String invocationJobURL = getInvocationJobURL(testSuiteName);
-
-		StringBuilder sb = new StringBuilder();
-
-		sb.append(invocationJobURL);
-
-		sb.append("/buildWithParameters?");
-
-		String jenkinsAuthenticationToken;
-
-		try {
-			Properties buildProperties =
-				JenkinsResultsParserUtil.getBuildProperties();
-
-			jenkinsAuthenticationToken = buildProperties.getProperty(
-				"jenkins.authentication.token");
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		sb.append("token=");
-		sb.append(jenkinsAuthenticationToken);
 
 		Map<String, String> invocationParameters = new HashMap<>();
 
@@ -110,33 +85,16 @@ public class SingleUpstreamPortalControllerBuildRunner
 		invocationParameters.put(
 			"TESTRAY_SLACK_USERNAME", getTestraySlackUsername(testSuiteName));
 
-		for (Map.Entry<String, String> invocationParameter :
-				invocationParameters.entrySet()) {
+		long queueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
+			invocationJobURL, invocationParameters);
 
-			String invocationParameterValue = invocationParameter.getValue();
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(
-					invocationParameterValue)) {
-
-				continue;
-			}
-
-			sb.append("&");
-			sb.append(invocationParameter.getKey());
-			sb.append("=");
-			sb.append(invocationParameterValue);
+		if (queueId == 0) {
+			throw new RuntimeException("Unable to invoke " + invocationJobURL);
 		}
 
-		try {
-			JenkinsResultsParserUtil.toString(sb.toString());
+		keepJenkinsBuild(true);
 
-			keepJenkinsBuild(true);
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
-		sb = new StringBuilder();
+		StringBuilder sb = new StringBuilder();
 
 		sb.append("<a href=\"");
 		sb.append(JenkinsResultsParserUtil.getRemoteURL(invocationJobURL));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestSuiteMultipleUpstreamPortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestSuiteMultipleUpstreamPortalControllerBuildRunner.java
@@ -40,19 +40,6 @@ public class TestSuiteMultipleUpstreamPortalControllerBuildRunner
 			return;
 		}
 
-		String jenkinsAuthenticationToken = null;
-
-		try {
-			Properties buildProperties =
-				JenkinsResultsParserUtil.getBuildProperties();
-
-			jenkinsAuthenticationToken = buildProperties.getProperty(
-				"jenkins.authentication.token");
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
 		S buildData = getBuildData();
 
 		String portalBranchSHA = buildData.getPortalBranchSHA();
@@ -73,13 +60,6 @@ public class TestSuiteMultipleUpstreamPortalControllerBuildRunner
 			}
 
 			String invocationJobURL = getInvocationJobURL(testSuiteName);
-
-			StringBuilder sb = new StringBuilder();
-
-			sb.append(invocationJobURL);
-			sb.append("/buildWithParameters?");
-			sb.append("token=");
-			sb.append(jenkinsAuthenticationToken);
 
 			Map<String, String> invocationParameters = new HashMap<>();
 
@@ -139,26 +119,14 @@ public class TestSuiteMultipleUpstreamPortalControllerBuildRunner
 				"TESTRAY_SLACK_USERNAME",
 				getTestraySlackUsername(testSuiteName));
 
-			for (Map.Entry<String, String> invocationParameter :
-					invocationParameters.entrySet()) {
-
-				String invocationParameterValue =
-					invocationParameter.getValue();
-
-				if (JenkinsResultsParserUtil.isNullOrEmpty(
-						invocationParameterValue)) {
-
-					continue;
-				}
-
-				sb.append("&");
-				sb.append(invocationParameter.getKey());
-				sb.append("=");
-				sb.append(invocationParameterValue);
-			}
-
 			try {
-				JenkinsResultsParserUtil.toString(sb.toString());
+				long queueId = JenkinsResultsParserUtil.invokeJenkinsBuild(
+					invocationJobURL, invocationParameters);
+
+				if (queueId == 0) {
+					throw new RuntimeException(
+						"Unable to invoke " + invocationJobURL);
+				}
 
 				System.out.println(
 					JenkinsResultsParserUtil.combine(
@@ -167,13 +135,13 @@ public class TestSuiteMultipleUpstreamPortalControllerBuildRunner
 
 				_invokedTestSuiteNames.add(testSuiteName);
 			}
-			catch (IOException ioException) {
+			catch (Exception exception) {
 				System.out.println(
 					JenkinsResultsParserUtil.combine(
 						"Unable to invoke a new build for test suite, '",
 						testSuiteName, "'"));
 
-				ioException.printStackTrace();
+				exception.printStackTrace();
 			}
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -318,15 +317,6 @@ public abstract class TopLevelBuildRunner<T extends TopLevelBuildData>
 		String cohortName, String jobName,
 		Map<String, String> invocationParameters) {
 
-		Properties buildProperties;
-
-		try {
-			buildProperties = JenkinsResultsParserUtil.getBuildProperties();
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
-
 		invocationParameters.put(
 			"PARENT_BUILD_URL", _topLevelBuild.getBuildURL());
 
@@ -335,19 +325,22 @@ public abstract class TopLevelBuildRunner<T extends TopLevelBuildData>
 		sb.append(getBaseInvocationURL(cohortName, jobName));
 		sb.append("/job/");
 		sb.append(jobName);
-		sb.append("/buildWithParameters?token=");
-		sb.append(buildProperties.getProperty("jenkins.authentication.token"));
+		sb.append("/buildWithParameters?");
 
 		for (Map.Entry<String, String> invocationParameter :
 				invocationParameters.entrySet()) {
 
-			sb.append("&");
 			sb.append(
 				JenkinsResultsParserUtil.fixURL(invocationParameter.getKey()));
 			sb.append("=");
 			sb.append(
 				JenkinsResultsParserUtil.fixURL(
 					invocationParameter.getValue()));
+			sb.append("&");
+		}
+
+		if (sb.charAt(sb.length() - 1) == '&') {
+			sb.deleteCharAt(sb.length() - 1);
 		}
 
 		_topLevelBuild.addDownstreamBuilds(sb.toString());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -48,9 +48,20 @@ public class UrlReader {
 			int timeout, String url)
 		throws IOException {
 
+		return getResponseHeader(
+			headerName, httpAuthorization, httpRequestMethod, postContent, null,
+			timeout, url);
+	}
+
+	public static String getResponseHeader(
+			String headerName, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, String postContent,
+			Map<String, String> requestHeaders, int timeout, String url)
+		throws IOException {
+
 		return _urlReader.doGetResponseHeader(
 			headerName, httpAuthorization, httpRequestMethod, postContent,
-			timeout, url);
+			requestHeaders, timeout, url);
 	}
 
 	public static InputStream read(
@@ -71,7 +82,7 @@ public class UrlReader {
 	protected String doGetResponseHeader(
 			String headerName, HTTPAuthorization httpAuthorization,
 			HttpRequestMethod httpRequestMethod, String postContent,
-			int timeout, String url)
+			Map<String, String> requestHeaders, int timeout, String url)
 		throws IOException {
 
 		URL urlObject = new URL(JenkinsResultsParserUtil.fixURL(url));
@@ -86,6 +97,15 @@ public class UrlReader {
 		if (httpAuthorization != null) {
 			httpURLConnection.setRequestProperty(
 				"Authorization", httpAuthorization.toString());
+		}
+
+		if (requestHeaders != null) {
+			for (Map.Entry<String, String> requestHeader :
+					requestHeaders.entrySet()) {
+
+				httpURLConnection.setRequestProperty(
+					requestHeader.getKey(), requestHeader.getValue());
+			}
 		}
 
 		if (timeout != 0) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -388,8 +388,6 @@ public class JenkinsResultsParserUtilTest
 			"jenkins.admin.user.name", RandomTestUtil.randomString());
 		buildProperties.setProperty(
 			"jenkins.admin.user.token", RandomTestUtil.randomString());
-		buildProperties.setProperty(
-			"jenkins.authentication.token", RandomTestUtil.randomString());
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
@@ -401,7 +399,7 @@ public class JenkinsResultsParserUtilTest
 			urlReader
 		).doGetResponseHeader(
 			Mockito.eq("Location"), Mockito.any(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.anyString()
+			Mockito.any(), Mockito.anyInt(), Mockito.anyString()
 		);
 
 		JenkinsMaster jenkinsMaster = Mockito.mock(JenkinsMaster.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7984

## What Is Being Fixed

Every Jenkins build invocation appended a `token=` query parameter read from the `jenkins.authentication.token` build property. That forced each call site to read build properties, wrap the resulting `IOException`, and hand-assemble its own `buildWithParameters` query string. The token also traveled in the URL, where it lands in logs and Jenkins request history, and the invocation logic was duplicated across every controller build runner.

## How It Is Being Fixed

Jenkins accepts an authenticated `POST` to `buildWithParameters` without a build token, so the token is no longer needed. `UrlReader` gained an overload that takes a map of request headers and applies them to the connection, which lets the caller send `Content-Type: application/x-www-form-urlencoded`. `JenkinsResultsParserUtil.invokeJenkinsBuild` now URL-encodes the build parameters into a form-encoded request body and issues a `POST`, and it picked up overloads that take a job URL and an optional timeout so the controller build runners can call it directly. Those runners, along with `TopLevelBuildRunner` and `BaseBuild`, drop their hand-rolled query-string assembly and their `jenkins.authentication.token` lookups.

## PR Check

**pr-check: PASS** — tested on `f58fa26f28b5fd9f353e0c4e344a9efee4052edd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |
| Transaction Usage | PASS |

<!-- pr-check {"result": "success", "sha": "f58fa26f28b5fd9f353e0c4e344a9efee4052edd"} -->
