### PR TITLE
LRCI-8000 Add method to pass in the minimum ram to load balancer

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2884,6 +2884,13 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static String getMostAvailableMasterURL(
+		String baseInvocationURL, int invokedBatchSize, int minimumRAM) {
+
+		return getMostAvailableMasterURL(
+			baseInvocationURL, null, invokedBatchSize, null, minimumRAM);
+	}
+
+	public static String getMostAvailableMasterURL(
 		String baseInvocationURL, String blacklist, int invokedBatchSize) {
 
 		return getMostAvailableMasterURL(
@@ -2893,6 +2900,14 @@ public class JenkinsResultsParserUtil {
 	public static String getMostAvailableMasterURL(
 		String baseInvocationURL, String blacklist, int invokedBatchSize,
 		String jobName) {
+
+		return getMostAvailableMasterURL(
+			baseInvocationURL, blacklist, invokedBatchSize, jobName, 0);
+	}
+
+	public static String getMostAvailableMasterURL(
+		String baseInvocationURL, String blacklist, int invokedBatchSize,
+		String jobName, int minimumRAM) {
 
 		StringBuilder sb = new StringBuilder();
 
@@ -2913,6 +2928,11 @@ public class JenkinsResultsParserUtil {
 		if (!isNullOrEmpty(jobName)) {
 			sb.append("&jobName=");
 			sb.append(fixURL(jobName));
+		}
+
+		if (minimumRAM > 0) {
+			sb.append("&minimumRAM=");
+			sb.append(minimumRAM);
 		}
 
 		try {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8000

## What Is Being Fixed

Callers of the Jenkins load balancer had no way to express a minimum RAM requirement when asking for the most available master. The `getMostAvailableMasterURL` overloads built the load balancer query from the base invocation URL, an optional blacklist, the invoked batch size, and an optional job name, so a batch that needs a master with a certain amount of free memory could not communicate that and would be routed to whichever master happened to be least loaded.

## How It Is Being Fixed

A `minimumRAM` parameter is threaded into the load balancer URL construction. The existing overloads delegate to a new full-arity `getMostAvailableMasterURL(String, String, int, String, int)` that appends `&minimumRAM=<value>` to the query only when the value is positive, so existing callers pass `0` and produce the same URL they did before. A second convenience overload takes the base invocation URL, the invoked batch size, and the minimum RAM for callers that need the new parameter without a blacklist or job name. Keeping the additive change behind a positive-value guard means the load balancer contract is unchanged for every current caller.

## Why Are There No Tests?

jenkins-results-parser changes are validated by running the actual Jenkins jobs rather than unit tests.

## PR Check

**pr-check: PASS** — tested on `6cc4ea9d6edad45022e18dd7c0d99d4a8acd0394`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6cc4ea9d6edad45022e18dd7c0d99d4a8acd0394"} -->
