### PR TITLE
LPD-83978 Mock the enhanced source editing plugin in the remaining Jest setups

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/jest-setup.config.ts
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/jest-setup.config.ts
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/jest-setup.config.ts
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/jest-setup.config.ts
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/site/site-cmp-site-initializer/jest-setup.config.ts
+++ b/modules/apps/site/site-cmp-site-initializer/jest-setup.config.ts
@@ -26,6 +26,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
+++ b/modules/apps/site/site-cms-site-initializer/jest-setup.config.ts
@@ -25,6 +25,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));

--- a/modules/apps/site/site-dsr-site-initializer/jest-setup.config.ts
+++ b/modules/apps/site/site-dsr-site-initializer/jest-setup.config.ts
@@ -27,6 +27,7 @@ jest.mock('@ckeditor/ckeditor5-media-embed/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-mention/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-minimap/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-page-break/dist/index', () => ({}));
+jest.mock('@ckeditor/ckeditor5-source-editing-enhanced/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-special-characters/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-style/dist/index', () => ({}));
 jest.mock('@ckeditor/ckeditor5-table/dist/index', () => ({}));


### PR DESCRIPTION
- [LPD-83978](https://liferay.atlassian.net/browse/LPD-83978)

## Summary

Completes the Jest fix for the enhanced source editing plugin. `c974d2ceab061` added the mock to the seven `jest-setup.config.js` files but not to the five `jest-setup.config.ts` ones, so the plugin still loads for real in those modules and evaluates `class ... extends View` against the empty `ckeditor5-ui` mock.

That leaves 21 suites failing in the `js-unit` batch: `site-cmp-site-initializer` (14), `site-dsr-site-initializer` (6), and `object-dynamic-data-mapping-form-field-type` (1).

Verified locally on all five modules: 248 suites, 1341 tests, all passing. Reverting the single line reproduces the upstream `@marijn/find-cluster-break` `Unexpected token 'export'` failure through the same import chain.
