### PR TITLE
LRCI-8002 Use remote URL instead of a hard-coded replacement

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -429,9 +429,7 @@ public class UrlReader {
 					return doRead(
 						checkCache, httpAuthorization, httpRequestMethod,
 						maxRetries, postContent, retryPeriod, timeout,
-						url.replaceAll(
-							"http://(test-\\d+-\\d+)(/.*)",
-							"https://$1.liferay.com$2"));
+						JenkinsResultsParserUtil.getRemoteURL(url));
 				}
 
 				String exceptionMessage = ioException1.getMessage();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8002

## What Is Being Fixed

When `UrlReader` hit an `UnknownHostException` for a `http://test-<n>-<n>/...` Jenkins host, it retried against a URL built by a hard-coded regex replacement that always rewrote the authority to `https://test-<n>-<n>.liferay.com`. That form is wrong for cloud CI nodes, whose remote authority carries an `-aws` suffix, so the retry resolved to a host that does not exist and the read failed anyway.

## How It Is Being Fixed

The retry now resolves the remote URL through `JenkinsResultsParserUtil.getRemoteURL`, which already owns the local-to-remote authority mapping and accounts for the cloud CI node case along with query-string and `file` URL handling. Routing through the existing utility removes the duplicated rewrite rule so there is a single place where the mapping is defined.

## Why Are There No Tests?

The change is a one-line swap inside an `IOException` retry path in a CI tooling module; behavior is verified by CI runs against real Jenkins hosts rather than unit tests.

## PR Check

**pr-check: PASS** — tested on `bde4137582ced3f3579637e92ed5d64fe9bee916`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bde4137582ced3f3579637e92ed5d64fe9bee916"} -->
