### PR TITLE
LRCI-8027 Remove unnecessary auth for server that does not exist

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -251,29 +251,7 @@ public class FilePropagator {
 			if (sourceFileName.startsWith("http")) {
 				StringBuilder sb = new StringBuilder();
 
-				sb.append("curl ");
-
-				try {
-					if (sourceFileName.startsWith(
-							"https://release.liferay.com")) {
-
-						sb.append(" -u ");
-						sb.append(
-							JenkinsResultsParserUtil.getBuildProperty(
-								"jenkins.admin.user.name"));
-						sb.append(":");
-						sb.append(
-							JenkinsResultsParserUtil.getBuildProperty(
-								"jenkins.admin.user.password"));
-					}
-				}
-				catch (IOException ioException) {
-					throw new FilePropagatorRuntimeException(
-						this, "Unable to get jenkins-admin user credentials",
-						ioException);
-				}
-
-				sb.append("-o ");
+				sb.append("curl -o ");
 				sb.append(targetFileName);
 				sb.append(" ");
 				sb.append(sourceFileName);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8027

## What Is Being Fixed

`FilePropagator._copyFromSource` special-cased source URLs starting with `https://release.liferay.com`, appending `curl -u <user>:<password>` built from the `jenkins.admin.user.name` and `jenkins.admin.user.password` build properties. That server no longer exists, so the credentials serve no purpose. Worse, the lookup was a liability: when either build property was absent, `getBuildProperty` threw an `IOException` that was rethrown as a `FilePropagatorRuntimeException` ("Unable to get jenkins-admin user credentials"), failing file propagation on a host that would never be contacted anyway.

## How It Is Being Fixed

The `release.liferay.com` branch and its surrounding `try`/`catch` are removed, collapsing the command construction to a plain `curl -o <target> <source>`. Every remaining `http` source is fetched unauthenticated, which is what all live sources already require, and the propagator no longer depends on `jenkins-admin` credentials being present in the build properties.

## Why Are There No Tests?

`jenkins-results-parser` has no test harness for this path — `FilePropagator` has no counterpart test class, and no test in the module references it. The method assembles shell command strings that are executed remotely on Jenkins slaves, so there is nothing to assert locally. The change is a pure deletion of a branch that targeted a server that no longer exists; behavior for all live source files is unchanged.

## PR Check

**pr-check: PASS** — tested on `41bff835063840d65099459c5725a34c09cd2ee2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "41bff835063840d65099459c5725a34c09cd2ee2"} -->
