### PR TITLE
LRCI-7854 Sandbox validation case B1 (whitelisted sender, no pr-check)

### DIFF
--- a/LRCI-7854-sandbox-test.txt
+++ b/LRCI-7854-sandbox-test.txt
@@ -1,0 +1,2 @@
+Throwaway file for LRCI-7854 sandbox webhook validation (case B1, whitelist).
+Safe to delete.


### PR DESCRIPTION
Throwaway pull request for LRCI-7854 sandbox webhook validation. Sender is on the hardcoded whitelist, so the sandbox webhook should leave this open even though it has no pr-check result.