### PR TITLE
LRCI-7854 Sandbox validation case B3 (whitelisted sender, round-2 code live)

### DIFF
--- a/LRCI-7854-sandbox-test.txt
+++ b/LRCI-7854-sandbox-test.txt
@@ -1,0 +1,2 @@
+Throwaway file for LRCI-7854 sandbox webhook validation (case B3, whitelist with round-2 code live).
+Safe to delete.


### PR DESCRIPTION
Throwaway pull request for LRCI-7854 sandbox validation. Sender is on the hardcoded whitelist, so this should stay open despite having no pr-check result.