### PR TITLE
LRCI-7904 Detect and abort builds that hang holding an executor

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -822,8 +822,13 @@ public class JenkinsCohort {
 				JenkinsResultsParserUtil.getBuildProperty(
 					"jenkins.load.balancer.blacklist");
 
-			Collections.addAll(
-				_jenkinsMastersBlacklist, jenkinsMastersBlacklist.split(","));
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(
+					jenkinsMastersBlacklist)) {
+
+				Collections.addAll(
+					_jenkinsMastersBlacklist,
+					jenkinsMastersBlacklist.split(","));
+			}
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -516,6 +516,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return new ArrayList<>(_jenkinsSlavesMap.values());
 	}
 
+	public int getMaximumRunningBuildCount() {
+		return Math.max(_busyExecutorCount, _runningBuilds.size());
+	}
+
 	@Override
 	public String getName() {
 		return _masterName;
@@ -761,6 +765,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _masterRemoteURL;
 	}
 
+	public List<RunningBuild> getRunningBuilds() {
+		return new ArrayList<>(_runningBuilds);
+	}
+
 	public Integer getSlaveRAM() {
 		return _slaveRAM;
 	}
@@ -849,12 +857,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				_AVAILABLE_TIMEOUT)) {
 
 			try {
-				if (!isBlacklisted()) {
-					JenkinsResultsParserUtil.toJSONObject(
-						getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
+				JenkinsResultsParserUtil.toJSONObject(
+					getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
 
-					_available = true;
-				}
+				_available = true;
 			}
 			catch (Exception exception) {
 				System.out.println(getName() + " is unreachable.");
@@ -960,7 +966,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		if (!isAvailable()) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
+			_busyExecutorCount = 0;
 			_jenkinsSlavesMap.clear();
+			_runningBuilds.clear();
 
 			return;
 		}
@@ -972,17 +980,23 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		try {
 			computerAPIJSONObject = JenkinsResultsParserUtil.toJSONObject(
 				JenkinsResultsParserUtil.combine(
-					getURL(), "/computer/api/json?tree=computer",
-					"[assignedLabels[name],displayName,",
-					"executors[currentExecutable[url]],idle,offline,",
-					"offlineCauseReason]"),
+					getURL(), "/computer/api/json?tree=busyExecutors,computer",
+					"[assignedLabels[name],displayName,executors",
+					"[currentExecutable[building,estimatedDuration,",
+					"fullDisplayName,number,timestamp,url],",
+					"likelyStuck],idle,offline,offlineCauseReason,",
+					"oneOffExecutors[currentExecutable[building,",
+					"estimatedDuration,fullDisplayName,number,timestamp,",
+					"url],likelyStuck]]"),
 				false, 5000);
 		}
 		catch (Exception exception) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
+			_busyExecutorCount = 0;
 			_jenkinsSlavesMap.clear();
 			_labelExpressionLabels.clear();
+			_runningBuilds.clear();
 
 			System.out.println("Unable to read " + _masterURL);
 
@@ -990,6 +1004,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		List<String> buildURLs = new ArrayList<>();
+		List<RunningBuild> runningBuilds = new ArrayList<>();
 
 		JSONArray computerJSONArray = computerAPIJSONObject.getJSONArray(
 			"computer");
@@ -999,6 +1014,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 			String jenkinsSlaveName = JenkinsSlave.getDisplayName(
 				computerJSONObject);
+
+			_addRunningBuilds(
+				runningBuilds, computerJSONObject, jenkinsSlaveName);
 
 			if (jenkinsSlaveName.equals("Built-In Node") ||
 				jenkinsSlaveName.equals("master")) {
@@ -1075,6 +1093,12 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		_buildURLs.clear();
 
 		_buildURLs.addAll(buildURLs);
+
+		_busyExecutorCount = computerAPIJSONObject.optInt("busyExecutors", 0);
+
+		_runningBuilds.clear();
+
+		_runningBuilds.addAll(runningBuilds);
 	}
 
 	public static class QueueItem implements Comparable<QueueItem> {
@@ -1231,6 +1255,95 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 	}
 
+	public static class RunningBuild {
+
+		public long getElapsedDuration() {
+			long timestamp = getTimestamp();
+
+			if (timestamp <= 0) {
+				return 0;
+			}
+
+			return JenkinsResultsParserUtil.getCurrentTimeMillis() - timestamp;
+		}
+
+		public long getEstimatedDuration() {
+			return _jsonObject.optLong("estimatedDuration", -1);
+		}
+
+		public String getFullDisplayName() {
+			return _jsonObject.optString("fullDisplayName");
+		}
+
+		public JenkinsMaster getJenkinsMaster() {
+			return _jenkinsMaster;
+		}
+
+		public String getJenkinsSlaveName() {
+			return _jenkinsSlaveName;
+		}
+
+		public int getNumber() {
+			return _jsonObject.optInt("number", -1);
+		}
+
+		public String getOfflineCauseReason() {
+			return _offlineCauseReason;
+		}
+
+		public long getTimestamp() {
+			return _jsonObject.optLong("timestamp", -1);
+		}
+
+		public String getURL() {
+			return _jsonObject.optString("url");
+		}
+
+		public boolean isBuilding() {
+			return _jsonObject.optBoolean("building", true);
+		}
+
+		public boolean isJenkinsSlaveOffline() {
+			return _jenkinsSlaveOffline;
+		}
+
+		public boolean isLikelyStuck() {
+			return _likelyStuck;
+		}
+
+		@Override
+		public String toString() {
+			return JenkinsResultsParserUtil.combine(
+				_jenkinsMaster.getName(), " ", getFullDisplayName(), " (",
+				getURL(), ")");
+		}
+
+		protected RunningBuild(
+			JenkinsMaster jenkinsMaster, String jenkinsSlaveName,
+			JSONObject computerJSONObject,
+			JSONObject currentExecutableJSONObject, boolean likelyStuck) {
+
+			_jenkinsMaster = jenkinsMaster;
+			_jenkinsSlaveName = jenkinsSlaveName;
+			_likelyStuck = likelyStuck;
+
+			_jsonObject = currentExecutableJSONObject;
+
+			_jenkinsSlaveOffline = computerJSONObject.optBoolean(
+				"offline", false);
+			_offlineCauseReason = computerJSONObject.optString(
+				"offlineCauseReason");
+		}
+
+		private final JenkinsMaster _jenkinsMaster;
+		private final String _jenkinsSlaveName;
+		private final boolean _jenkinsSlaveOffline;
+		private final JSONObject _jsonObject;
+		private final boolean _likelyStuck;
+		private final String _offlineCauseReason;
+
+	}
+
 	protected static long maxRecentBatchAge = 120 * 1000;
 
 	private static Map<String, String> _getParameters(JSONObject jsonObject) {
@@ -1340,6 +1453,39 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		catch (Exception exception) {
 			throw new RuntimeException(
 				"Unable to determine URL for master " + _masterName, exception);
+		}
+	}
+
+	private void _addRunningBuilds(
+		List<RunningBuild> runningBuilds, JSONObject computerJSONObject,
+		String jenkinsSlaveName) {
+
+		for (String key : new String[] {"executors", "oneOffExecutors"}) {
+			JSONArray executorsJSONArray = computerJSONObject.optJSONArray(key);
+
+			if (executorsJSONArray == null) {
+				continue;
+			}
+
+			for (int i = 0; i < executorsJSONArray.length(); i++) {
+				JSONObject executorJSONObject =
+					executorsJSONArray.getJSONObject(i);
+
+				JSONObject currentExecutableJSONObject =
+					executorJSONObject.optJSONObject("currentExecutable");
+
+				if ((currentExecutableJSONObject == null) ||
+					!currentExecutableJSONObject.has("url")) {
+
+					continue;
+				}
+
+				runningBuilds.add(
+					new RunningBuild(
+						this, jenkinsSlaveName, computerJSONObject,
+						currentExecutableJSONObject,
+						executorJSONObject.optBoolean("likelyStuck", false)));
+			}
 		}
 	}
 
@@ -1712,6 +1858,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		new HashMap<>();
 	private final Map<String, Long> _buildsUpdateTimes = new HashMap<>();
 	private final List<String> _buildURLs = new CopyOnWriteArrayList<>();
+	private int _busyExecutorCount;
 	private final List<DefaultBuild> _defaultBuilds = new ArrayList<>();
 	private Map<String, String> _globalEnvironmentVariables;
 	private boolean _idle;
@@ -1728,6 +1875,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	private boolean _offline;
 	private final List<QueueItem> _queueItems = new ArrayList<>();
 	private Long _queueUpdateTime;
+	private final List<RunningBuild> _runningBuilds =
+		new CopyOnWriteArrayList<>();
 	private final Integer _slaveRAM;
 	private final Integer _slavesPerHost;
 	private List<String> _topLevelJobNames;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -29,24 +29,19 @@ public class JenkinsStopBuildUtil {
 		String normalizedURL = JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.getLocalURL(jenkinsMaster.getURL()));
 
-		URL urlObject = new URL(
-			normalizedURL + "/queue/cancelItem?id=" + queueId);
-
-		HttpURLConnection httpConnection =
-			(HttpURLConnection)urlObject.openConnection();
-
-		httpConnection.setRequestMethod("POST");
-
-		_setAuthorization(httpConnection);
-
-		System.out.println(
-			"Response from " + urlObject.toString() + ": " +
-				httpConnection.getResponseCode() + " " +
-					httpConnection.getResponseMessage());
+		_post(normalizedURL + "/queue/cancelItem?id=" + queueId);
 	}
 
 	public static void stopBuild(String buildURL) throws Exception {
-		_stopDownstreamBuilds(buildURL);
+		try {
+			_stopDownstreamBuilds(buildURL);
+		}
+		catch (Exception exception) {
+			System.out.println(
+				"Unable to stop the downstream builds of " + buildURL);
+
+			exception.printStackTrace();
+		}
 
 		_stopBuild(buildURL);
 	}
@@ -102,6 +97,35 @@ public class JenkinsStopBuildUtil {
 		return downstreamURLs;
 	}
 
+	private static boolean _isBuilding(String normalizedBuildURL)
+		throws Exception {
+
+		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
+			normalizedBuildURL + "/api/json?tree=result", false);
+
+		if (jsonObject.has("result") && jsonObject.isNull("result")) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static void _post(String urlString) throws Exception {
+		URL urlObject = new URL(urlString);
+
+		HttpURLConnection httpConnection =
+			(HttpURLConnection)urlObject.openConnection();
+
+		httpConnection.setRequestMethod("POST");
+
+		_setAuthorization(httpConnection);
+
+		System.out.println(
+			"Response from " + urlObject.toString() + ": " +
+				httpConnection.getResponseCode() + " " +
+					httpConnection.getResponseMessage());
+	}
+
 	private static void _setAuthorization(HttpURLConnection httpConnection)
 		throws Exception {
 
@@ -123,24 +147,25 @@ public class JenkinsStopBuildUtil {
 		String normalizedBuildURL = JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.getLocalURL(buildURL));
 
-		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-			normalizedBuildURL + "/api/json?tree=result", false);
-
-		if (jsonObject.has("result") && jsonObject.isNull("result")) {
-			URL urlObject = new URL(normalizedBuildURL + "/stop");
-
-			HttpURLConnection httpConnection =
-				(HttpURLConnection)urlObject.openConnection();
-
-			httpConnection.setRequestMethod("POST");
-
-			_setAuthorization(httpConnection);
-
-			System.out.println(
-				"Response from " + urlObject.toString() + ": " +
-					httpConnection.getResponseCode() + " " +
-						httpConnection.getResponseMessage());
+		if (!_isBuilding(normalizedBuildURL)) {
+			return;
 		}
+
+		_post(normalizedBuildURL + "/stop");
+
+		for (int i = 0; i < _KILL_ESCALATION_RETRIES; i++) {
+			JenkinsResultsParserUtil.sleep(_KILL_ESCALATION_WAIT_DURATION);
+
+			if (!_isBuilding(normalizedBuildURL)) {
+				return;
+			}
+		}
+
+		System.out.println(
+			normalizedBuildURL +
+				" ignored \"/stop\". Escalating to \"/kill\".");
+
+		_post(normalizedBuildURL + "/kill");
 	}
 
 	private static void _stopDownstreamBuilds(String buildURL)
@@ -152,6 +177,10 @@ public class JenkinsStopBuildUtil {
 			_stopBuild(downstreamURL);
 		}
 	}
+
+	private static final int _KILL_ESCALATION_RETRIES = 6;
+
+	private static final long _KILL_ESCALATION_WAIT_DURATION = 5 * 1000;
 
 	private static final Pattern _buildURLPattern = Pattern.compile(
 		".+://(?<hostName>[^.]+)(.liferay.com)?/job/(?<jobName>[^/]+).*/" +

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -1,0 +1,296 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Calum Ragan
+ */
+public class StaleBuildReaper {
+
+	public StaleBuildReaper(JenkinsCohort jenkinsCohort, boolean dryRun) {
+		_jenkinsCohort = jenkinsCohort;
+		_dryRun = dryRun;
+	}
+
+	public int getReapedBuildCount() {
+		int reapedBuildCount = 0;
+
+		for (ReapAction reapAction : _reapActions) {
+			if (reapAction.isExecuted()) {
+				reapedBuildCount++;
+			}
+		}
+
+		return reapedBuildCount;
+	}
+
+	public String getSummary() {
+		StringBuilder sb = new StringBuilder();
+
+		if (_dryRun) {
+			sb.append("Found ");
+			sb.append(_reapActions.size());
+			sb.append(" stale build(s). No build was aborted because DRY_RUN ");
+			sb.append("is enabled.");
+		}
+		else {
+			sb.append("Reaped ");
+			sb.append(getReapedBuildCount());
+			sb.append(" of ");
+			sb.append(_reapActions.size());
+			sb.append(" stale build(s).");
+		}
+
+		for (ReapAction reapAction : _reapActions) {
+			sb.append("\n");
+			sb.append(reapAction.getSummary());
+		}
+
+		return sb.toString();
+	}
+
+	public void reap() {
+		_generateReapActions();
+
+		_executeReapActions();
+
+		System.out.println(getSummary());
+
+		_sendSlackNotification();
+	}
+
+	public static enum Reason {
+
+		LIKELY_STUCK("its executor reports likelyStuck"),
+		NODE_BEING_REMOVED("its node is being removed"),
+		NODE_OFFLINE("its node is offline"),
+		PAST_ESTIMATED_DURATION("it is running far past its estimate");
+
+		public String getDescription() {
+			return _description;
+		}
+
+		private Reason(String description) {
+			_description = description;
+		}
+
+		private final String _description;
+
+	}
+
+	private void _executeReapActions() {
+		if (_dryRun) {
+			return;
+		}
+
+		for (ReapAction reapAction : _reapActions) {
+			reapAction.execute();
+		}
+	}
+
+	private void _generateReapActions() {
+		for (JenkinsMaster jenkinsMaster : _getJenkinsMasters()) {
+			jenkinsMaster.update(false);
+
+			List<JenkinsMaster.RunningBuild> runningBuilds =
+				jenkinsMaster.getRunningBuilds();
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					jenkinsMaster.getName(), " has at most ",
+					String.valueOf(jenkinsMaster.getMaximumRunningBuildCount()),
+					" running build(s). Enumerated ",
+					String.valueOf(runningBuilds.size()), "."));
+
+			for (JenkinsMaster.RunningBuild runningBuild : runningBuilds) {
+				List<Reason> reasons = _getReasons(runningBuild);
+
+				if (reasons.isEmpty()) {
+					continue;
+				}
+
+				_reapActions.add(new ReapAction(runningBuild, reasons));
+			}
+		}
+	}
+
+	private List<JenkinsMaster> _getJenkinsMasters() {
+		List<JenkinsMaster> jenkinsMasters = new ArrayList<>(
+			_jenkinsCohort.getAvailableJenkinsMasters());
+
+		for (JenkinsMaster jenkinsMaster :
+				_jenkinsCohort.getBlacklistedJenkinsMasters()) {
+
+			if (!jenkinsMasters.contains(jenkinsMaster)) {
+				jenkinsMasters.add(jenkinsMaster);
+			}
+		}
+
+		return jenkinsMasters;
+	}
+
+	private List<Reason> _getReasons(JenkinsMaster.RunningBuild runningBuild) {
+		List<Reason> reasons = new ArrayList<>();
+
+		if (!runningBuild.isBuilding()) {
+			return reasons;
+		}
+
+		long elapsedDuration = runningBuild.getElapsedDuration();
+
+		if (elapsedDuration < _MINIMUM_ELAPSED_DURATION) {
+			return reasons;
+		}
+
+		if (runningBuild.isLikelyStuck()) {
+			reasons.add(Reason.LIKELY_STUCK);
+		}
+
+		if (runningBuild.isJenkinsSlaveOffline()) {
+			String offlineCauseReason = runningBuild.getOfflineCauseReason();
+
+			if ((offlineCauseReason != null) &&
+				offlineCauseReason.contains(_OFFLINE_CAUSE_REASON_REMOVED)) {
+
+				reasons.add(Reason.NODE_BEING_REMOVED);
+			}
+			else {
+				reasons.add(Reason.NODE_OFFLINE);
+			}
+		}
+
+		long estimatedDuration = runningBuild.getEstimatedDuration();
+
+		if (estimatedDuration > 0) {
+			long thresholdDuration =
+				estimatedDuration * _ESTIMATED_DURATION_MULTIPLIER;
+
+			if (elapsedDuration > thresholdDuration) {
+				reasons.add(Reason.PAST_ESTIMATED_DURATION);
+			}
+		}
+
+		return reasons;
+	}
+
+	private void _sendSlackNotification() {
+		if (_reapActions.isEmpty()) {
+			return;
+		}
+
+		String subject = "Stale builds reaped";
+
+		if (_dryRun) {
+			subject = "Stale builds detected";
+		}
+
+		NotificationUtil.sendSlackNotification(
+			getSummary(), _SLACK_CHANNEL_NAME, subject);
+	}
+
+	private static final int _ESTIMATED_DURATION_MULTIPLIER = 10;
+
+	private static final long _MINIMUM_ELAPSED_DURATION = 4 * 60 * 60 * 1000L;
+
+	private static final String _OFFLINE_CAUSE_REASON_REMOVED =
+		"is being removed";
+
+	private static final String _SLACK_CHANNEL_NAME = "ci-notifications";
+
+	private final boolean _dryRun;
+	private final JenkinsCohort _jenkinsCohort;
+	private final List<ReapAction> _reapActions = new ArrayList<>();
+
+	private class ReapAction {
+
+		public void execute() {
+			String buildURL = _runningBuild.getURL();
+
+			try {
+				JenkinsStopBuildUtil.stopBuild(buildURL);
+
+				_executed = true;
+			}
+			catch (Exception exception) {
+				System.out.println("Unable to reap " + buildURL);
+
+				exception.printStackTrace();
+			}
+		}
+
+		public String getSummary() {
+			StringBuilder sb = new StringBuilder();
+
+			JenkinsMaster jenkinsMaster = _runningBuild.getJenkinsMaster();
+
+			sb.append(jenkinsMaster.getName());
+
+			sb.append(" ");
+			sb.append(_runningBuild.getFullDisplayName());
+			sb.append(" on ");
+			sb.append(_runningBuild.getJenkinsSlaveName());
+			sb.append(" has been running for ");
+			sb.append(
+				JenkinsResultsParserUtil.toDurationString(
+					_runningBuild.getElapsedDuration()));
+
+			long estimatedDuration = _runningBuild.getEstimatedDuration();
+
+			if (estimatedDuration > 0) {
+				sb.append(" against an estimate of ");
+				sb.append(
+					JenkinsResultsParserUtil.toDurationString(
+						estimatedDuration));
+			}
+
+			sb.append(". Flagged because ");
+
+			List<String> descriptions = new ArrayList<>();
+
+			for (Reason reason : _reasons) {
+				descriptions.add(reason.getDescription());
+			}
+
+			sb.append(JenkinsResultsParserUtil.join(", and ", descriptions));
+
+			sb.append(". ");
+
+			if (_dryRun) {
+				sb.append("Not aborted (DRY_RUN). ");
+			}
+			else if (_executed) {
+				sb.append("Aborted. ");
+			}
+			else {
+				sb.append("Abort failed. ");
+			}
+
+			sb.append(_runningBuild.getURL());
+
+			return sb.toString();
+		}
+
+		public boolean isExecuted() {
+			return _executed;
+		}
+
+		private ReapAction(
+			JenkinsMaster.RunningBuild runningBuild, List<Reason> reasons) {
+
+			_runningBuild = runningBuild;
+			_reasons = reasons;
+		}
+
+		private boolean _executed;
+		private final List<Reason> _reasons;
+		private final JenkinsMaster.RunningBuild _runningBuild;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.util.List;
 import java.util.Map;
 
 import org.json.JSONArray;
@@ -48,6 +49,22 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		setUrlReaderOutput(
 			read(new File(dependenciesDirs.get(0), "computer-api.json")),
 			"http://test-9-1/computer/api/json", urlReader);
+
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"items", new JSONArray()
+			).toString(),
+			"http://test-9-2/queue/api/json", urlReader);
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"mode", "NORMAL"
+			).toString(),
+			"http://test-9-2/api/json?tree=mode", urlReader);
+		setUrlReaderOutput(
+			_getRunningBuildsComputerAPIJSONObject().toString(),
+			"http://test-9-2/computer/api/json", urlReader);
 
 		_jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
 			"test-9-1", "http://test-9-1");
@@ -91,6 +108,46 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
+	public void testGetRunningBuilds() {
+		JenkinsMaster jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
+			"test-9-2", "http://test-9-2");
+
+		jenkinsMaster.update();
+
+		List<JenkinsMaster.RunningBuild> runningBuilds =
+			jenkinsMaster.getRunningBuilds();
+
+		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
+
+		Assert.assertEquals(3, jenkinsMaster.getMaximumRunningBuildCount());
+
+		JenkinsMaster.RunningBuild flyweightRunningBuild = _getRunningBuild(
+			runningBuilds, _FLYWEIGHT_BUILD_URL);
+
+		Assert.assertEquals(
+			"Built-In Node", flyweightRunningBuild.getJenkinsSlaveName());
+		Assert.assertFalse(flyweightRunningBuild.isLikelyStuck());
+		Assert.assertFalse(flyweightRunningBuild.isJenkinsSlaveOffline());
+
+		JenkinsMaster.RunningBuild likelyStuckRunningBuild = _getRunningBuild(
+			runningBuilds, _LIKELY_STUCK_BUILD_URL);
+
+		Assert.assertTrue(likelyStuckRunningBuild.isLikelyStuck());
+		Assert.assertFalse(likelyStuckRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertEquals(1580, likelyStuckRunningBuild.getNumber());
+		Assert.assertEquals(
+			60 * 60 * 1000L, likelyStuckRunningBuild.getEstimatedDuration());
+
+		JenkinsMaster.RunningBuild offlineRunningBuild = _getRunningBuild(
+			runningBuilds, _OFFLINE_NODE_BUILD_URL);
+
+		Assert.assertTrue(offlineRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertEquals(
+			"Node is being removed",
+			offlineRunningBuild.getOfflineCauseReason());
+	}
+
+	@Test
 	public void testUpdate() {
 		_jenkinsMaster.update();
 
@@ -116,6 +173,51 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertFalse(labelBatchSizes.isEmpty());
 	}
+
+	private JenkinsMaster.RunningBuild _getRunningBuild(
+		List<JenkinsMaster.RunningBuild> runningBuilds, String buildURL) {
+
+		for (JenkinsMaster.RunningBuild runningBuild : runningBuilds) {
+			String runningBuildURL = runningBuild.getURL();
+
+			if (runningBuildURL.equals(buildURL)) {
+				return runningBuild;
+			}
+		}
+
+		throw new AssertionError(
+			"Unable to find " + buildURL + " in " + runningBuilds);
+	}
+
+	private JSONObject _getRunningBuildsComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			1,
+			JenkinsMasterTestUtil.getBuiltInComputerJSONObject(
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_FLYWEIGHT_BUILD_URL, "publish-testray-report #7", 7, false,
+					1700000000000L, 5 * 60 * 1000L)),
+			JenkinsMasterTestUtil.getComputerJSONObject(
+				"test-9-2-1",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_LIKELY_STUCK_BUILD_URL,
+					"test-portal-acceptance-pullrequest(master) #1580", 1580,
+					true, 1700000000000L, 60 * 60 * 1000L)),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-2", "Node is being removed",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_OFFLINE_NODE_BUILD_URL,
+					"test-portal-release-downstream #22649", 22649, false,
+					1700000000000L, 8 * 60 * 60 * 1000L)));
+	}
+
+	private static final String _FLYWEIGHT_BUILD_URL =
+		"http://test-9-2/job/publish-testray-report/7/";
+
+	private static final String _LIKELY_STUCK_BUILD_URL =
+		"http://test-9-2/job/test-portal-acceptance-pullrequest(master)/1580/";
+
+	private static final String _OFFLINE_NODE_BUILD_URL =
+		"http://test-9-2/job/test-portal-release-downstream/22649/";
 
 	private JenkinsMaster _jenkinsMaster;
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -10,10 +10,67 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 /**
  * @author Calum Ragan
  */
 public class JenkinsMasterTestUtil {
+
+	public static JSONObject getBuiltInComputerJSONObject(
+		JSONObject... oneOffExecutorJSONObjects) {
+
+		return _getComputerJSONObject(
+			"Built-In Node", "hudson.model.Hudson$MasterComputer", false, "",
+			new JSONArray(), new JSONArray(oneOffExecutorJSONObjects));
+	}
+
+	public static JSONObject getComputerAPIJSONObject(
+		int busyExecutorCount, JSONObject... computerJSONObjects) {
+
+		return new JSONObject(
+		).put(
+			"busyExecutors", busyExecutorCount
+		).put(
+			"computer", new JSONArray(computerJSONObjects)
+		);
+	}
+
+	public static JSONObject getComputerJSONObject(
+		String displayName, JSONObject... executorJSONObjects) {
+
+		return _getComputerJSONObject(
+			displayName, "hudson.slaves.SlaveComputer", false, "",
+			new JSONArray(executorJSONObjects), new JSONArray());
+	}
+
+	public static JSONObject getExecutorJSONObject(
+		String buildURL, String fullDisplayName, int number,
+		boolean likelyStuck, long timestamp, long estimatedDuration) {
+
+		JSONObject currentExecutableJSONObject = new JSONObject(
+		).put(
+			"building", true
+		).put(
+			"estimatedDuration", estimatedDuration
+		).put(
+			"fullDisplayName", fullDisplayName
+		).put(
+			"number", number
+		).put(
+			"timestamp", timestamp
+		).put(
+			"url", buildURL
+		);
+
+		return new JSONObject(
+		).put(
+			"currentExecutable", currentExecutableJSONObject
+		).put(
+			"likelyStuck", likelyStuck
+		);
+	}
 
 	public static Properties getJenkinsCohortProperties(
 		String cohortName, int masterCount) {
@@ -76,7 +133,22 @@ public class JenkinsMasterTestUtil {
 			jenkinsMaster, "_labelBatchSizes");
 	}
 
+	public static JSONObject getOfflineComputerJSONObject(
+		String displayName, String offlineCauseReason,
+		JSONObject... executorJSONObjects) {
+
+		return _getComputerJSONObject(
+			displayName, "hudson.slaves.EC2FleetNodeComputer", true,
+			offlineCauseReason, new JSONArray(executorJSONObjects),
+			new JSONArray());
+	}
+
 	public static void resetCaches() {
+		Map<String, ?> jenkinsCohorts = ReflectionTestUtil.getFieldValue(
+			JenkinsCohort.class, "_jenkinsCohorts");
+
+		jenkinsCohorts.clear();
+
 		Map<String, ?> jenkinsMasters = ReflectionTestUtil.getFieldValue(
 			JenkinsMaster.class, "_jenkinsMasters");
 
@@ -96,6 +168,39 @@ public class JenkinsMasterTestUtil {
 			LoadBalancerUtil.class, "_roundRobinCounters");
 
 		roundRobinCounters.clear();
+	}
+
+	private static JSONObject _getComputerJSONObject(
+		String displayName, String className, boolean offline,
+		String offlineCauseReason, JSONArray executorsJSONArray,
+		JSONArray oneOffExecutorsJSONArray) {
+
+		JSONObject assignedLabelJSONObject = new JSONObject();
+
+		assignedLabelJSONObject.put("name", displayName);
+
+		JSONArray assignedLabelsJSONArray = new JSONArray();
+
+		assignedLabelsJSONArray.put(assignedLabelJSONObject);
+
+		return new JSONObject(
+		).put(
+			"_class", className
+		).put(
+			"assignedLabels", assignedLabelsJSONArray
+		).put(
+			"displayName", displayName
+		).put(
+			"executors", executorsJSONArray
+		).put(
+			"idle", executorsJSONArray.isEmpty()
+		).put(
+			"offline", offline
+		).put(
+			"offlineCauseReason", offlineCauseReason
+		).put(
+			"oneOffExecutors", oneOffExecutorsJSONArray
+		);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
@@ -1,0 +1,265 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Calum Ragan
+ */
+public class StaleBuildReaperTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Environment.setInstance(Mockito.mock(Environment.class));
+
+		_urlReader = mockUrlReader();
+
+		JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 2);
+
+		_setUpJenkinsMaster("test-9-1", _getTest91ComputerAPIJSONObject());
+		_setUpJenkinsMaster("test-9-2", _getTest92ComputerAPIJSONObject());
+
+		_jenkinsCohort = JenkinsCohort.getInstance("test-9");
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+
+		JenkinsResultsParserUtil.setBuildProperties(new Properties());
+	}
+
+	@Test
+	public void testGetSummary() {
+		StaleBuildReaper staleBuildReaper = _reap(
+			true, new ArrayList<String>());
+
+		String summary = staleBuildReaper.getSummary();
+
+		Assert.assertTrue(
+			summary, summary.startsWith("Found 3 stale build(s)"));
+
+		Assert.assertTrue(summary, summary.contains(_LIKELY_STUCK_BUILD_URL));
+		Assert.assertTrue(summary, summary.contains(_NODE_REMOVED_BUILD_URL));
+		Assert.assertTrue(summary, summary.contains(_PAST_ESTIMATE_BUILD_URL));
+
+		Assert.assertFalse(summary, summary.contains(_HEALTHY_BUILD_URL));
+		Assert.assertFalse(summary, summary.contains(_RECENT_BUILD_URL));
+
+		Assert.assertTrue(
+			summary, summary.contains("its executor reports likelyStuck"));
+		Assert.assertTrue(
+			summary, summary.contains("its node is being removed"));
+		Assert.assertTrue(
+			summary, summary.contains("it is running far past its estimate"));
+	}
+
+	@Test
+	public void testReap() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(false, stoppedBuildURLs);
+
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+
+		String summary = staleBuildReaper.getSummary();
+
+		Assert.assertTrue(
+			summary, summary.startsWith("Reaped 3 of 3 stale build(s)"));
+
+		List<String> expectedBuildURLs = new ArrayList<>();
+
+		expectedBuildURLs.add(_LIKELY_STUCK_BUILD_URL);
+		expectedBuildURLs.add(_NODE_REMOVED_BUILD_URL);
+		expectedBuildURLs.add(_PAST_ESTIMATE_BUILD_URL);
+
+		Collections.sort(expectedBuildURLs);
+
+		Collections.sort(stoppedBuildURLs);
+
+		Assert.assertEquals(expectedBuildURLs, stoppedBuildURLs);
+	}
+
+	@Test
+	public void testReapBlacklistedJenkinsMaster() {
+		ReflectionTestUtil.setFieldValue(
+			JenkinsMaster.getInstance("test-9-2"), "_blacklisted", true);
+
+		List<JenkinsMaster> availableJenkinsMasters =
+			_jenkinsCohort.getAvailableJenkinsMasters();
+
+		Assert.assertEquals(
+			availableJenkinsMasters.toString(), 1,
+			availableJenkinsMasters.size());
+
+		List<JenkinsMaster> blacklistedJenkinsMasters =
+			_jenkinsCohort.getBlacklistedJenkinsMasters();
+
+		Assert.assertEquals(
+			blacklistedJenkinsMasters.toString(), 1,
+			blacklistedJenkinsMasters.size());
+
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(false, stoppedBuildURLs);
+
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertTrue(
+			stoppedBuildURLs.toString(),
+			stoppedBuildURLs.contains(_PAST_ESTIMATE_BUILD_URL));
+	}
+
+	@Test
+	public void testReapDryRun() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(true, stoppedBuildURLs);
+
+		Assert.assertEquals(0, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertTrue(
+			stoppedBuildURLs.toString(), stoppedBuildURLs.isEmpty());
+	}
+
+	private JSONObject _getTest91ComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			1,
+			JenkinsMasterTestUtil.getBuiltInComputerJSONObject(
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_HEALTHY_BUILD_URL, "test-portal-release-downstream #1", 1,
+					false, _timestampAgo(20 * _HOUR), 30 * _HOUR)),
+			JenkinsMasterTestUtil.getComputerJSONObject(
+				"test-9-1-1",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_LIKELY_STUCK_BUILD_URL,
+					"test-portal-acceptance-pullrequest(master) #1580", 1580,
+					true, _timestampAgo(20 * _HOUR), 100 * _MINUTE)),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-1-2", "Node is being removed",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_NODE_REMOVED_BUILD_URL,
+					"test-portal-release-downstream #22649", 22649, false,
+					_timestampAgo(12 * 24 * _HOUR), 8 * _HOUR)));
+	}
+
+	private JSONObject _getTest92ComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			2,
+			JenkinsMasterTestUtil.getComputerJSONObject(
+				"test-9-2-1",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_PAST_ESTIMATE_BUILD_URL,
+					"test-portal-testsuite-downstream #166636", 166636, false,
+					_timestampAgo(46 * _HOUR), 4 * _HOUR),
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_RECENT_BUILD_URL, "test-portal-source-format(master) #99",
+					99, false, _timestampAgo(2 * _HOUR), 5 * _MINUTE)));
+	}
+
+	private StaleBuildReaper _reap(
+		boolean dryRun, List<String> stoppedBuildURLs) {
+
+		try (MockedStatic<JenkinsStopBuildUtil> stopBuildMockedStatic =
+				Mockito.mockStatic(JenkinsStopBuildUtil.class);
+			MockedStatic<NotificationUtil> notificationMockedStatic =
+				Mockito.mockStatic(NotificationUtil.class)) {
+
+			stopBuildMockedStatic.when(
+				() -> JenkinsStopBuildUtil.stopBuild(Mockito.anyString())
+			).thenAnswer(
+				invocation -> {
+					stoppedBuildURLs.add(invocation.getArgument(0));
+
+					return null;
+				}
+			);
+
+			StaleBuildReaper staleBuildReaper = new StaleBuildReaper(
+				_jenkinsCohort, dryRun);
+
+			staleBuildReaper.reap();
+
+			return staleBuildReaper;
+		}
+	}
+
+	private void _setUpJenkinsMaster(
+			String masterName, JSONObject computerAPIJSONObject)
+		throws Exception {
+
+		String masterURL = "http://" + masterName;
+
+		JSONObject queueJSONObject = new JSONObject();
+
+		queueJSONObject.put("items", new JSONArray());
+
+		setUrlReaderOutput(
+			queueJSONObject.toString(), masterURL + "/queue/api/json",
+			_urlReader);
+
+		JSONObject modeJSONObject = new JSONObject();
+
+		modeJSONObject.put("mode", "NORMAL");
+
+		setUrlReaderOutput(
+			modeJSONObject.toString(), masterURL + "/api/json?tree=mode",
+			_urlReader);
+
+		setUrlReaderOutput(
+			computerAPIJSONObject.toString(), masterURL + "/computer/api/json",
+			_urlReader);
+	}
+
+	private long _timestampAgo(long duration) {
+		return System.currentTimeMillis() - duration;
+	}
+
+	private static final String _HEALTHY_BUILD_URL =
+		"http://test-9-1/job/test-portal-release-downstream/1/";
+
+	private static final long _HOUR = 60 * 60 * 1000L;
+
+	private static final String _LIKELY_STUCK_BUILD_URL =
+		"http://test-9-1/job/test-portal-acceptance-pullrequest(master)/1580/";
+
+	private static final long _MINUTE = 60 * 1000L;
+
+	private static final String _NODE_REMOVED_BUILD_URL =
+		"http://test-9-1/job/test-portal-release-downstream/22649/";
+
+	private static final String _PAST_ESTIMATE_BUILD_URL =
+		"http://test-9-2/job/test-portal-testsuite-downstream/166636/";
+
+	private static final String _RECENT_BUILD_URL =
+		"http://test-9-2/job/test-portal-source-format(master)/99/";
+
+	private JenkinsCohort _jenkinsCohort;
+	private UrlReader _urlReader;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7904

## What Is Being Fixed

A build whose agent is torn down under it, or that wedges in teardown, can hold a Jenkins executor for hours or days. Nothing aborts it today, so it pins its cloud fleet node up and quietly reduces capacity until someone notices by hand. During the ITINF-6110 rolling blacklist three such builds were found on production masters, the oldest running for twelve and a half days.

Two things made these builds hard to see. `JenkinsMaster` enumerated `currentExecutable` only from the `executors` of fleet and slave computers, so a build on a flyweight executor or on a node that had gone offline was invisible, and it was also missing from `busyExecutors`. Separately, `isAvailable` conflated reachability with eligibility: it probed nothing for a blacklisted master and simply returned false, so `update` bailed out and a blacklisted master reported no running builds at all. That is the case that matters most, since a rolling blacklist drains a master precisely so it can be taken out of service, and a build holding an executor is what stops it reaching zero.

## How It Is Being Fixed

`StaleBuildReaper` walks every master in the cohort, including blacklisted ones, and flags a running build when its executor reports `likelyStuck`, when its node is offline or being removed, or when it has run past ten times its estimate. Every criterion is gated on a four hour minimum so a node reconnecting, or an executor that momentarily looks stuck, is left alone. It reports what it found in the console log and the build description, and posts to Slack. The caller decides whether to abort or only report, so the job ships in a reporting mode first and the thresholds can be watched against real traffic before anything is aborted.

`JenkinsMaster` now enumerates across both `executors` and `oneOffExecutors` on every computer, and exposes the result along with an upper bound that takes the greater of `busyExecutors` and what was enumerated. The existing build URL list is deliberately left as it was, so the CI system status report is unchanged.

`isAvailable` is now a reachability probe alone. Every caller either already tests `isBlacklisted` separately, in `JenkinsCohort` in three places and in `build-common.xml` in `liferay-jenkins-ee`, or wants reachability rather than eligibility, so master selection is unaffected. Two callers improve as a result: reading live test reports and reading global environment variables now work against a master that is merely draining instead of returning nothing.

`JenkinsStopBuildUtil` escalates to `/kill` when `/stop` does not take, because a build blocked on a dead agent channel never receives the interrupt. Reading downstream URLs from the console log is now non-fatal, since that log is large and slow on a build wedged for days and must not prevent the parent from being stopped.

`StaleBuildReaperTest` covers each detection reason, the four hour floor, the dry run path, and the blacklisted master case. That last test was checked against the unfixed gate and fails there, so it pins the behavior rather than passing incidentally.

## PR Check

**pr-check: PASS** — tested on `f07b3948710a7a30b0db6737cd1a6a7d85f315c5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f07b3948710a7a30b0db6737cd1a6a7d85f315c5"} -->
