### PR TITLE
LRCI-8027 Remove unnecessary auth for server that does not exist (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -251,29 +251,7 @@ public class FilePropagator {
 			if (sourceFileName.startsWith("http")) {
 				StringBuilder sb = new StringBuilder();
 
-				sb.append("curl ");
-
-				try {
-					if (sourceFileName.startsWith(
-							"https://release.liferay.com")) {
-
-						sb.append(" -u ");
-						sb.append(
-							JenkinsResultsParserUtil.getBuildProperty(
-								"jenkins.admin.user.name"));
-						sb.append(":");
-						sb.append(
-							JenkinsResultsParserUtil.getBuildProperty(
-								"jenkins.admin.user.password"));
-					}
-				}
-				catch (IOException ioException) {
-					throw new FilePropagatorRuntimeException(
-						this, "Unable to get jenkins-admin user credentials",
-						ioException);
-				}
-
-				sb.append("-o ");
+				sb.append("curl -o ");
 				sb.append(targetFileName);
 				sb.append(" ");
 				sb.append(sourceFileName);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -249,14 +249,10 @@ public class FilePropagator {
 			commands.add(_getMkdirCommand(targetFileName));
 
 			if (sourceFileName.startsWith("http")) {
-				StringBuilder sb = new StringBuilder();
-
-				sb.append("curl -f -L --max-redirs 0 -o ");
-				sb.append(targetFileName);
-				sb.append(" ");
-				sb.append(sourceFileName);
-
-				commands.add(sb.toString());
+				commands.add(
+					JenkinsResultsParserUtil.combine(
+						"curl --fail --location --max-redirs 0 --output ",
+						targetFileName, " ", sourceFileName));
 			}
 			else {
 				commands.add(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -251,7 +251,7 @@ public class FilePropagator {
 			if (sourceFileName.startsWith("http")) {
 				StringBuilder sb = new StringBuilder();
 
-				sb.append("curl -o ");
+				sb.append("curl -f -L --max-redirs 0 -o ");
 				sb.append(targetFileName);
 				sb.append(" ");
 				sb.append(sourceFileName);


### PR DESCRIPTION
[LRCI-8027](https://liferay.atlassian.net/browse/LRCI-8027)

Revises [#4497](https://github.com/pyoo47/liferay-portal/pull/4497) (opened by @michaelhashimoto) with the following follow-up commits:

- [97314181d71d](https://github.com/pyoo47/liferay-portal/commit/97314181d71d7e037ba3f8df197e8745ff336352) LRCI-8027 Fail the propagation when an HTTP source does not return 2xx
- [ba6cebe9890f](https://github.com/pyoo47/liferay-portal/commit/ba6cebe9890f47f246823416a021752da4efb3ec) LRCI-8027 Consistency

## Summary

Removing the auth branch left a bare `curl -o`, which writes an error or redirect body to the target and exits 0, so a dead source is mirrored as a corrupt file and reported as a successful propagation. The curl now uses `--fail --location --max-redirs 0`, so any non-2xx response exits non-zero and `FilePropagator`'s existing `process.exitValue() != 0` check routes the slave to `_errorSlaves`. The command construction also collapses to `JenkinsResultsParserUtil.combine(...)`, the idiom already used seven times in this file.
