### PR TITLE
LRCI-7820 Add the job health monitor check type

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
@@ -1,0 +1,362 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsMaster;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONObject;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class JobHealthMonitor implements Monitor {
+
+	public JobHealthMonitor(MonitorConfig monitorConfig) {
+		_monitorConfig = monitorConfig;
+
+		Map<String, String> parameters = monitorConfig.getParameters();
+
+		_cadenceSeconds = _getLongValue("parameter", 0, "cadence", parameters);
+		_expectedGreen = _isExpectedGreen(parameters);
+		_jobName = _getRequiredParameter("job.name", parameters);
+		_jobURL = _getJobURL(_getRequiredParameter("master.name", parameters));
+
+		Map<String, String> thresholds = monitorConfig.getThresholds();
+
+		_buildDurationMaximumSeconds = _getLongValue(
+			"threshold", 0, "build.duration.maximum", thresholds);
+		_overdueGraceSeconds = _getLongValue(
+			"threshold",
+			Math.max(_SECONDS_OVERDUE_GRACE_MINIMUM, _cadenceSeconds / 4),
+			"overdue.grace", thresholds);
+	}
+
+	@Override
+	public MonitorResult execute() {
+		long currentTimeMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		JSONObject jobJSONObject = null;
+
+		try {
+			jobJSONObject = _getJobJSONObject();
+		}
+		catch (Exception exception) {
+			return new MonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Unable to read ", _jobURL, ": ",
+					String.valueOf(exception.getMessage())),
+				null, MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		if (jobJSONObject == null) {
+			return new MonitorResult(
+				"Unable to read " + _jobURL, null,
+				MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		JSONObject lastBuildJSONObject = jobJSONObject.optJSONObject(
+			"lastBuild");
+		JSONObject lastCompletedBuildJSONObject = jobJSONObject.optJSONObject(
+			"lastCompletedBuild");
+
+		if ((lastBuildJSONObject == null) &&
+			(lastCompletedBuildJSONObject == null)) {
+
+			return new MonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Job ", _jobName, " has never run"),
+				null, MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		Map<String, String> metrics = new LinkedHashMap<>();
+		List<String> messages = new ArrayList<>();
+		List<MonitorResult.Status> statuses = new ArrayList<>();
+
+		if (lastCompletedBuildJSONObject != null) {
+			int number = lastCompletedBuildJSONObject.optInt("number");
+			String result = lastCompletedBuildJSONObject.optString("result");
+
+			metrics.put("last.completed.build.number", String.valueOf(number));
+			metrics.put("last.completed.build.result", result);
+
+			if (_expectedGreen &&
+				!JenkinsResultsParserUtil.isNullOrEmpty(result) &&
+				!result.equals("SUCCESS")) {
+
+				messages.add(
+					JenkinsResultsParserUtil.combine(
+						"Job ", _jobName, " completed build ",
+						String.valueOf(number), " with the result ", result));
+
+				if (result.equals("ABORTED")) {
+					statuses.add(MonitorResult.Status.WARN);
+				}
+				else {
+					statuses.add(MonitorResult.Status.CRITICAL);
+				}
+			}
+		}
+
+		long lastBuildTimestamp = _getLastBuildTimestamp(
+			lastBuildJSONObject, lastCompletedBuildJSONObject);
+
+		boolean buildRunning = _isBuildRunning(lastBuildJSONObject);
+
+		metrics.put("last.build.running", String.valueOf(buildRunning));
+
+		if (lastBuildTimestamp <= 0) {
+			messages.add(
+				JenkinsResultsParserUtil.combine(
+					"Unable to determine the last build timestamp for job ",
+					_jobName));
+
+			statuses.add(MonitorResult.Status.UNKNOWN);
+
+			return _newMonitorResult(
+				currentTimeMillis, messages, metrics, statuses);
+		}
+
+		long lastBuildAgeSeconds =
+			(currentTimeMillis - lastBuildTimestamp) / 1000;
+
+		metrics.put(
+			"last.build.age.seconds", String.valueOf(lastBuildAgeSeconds));
+
+		if (buildRunning && (_buildDurationMaximumSeconds > 0)) {
+			if (lastBuildAgeSeconds > _buildDurationMaximumSeconds) {
+				messages.add(
+					JenkinsResultsParserUtil.combine(
+						"Job ", _jobName, " has been running for ",
+						JenkinsResultsParserUtil.toDurationString(
+							lastBuildAgeSeconds * 1000),
+						", exceeding its maximum duration of ",
+						JenkinsResultsParserUtil.toDurationString(
+							_buildDurationMaximumSeconds * 1000)));
+
+				statuses.add(MonitorResult.Status.CRITICAL);
+			}
+		}
+		else if (_isOverdue(lastBuildAgeSeconds)) {
+			messages.add(_getOverdueMessage(buildRunning, lastBuildAgeSeconds));
+
+			statuses.add(MonitorResult.Status.WARN);
+		}
+
+		return _newMonitorResult(
+			currentTimeMillis, messages, metrics, statuses);
+	}
+
+	@Override
+	public String getId() {
+		return _monitorConfig.getId();
+	}
+
+	@Override
+	public MonitorConfig getMonitorConfig() {
+		return _monitorConfig;
+	}
+
+	private int _getAttemptTimeoutMillis() {
+		long timeoutSeconds = _monitorConfig.getTimeoutSeconds();
+
+		if (timeoutSeconds <= 0) {
+			timeoutSeconds = _SECONDS_TIMEOUT_DEFAULT;
+		}
+
+		timeoutSeconds = Math.min(timeoutSeconds, Integer.MAX_VALUE / 1000);
+
+		return (int)((timeoutSeconds * 1000) / 3);
+	}
+
+	private String _getCadenceMessage() {
+		return JenkinsResultsParserUtil.combine(
+			"exceeding its cadence of ",
+			JenkinsResultsParserUtil.toDurationString(_cadenceSeconds * 1000),
+			" plus a grace period of ",
+			JenkinsResultsParserUtil.toDurationString(
+				_overdueGraceSeconds * 1000));
+	}
+
+	private String _getInvalidValueMessage(
+		String category, String name, String value) {
+
+		return JenkinsResultsParserUtil.combine(
+			"Invalid ", name, " for ", _getKey(category, name), ": ", value);
+	}
+
+	private JSONObject _getJobJSONObject() throws IOException {
+		return JenkinsResultsParserUtil.toJSONObject(
+			JenkinsResultsParserUtil.combine(
+				_jobURL, "/api/json?tree=",
+				"lastBuild[building,number,timestamp],",
+				"lastCompletedBuild[number,result,timestamp]"),
+			false, 1, null, null, _SECONDS_RETRY_PERIOD,
+			_getAttemptTimeoutMillis(), null);
+	}
+
+	private String _getJobURL(String masterName) {
+		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(masterName);
+
+		String masterURL = jenkinsMaster.getURL();
+
+		if (!masterURL.endsWith("/")) {
+			masterURL += "/";
+		}
+
+		return JenkinsResultsParserUtil.combine(masterURL, "job/", _jobName);
+	}
+
+	private String _getKey(String category, String name) {
+		return JenkinsResultsParserUtil.combine(
+			"monitor[", _monitorConfig.getId(), "].", category, "[", name, "]");
+	}
+
+	private long _getLastBuildTimestamp(
+		JSONObject lastBuildJSONObject,
+		JSONObject lastCompletedBuildJSONObject) {
+
+		if (lastBuildJSONObject != null) {
+			return lastBuildJSONObject.optLong("timestamp");
+		}
+
+		return lastCompletedBuildJSONObject.optLong("timestamp");
+	}
+
+	private long _getLongValue(
+		String category, long defaultValue, String name,
+		Map<String, String> values) {
+
+		String value = values.get(name);
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+			return defaultValue;
+		}
+
+		long longValue = 0;
+
+		try {
+			longValue = Long.parseLong(value);
+		}
+		catch (NumberFormatException numberFormatException) {
+			throw new IllegalArgumentException(
+				_getInvalidValueMessage(category, name, value),
+				numberFormatException);
+		}
+
+		if (longValue < 0) {
+			throw new IllegalArgumentException(
+				_getInvalidValueMessage(category, name, value));
+		}
+
+		return longValue;
+	}
+
+	private String _getOverdueMessage(
+		boolean buildRunning, long lastBuildAgeSeconds) {
+
+		if (buildRunning) {
+			return JenkinsResultsParserUtil.combine(
+				"Job ", _jobName, " has been running for ",
+				JenkinsResultsParserUtil.toDurationString(
+					lastBuildAgeSeconds * 1000),
+				", ", _getCadenceMessage());
+		}
+
+		return JenkinsResultsParserUtil.combine(
+			"Job ", _jobName, " last ran ",
+			JenkinsResultsParserUtil.toDurationString(
+				lastBuildAgeSeconds * 1000),
+			" ago, ", _getCadenceMessage());
+	}
+
+	private String _getRequiredParameter(
+		String name, Map<String, String> parameters) {
+
+		String value = parameters.get(name);
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+			throw new IllegalArgumentException(
+				"Missing required property " + _getKey("parameter", name));
+		}
+
+		return value;
+	}
+
+	private boolean _isBuildRunning(JSONObject lastBuildJSONObject) {
+		if (lastBuildJSONObject == null) {
+			return false;
+		}
+
+		return lastBuildJSONObject.optBoolean("building");
+	}
+
+	private boolean _isExpectedGreen(Map<String, String> parameters) {
+		String expectedGreen = parameters.get("expected.green");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(expectedGreen)) {
+			return true;
+		}
+
+		if (!expectedGreen.equals("false") && !expectedGreen.equals("true")) {
+			throw new IllegalArgumentException(
+				_getInvalidValueMessage(
+					"parameter", "expected.green", expectedGreen));
+		}
+
+		return Boolean.parseBoolean(expectedGreen);
+	}
+
+	private boolean _isOverdue(long lastBuildAgeSeconds) {
+		if (_cadenceSeconds <= 0) {
+			return false;
+		}
+
+		if (lastBuildAgeSeconds > (_cadenceSeconds + _overdueGraceSeconds)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private MonitorResult _newMonitorResult(
+		long currentTimeMillis, List<String> messages,
+		Map<String, String> metrics, List<MonitorResult.Status> statuses) {
+
+		if (statuses.isEmpty()) {
+			return new MonitorResult(
+				JenkinsResultsParserUtil.combine("Job ", _jobName, " is OK"),
+				metrics, MonitorResult.Status.OK, currentTimeMillis);
+		}
+
+		return new MonitorResult(
+			JenkinsResultsParserUtil.join(". ", messages), metrics,
+			MonitorResult.Status.getMostSevere(statuses), currentTimeMillis);
+	}
+
+	private static final long _SECONDS_OVERDUE_GRACE_MINIMUM = 30 * 60;
+
+	private static final int _SECONDS_RETRY_PERIOD = 1;
+
+	private static final long _SECONDS_TIMEOUT_DEFAULT = 60;
+
+	private final long _buildDurationMaximumSeconds;
+	private final long _cadenceSeconds;
+	private final boolean _expectedGreen;
+	private final String _jobName;
+	private final String _jobURL;
+	private final MonitorConfig _monitorConfig;
+	private final long _overdueGraceSeconds;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorFactory.java
@@ -5,14 +5,23 @@
 
 package com.liferay.jenkins.results.parser.monitor;
 
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
 /**
  * @author Brittney Nguyen
  */
 public class MonitorFactory {
 
 	public static Monitor newMonitor(MonitorConfig monitorConfig) {
-		throw new IllegalArgumentException(
-			"Unknown monitor type: " + monitorConfig.getType());
+		String type = monitorConfig.getType();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(type) &&
+			type.equals("job-health")) {
+
+			return new JobHealthMonitor(monitorConfig);
+		}
+
+		throw new IllegalArgumentException("Unknown monitor type: " + type);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -1,0 +1,632 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsMasterTestUtil;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+import com.liferay.jenkins.results.parser.UrlReader;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class JobHealthMonitorTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		JenkinsMasterTestUtil.getJenkinsMaster(_MASTER_NAME, _MASTER_URL);
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+	}
+
+	@Test
+	public void testExecuteAborted() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "ABORTED",
+				JenkinsResultsParserUtil.getCurrentTimeMillis()));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.WARN, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result ABORTED",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximum() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (1800 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has been running for 30 " +
+				"minutes, exceeding its maximum duration of 15 minutes",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximumWithCadence() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (7200 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(4 * 3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "3600");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has been running for 2 hours, " +
+				"exceeding its maximum duration of 1 hour",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximumWithinBound() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (300 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximumWithoutThreshold()
+		throws Exception {
+
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (7200 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(4 * 3600 * 1000)));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteMasterURLWithTrailingSlash() throws Exception {
+		JenkinsMasterTestUtil.getJenkinsMaster(
+			_MASTER_NAME, _MASTER_URL_TRAILING_SLASH);
+
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(600 * 1000)));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller is OK",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteMissingLastBuildTimestamp() throws Exception {
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild",
+				new JSONObject(
+				).put(
+					"building", false
+				).put(
+					"number", 42
+				)
+			));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Unable to determine the last build timestamp for job " +
+				"generate-reports-controller",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreen() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "FAILURE",
+				JenkinsResultsParserUtil.getCurrentTimeMillis()));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result FAILURE",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreenAndOverdue() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "FAILURE",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result FAILURE. Job generate-reports-controller last ran 1 " +
+					"hour ago, exceeding its cadence of 15 minutes plus a " +
+						"grace period of 30 minutes",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreenMissingLastBuildTimestamp()
+		throws Exception {
+
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild",
+				new JSONObject(
+				).put(
+					"building", false
+				).put(
+					"number", 42
+				)
+			).put(
+				"lastCompletedBuild",
+				new JSONObject(
+				).put(
+					"number", 42
+				).put(
+					"result", "FAILURE"
+				).put(
+					"timestamp", JenkinsResultsParserUtil.getCurrentTimeMillis()
+				)
+			));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result FAILURE. Unable to determine the last build " +
+					"timestamp for job generate-reports-controller",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreenNotExpectedGreen() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "FAILURE",
+				JenkinsResultsParserUtil.getCurrentTimeMillis()));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[expected.green]", "false");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller is OK",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotTriggered() throws Exception {
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild", JSONObject.NULL
+			).put(
+				"lastCompletedBuild", JSONObject.NULL
+			));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has never run",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteOK() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller is OK",
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		testEquals("42", metrics.get("last.completed.build.number"));
+		testEquals("600", metrics.get("last.build.age.seconds"));
+		testEquals("SUCCESS", metrics.get("last.completed.build.result"));
+		testEquals("false", metrics.get("last.build.running"));
+	}
+
+	@Test
+	public void testExecuteOverdue() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.WARN, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller last ran 1 hour ago, exceeding " +
+				"its cadence of 15 minutes plus a grace period of 30 minutes",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteOverdueGraceThreshold() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+		monitorProperties.setProperty(
+			"monitor[a].threshold[overdue.grace]", "7200");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteOverdueWithoutCadence() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(30L * 24 * 3600 * 1000)));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteRunningPastCadence() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (3600 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.WARN, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has been running for 1 hour, " +
+				"exceeding its cadence of 15 minutes plus a grace period of " +
+					"30 minutes",
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		testEquals("true", metrics.get("last.build.running"));
+	}
+
+	@Test
+	public void testExecuteRunningWithinBuildDurationMaximum()
+		throws Exception {
+
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (3600 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "86400");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteRunningWithoutCompletedBuild() throws Exception {
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild",
+				new JSONObject(
+				).put(
+					"building", true
+				).put(
+					"number", 43
+				).put(
+					"timestamp",
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(7200 * 1000)
+				)
+			));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteUnreadableResponse() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			RandomTestUtil.randomString(), _JOB_API_URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Unable to read http://test-9-1/job/generate-reports-controller: " +
+				"Unable to create JSON object",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testJobHealthMonitorInvalidCadence() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[cadence]", "not-a-number");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorInvalidExpectedGreen() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[expected.green]", "yes");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorMissingJobName() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.remove("monitor[a].parameter[job.name]");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorMissingMasterName() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.remove("monitor[a].parameter[master.name]");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorNegativeCadence() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "-1");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	private MonitorResult _execute(Properties monitorProperties) {
+		JobHealthMonitor jobHealthMonitor = _newJobHealthMonitor(
+			monitorProperties);
+
+		return jobHealthMonitor.execute();
+	}
+
+	private JobHealthMonitor _newJobHealthMonitor(
+		Properties monitorProperties) {
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(monitorProperties);
+
+		return new JobHealthMonitor(monitorConfigs.get(0));
+	}
+
+	private JSONObject _newJobJSONObject(
+		int number, String result, long timestamp) {
+
+		return new JSONObject(
+		).put(
+			"lastBuild",
+			new JSONObject(
+			).put(
+				"building", false
+			).put(
+				"number", number
+			).put(
+				"timestamp", timestamp
+			)
+		).put(
+			"lastCompletedBuild",
+			new JSONObject(
+			).put(
+				"number", number
+			).put(
+				"result", result
+			).put(
+				"timestamp", timestamp
+			)
+		);
+	}
+
+	private Properties _newMonitorProperties() {
+		Properties monitorProperties = new Properties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[job.name]", _JOB_NAME);
+		monitorProperties.setProperty(
+			"monitor[a].parameter[master.name]", _MASTER_NAME);
+		monitorProperties.setProperty("monitor[a].type", "job-health");
+
+		return monitorProperties;
+	}
+
+	private JSONObject _newRunningJobJSONObject(
+		long lastBuildTimestamp, long lastCompletedBuildTimestamp) {
+
+		return new JSONObject(
+		).put(
+			"lastBuild",
+			new JSONObject(
+			).put(
+				"building", true
+			).put(
+				"number", 43
+			).put(
+				"timestamp", lastBuildTimestamp
+			)
+		).put(
+			"lastCompletedBuild",
+			new JSONObject(
+			).put(
+				"number", 42
+			).put(
+				"result", "SUCCESS"
+			).put(
+				"timestamp", lastCompletedBuildTimestamp
+			)
+		);
+	}
+
+	private void _setJobJSONObject(JSONObject jobJSONObject) throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(jobJSONObject.toString(), _JOB_API_URL, urlReader);
+	}
+
+	private void _testJobHealthMonitorExpectedIllegalArgumentException(
+		Properties monitorProperties) {
+
+		try {
+			_newJobHealthMonitor(monitorProperties);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	private static final String _JOB_API_URL =
+		"http://test-9-1/job/generate-reports-controller/api/json";
+
+	private static final String _JOB_NAME = "generate-reports-controller";
+
+	private static final String _MASTER_NAME = "test-9-1";
+
+	private static final String _MASTER_URL = "http://test-9-1";
+
+	private static final String _MASTER_URL_TRAILING_SLASH = "http://test-9-1/";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -5,6 +5,12 @@
 
 package com.liferay.jenkins.results.parser.monitor;
 
+import com.liferay.jenkins.results.parser.JenkinsMasterTestUtil;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -14,11 +20,51 @@ import org.junit.Test;
 public class MonitorFactoryTest
 	extends com.liferay.jenkins.results.parser.Test {
 
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+	}
+
+	@Test
+	public void testNewMonitorJobHealth() {
+		JenkinsMasterTestUtil.getJenkinsMaster("test-9-1", "http://test-9-1/");
+
+		Properties monitorProperties = new Properties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[job.name]", "generate-reports-controller");
+		monitorProperties.setProperty(
+			"monitor[a].parameter[master.name]", "test-9-1");
+		monitorProperties.setProperty("monitor[a].type", "job-health");
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(monitorProperties);
+
+		Monitor monitor = MonitorFactory.newMonitor(monitorConfigs.get(0));
+
+		Assert.assertTrue(monitor instanceof JobHealthMonitor);
+	}
+
+	@Test
+	public void testNewMonitorNullType() {
+		_testNewMonitorExpectedIllegalArgumentException(
+			new MonitorConfig(
+				"a", 0, null, MonitorConfig.Severity.MEDIUM, null, 60, null));
+	}
+
 	@Test
 	public void testNewMonitorUnknownType() {
-		MonitorConfig monitorConfig = new MonitorConfig(
-			"a", 0, null, MonitorConfig.Severity.MEDIUM, null, 60,
-			"unknown-type");
+		_testNewMonitorExpectedIllegalArgumentException(
+			new MonitorConfig(
+				"a", 0, null, MonitorConfig.Severity.MEDIUM, null, 60,
+				"unknown-type"));
+	}
+
+	private void _testNewMonitorExpectedIllegalArgumentException(
+		MonitorConfig monitorConfig) {
 
 		try {
 			MonitorFactory.newMonitor(monitorConfig);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7820

## What Is Being Fixed

The monitoring engine from LRCI-7816 shipped with no concrete checks —
`MonitorFactory.newMonitor` threw for every type — so nothing observed job
health. There was no signal for the jobs we expect green going red, for a cron'd
job that stopped running, or for a build that started and never finished.

## How It Is Being Fixed

`JobHealthMonitor` implements `Monitor` and is registered under the type
`job-health`. Each check makes one Jenkins job API call reading `lastBuild` and
`lastCompletedBuild`, with its own connect and read timeout plus one bounded
retry sized to finish inside the runner's budget, so an unreachable master
returns a real CRITICAL rather than being cut off as UNKNOWN.

It grades three conditions. The last completed build not being green is CRITICAL,
except ABORTED which is WARN, because spot interruptions abort builds routinely
and a hard CRITICAL there would be noise. A job that has not run within its
cadence plus a grace period of max(30 min, 25% of cadence) is WARN. A build still
running past a declared maximum duration is CRITICAL, and that declared maximum
wins outright so a job known to run for hours does not also trip its cadence.

Every threshold is declared in config and none is inferred. Deriving a duration
bound was tried three ways and rejected against measured data: a static ceiling
sits inside `test-portal-acceptance-upstream-dxp(master)`'s normal range,
anything keyed on successful builds is useless here because
`test-portal-release` had 1 of 8 builds SUCCESS and upstream-dxp 0 of 10, and a
history-derived bound dies on per-master retention of 8 to 10 build records.
Config entries and the registered job set move to LRCI-7821, since entries are
inert until a job runs the engine.

## PR Check

**pr-check: PASS** — tested on `50abf6c7c48b3eb8b62e03bfcf3c0be14e8a921c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "50abf6c7c48b3eb8b62e03bfcf3c0be14e8a921c"} -->
