### PR TITLE
LRCI-7820 Add the job health monitor check type (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
@@ -44,12 +44,7 @@ public abstract class BaseMonitor implements Monitor {
 		String category, String name, String value) {
 
 		return JenkinsResultsParserUtil.combine(
-			"Invalid ", name, " for ", getKey(category, name), ": ", value);
-	}
-
-	protected String getKey(String category, String name) {
-		return JenkinsResultsParserUtil.combine(
-			"monitor[", _monitorConfig.getId(), "].", category, "[", name, "]");
+			"Invalid ", name, " for ", _getKey(category, name), ": ", value);
 	}
 
 	protected long getLongValue(
@@ -88,10 +83,15 @@ public abstract class BaseMonitor implements Monitor {
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
 			throw new IllegalArgumentException(
-				"Missing required property " + getKey("parameter", name));
+				"Missing required property " + _getKey("parameter", name));
 		}
 
 		return value;
+	}
+
+	private String _getKey(String category, String name) {
+		return JenkinsResultsParserUtil.combine(
+			"monitor[", _monitorConfig.getId(), "].", category, "[", name, "]");
 	}
 
 	private static final long _SECONDS_TIMEOUT_DEFAULT = 60;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.util.Map;
+
+/**
+ * @author Brittney Nguyen
+ */
+public abstract class BaseMonitor implements Monitor {
+
+	@Override
+	public String getId() {
+		return _monitorConfig.getId();
+	}
+
+	@Override
+	public MonitorConfig getMonitorConfig() {
+		return _monitorConfig;
+	}
+
+	protected BaseMonitor(MonitorConfig monitorConfig) {
+		_monitorConfig = monitorConfig;
+	}
+
+	protected int getAttemptTimeoutMillis() {
+		long timeoutSeconds = _monitorConfig.getTimeoutSeconds();
+
+		if (timeoutSeconds <= 0) {
+			timeoutSeconds = _SECONDS_TIMEOUT_DEFAULT;
+		}
+
+		timeoutSeconds = Math.min(timeoutSeconds, Integer.MAX_VALUE / 1000);
+
+		return (int)((timeoutSeconds * 1000) / 3);
+	}
+
+	protected String getInvalidValueMessage(
+		String category, String name, String value) {
+
+		return JenkinsResultsParserUtil.combine(
+			"Invalid ", name, " for ", getKey(category, name), ": ", value);
+	}
+
+	protected String getKey(String category, String name) {
+		return JenkinsResultsParserUtil.combine(
+			"monitor[", _monitorConfig.getId(), "].", category, "[", name, "]");
+	}
+
+	protected long getLongValue(
+		String category, long defaultValue, String name,
+		Map<String, String> values) {
+
+		String value = values.get(name);
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+			return defaultValue;
+		}
+
+		long longValue = 0;
+
+		try {
+			longValue = Long.parseLong(value);
+		}
+		catch (NumberFormatException numberFormatException) {
+			throw new IllegalArgumentException(
+				getInvalidValueMessage(category, name, value),
+				numberFormatException);
+		}
+
+		if (longValue < 0) {
+			throw new IllegalArgumentException(
+				getInvalidValueMessage(category, name, value));
+		}
+
+		return longValue;
+	}
+
+	protected String getRequiredParameter(
+		String name, Map<String, String> parameters) {
+
+		String value = parameters.get(name);
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+			throw new IllegalArgumentException(
+				"Missing required property " + getKey("parameter", name));
+		}
+
+		return value;
+	}
+
+	private static final long _SECONDS_TIMEOUT_DEFAULT = 60;
+
+	private final MonitorConfig _monitorConfig;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
@@ -20,23 +20,23 @@ import org.json.JSONObject;
 /**
  * @author Brittney Nguyen
  */
-public class JobHealthMonitor implements Monitor {
+public class JobHealthMonitor extends BaseMonitor {
 
 	public JobHealthMonitor(MonitorConfig monitorConfig) {
-		_monitorConfig = monitorConfig;
+		super(monitorConfig);
 
 		Map<String, String> parameters = monitorConfig.getParameters();
 
-		_cadenceSeconds = _getLongValue("parameter", 0, "cadence", parameters);
+		_cadenceSeconds = getLongValue("parameter", 0, "cadence", parameters);
 		_expectedGreen = _isExpectedGreen(parameters);
-		_jobName = _getRequiredParameter("job.name", parameters);
-		_jobURL = _getJobURL(_getRequiredParameter("master.name", parameters));
+		_jobName = getRequiredParameter("job.name", parameters);
+		_jobURL = _getJobURL(getRequiredParameter("master.name", parameters));
 
 		Map<String, String> thresholds = monitorConfig.getThresholds();
 
-		_buildDurationMaximumSeconds = _getLongValue(
+		_buildDurationMaximumSeconds = getLongValue(
 			"threshold", 0, "build.duration.maximum", thresholds);
-		_overdueGraceSeconds = _getLongValue(
+		_overdueGraceSeconds = getLongValue(
 			"threshold",
 			Math.max(_SECONDS_OVERDUE_GRACE_MINIMUM, _cadenceSeconds / 4),
 			"overdue.grace", thresholds);
@@ -157,28 +157,6 @@ public class JobHealthMonitor implements Monitor {
 			currentTimeMillis, messages, metrics, statuses);
 	}
 
-	@Override
-	public String getId() {
-		return _monitorConfig.getId();
-	}
-
-	@Override
-	public MonitorConfig getMonitorConfig() {
-		return _monitorConfig;
-	}
-
-	private int _getAttemptTimeoutMillis() {
-		long timeoutSeconds = _monitorConfig.getTimeoutSeconds();
-
-		if (timeoutSeconds <= 0) {
-			timeoutSeconds = _SECONDS_TIMEOUT_DEFAULT;
-		}
-
-		timeoutSeconds = Math.min(timeoutSeconds, Integer.MAX_VALUE / 1000);
-
-		return (int)((timeoutSeconds * 1000) / 3);
-	}
-
 	private String _getCadenceMessage() {
 		return JenkinsResultsParserUtil.combine(
 			"exceeding its cadence of ",
@@ -188,13 +166,6 @@ public class JobHealthMonitor implements Monitor {
 				_overdueGraceSeconds * 1000));
 	}
 
-	private String _getInvalidValueMessage(
-		String category, String name, String value) {
-
-		return JenkinsResultsParserUtil.combine(
-			"Invalid ", name, " for ", _getKey(category, name), ": ", value);
-	}
-
 	private JSONObject _getJobJSONObject() throws IOException {
 		return JenkinsResultsParserUtil.toJSONObject(
 			JenkinsResultsParserUtil.combine(
@@ -202,7 +173,7 @@ public class JobHealthMonitor implements Monitor {
 				"lastBuild[building,number,timestamp],",
 				"lastCompletedBuild[number,result,timestamp]"),
 			false, 1, null, null, _SECONDS_RETRY_PERIOD,
-			_getAttemptTimeoutMillis(), null);
+			getAttemptTimeoutMillis(), null);
 	}
 
 	private String _getJobURL(String masterName) {
@@ -210,11 +181,6 @@ public class JobHealthMonitor implements Monitor {
 
 		return JenkinsResultsParserUtil.combine(
 			jenkinsMaster.getURL(), "/job/", _jobName);
-	}
-
-	private String _getKey(String category, String name) {
-		return JenkinsResultsParserUtil.combine(
-			"monitor[", _monitorConfig.getId(), "].", category, "[", name, "]");
 	}
 
 	private long _getLastBuildTimestamp(
@@ -226,35 +192,6 @@ public class JobHealthMonitor implements Monitor {
 		}
 
 		return lastCompletedBuildJSONObject.optLong("timestamp");
-	}
-
-	private long _getLongValue(
-		String category, long defaultValue, String name,
-		Map<String, String> values) {
-
-		String value = values.get(name);
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-			return defaultValue;
-		}
-
-		long longValue = 0;
-
-		try {
-			longValue = Long.parseLong(value);
-		}
-		catch (NumberFormatException numberFormatException) {
-			throw new IllegalArgumentException(
-				_getInvalidValueMessage(category, name, value),
-				numberFormatException);
-		}
-
-		if (longValue < 0) {
-			throw new IllegalArgumentException(
-				_getInvalidValueMessage(category, name, value));
-		}
-
-		return longValue;
 	}
 
 	private String _getOverdueMessage(
@@ -275,19 +212,6 @@ public class JobHealthMonitor implements Monitor {
 			" ago, ", _getCadenceMessage());
 	}
 
-	private String _getRequiredParameter(
-		String name, Map<String, String> parameters) {
-
-		String value = parameters.get(name);
-
-		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-			throw new IllegalArgumentException(
-				"Missing required property " + _getKey("parameter", name));
-		}
-
-		return value;
-	}
-
 	private boolean _isBuildRunning(JSONObject lastBuildJSONObject) {
 		if (lastBuildJSONObject == null) {
 			return false;
@@ -305,7 +229,7 @@ public class JobHealthMonitor implements Monitor {
 
 		if (!expectedGreen.equals("false") && !expectedGreen.equals("true")) {
 			throw new IllegalArgumentException(
-				_getInvalidValueMessage(
+				getInvalidValueMessage(
 					"parameter", "expected.green", expectedGreen));
 		}
 
@@ -343,14 +267,11 @@ public class JobHealthMonitor implements Monitor {
 
 	private static final int _SECONDS_RETRY_PERIOD = 1;
 
-	private static final long _SECONDS_TIMEOUT_DEFAULT = 60;
-
 	private final long _buildDurationMaximumSeconds;
 	private final long _cadenceSeconds;
 	private final boolean _expectedGreen;
 	private final String _jobName;
 	private final String _jobURL;
-	private final MonitorConfig _monitorConfig;
 	private final long _overdueGraceSeconds;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
@@ -1,0 +1,362 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsMaster;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONObject;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class JobHealthMonitor implements Monitor {
+
+	public JobHealthMonitor(MonitorConfig monitorConfig) {
+		_monitorConfig = monitorConfig;
+
+		Map<String, String> parameters = monitorConfig.getParameters();
+
+		_cadenceSeconds = _getLongValue("parameter", 0, "cadence", parameters);
+		_expectedGreen = _isExpectedGreen(parameters);
+		_jobName = _getRequiredParameter("job.name", parameters);
+		_jobURL = _getJobURL(_getRequiredParameter("master.name", parameters));
+
+		Map<String, String> thresholds = monitorConfig.getThresholds();
+
+		_buildDurationMaximumSeconds = _getLongValue(
+			"threshold", 0, "build.duration.maximum", thresholds);
+		_overdueGraceSeconds = _getLongValue(
+			"threshold",
+			Math.max(_SECONDS_OVERDUE_GRACE_MINIMUM, _cadenceSeconds / 4),
+			"overdue.grace", thresholds);
+	}
+
+	@Override
+	public MonitorResult execute() {
+		long currentTimeMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		JSONObject jobJSONObject = null;
+
+		try {
+			jobJSONObject = _getJobJSONObject();
+		}
+		catch (Exception exception) {
+			return new MonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Unable to read ", _jobURL, ": ",
+					String.valueOf(exception.getMessage())),
+				null, MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		if (jobJSONObject == null) {
+			return new MonitorResult(
+				"Unable to read " + _jobURL, null,
+				MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		JSONObject lastBuildJSONObject = jobJSONObject.optJSONObject(
+			"lastBuild");
+		JSONObject lastCompletedBuildJSONObject = jobJSONObject.optJSONObject(
+			"lastCompletedBuild");
+
+		if ((lastBuildJSONObject == null) &&
+			(lastCompletedBuildJSONObject == null)) {
+
+			return new MonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Job ", _jobName, " has never run"),
+				null, MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		Map<String, String> metrics = new LinkedHashMap<>();
+		List<String> messages = new ArrayList<>();
+		List<MonitorResult.Status> statuses = new ArrayList<>();
+
+		if (lastCompletedBuildJSONObject != null) {
+			int number = lastCompletedBuildJSONObject.optInt("number");
+			String result = lastCompletedBuildJSONObject.optString("result");
+
+			metrics.put("last.completed.build.number", String.valueOf(number));
+			metrics.put("last.completed.build.result", result);
+
+			if (_expectedGreen &&
+				!JenkinsResultsParserUtil.isNullOrEmpty(result) &&
+				!result.equals("SUCCESS")) {
+
+				messages.add(
+					JenkinsResultsParserUtil.combine(
+						"Job ", _jobName, " completed build ",
+						String.valueOf(number), " with the result ", result));
+
+				if (result.equals("ABORTED")) {
+					statuses.add(MonitorResult.Status.WARN);
+				}
+				else {
+					statuses.add(MonitorResult.Status.CRITICAL);
+				}
+			}
+		}
+
+		long lastBuildTimestamp = _getLastBuildTimestamp(
+			lastBuildJSONObject, lastCompletedBuildJSONObject);
+
+		boolean buildRunning = _isBuildRunning(lastBuildJSONObject);
+
+		metrics.put("last.build.running", String.valueOf(buildRunning));
+
+		if (lastBuildTimestamp <= 0) {
+			messages.add(
+				JenkinsResultsParserUtil.combine(
+					"Unable to determine the last build timestamp for job ",
+					_jobName));
+
+			statuses.add(MonitorResult.Status.UNKNOWN);
+
+			return _newMonitorResult(
+				currentTimeMillis, messages, metrics, statuses);
+		}
+
+		long lastBuildAgeSeconds =
+			(currentTimeMillis - lastBuildTimestamp) / 1000;
+
+		metrics.put(
+			"last.build.age.seconds", String.valueOf(lastBuildAgeSeconds));
+
+		if (buildRunning && (_buildDurationMaximumSeconds > 0)) {
+			if (lastBuildAgeSeconds > _buildDurationMaximumSeconds) {
+				messages.add(
+					JenkinsResultsParserUtil.combine(
+						"Job ", _jobName, " has been running for ",
+						JenkinsResultsParserUtil.toDurationString(
+							lastBuildAgeSeconds * 1000),
+						", exceeding its maximum duration of ",
+						JenkinsResultsParserUtil.toDurationString(
+							_buildDurationMaximumSeconds * 1000)));
+
+				statuses.add(MonitorResult.Status.CRITICAL);
+			}
+		}
+		else if (_isOverdue(lastBuildAgeSeconds)) {
+			messages.add(_getOverdueMessage(buildRunning, lastBuildAgeSeconds));
+
+			statuses.add(MonitorResult.Status.WARN);
+		}
+
+		return _newMonitorResult(
+			currentTimeMillis, messages, metrics, statuses);
+	}
+
+	@Override
+	public String getId() {
+		return _monitorConfig.getId();
+	}
+
+	@Override
+	public MonitorConfig getMonitorConfig() {
+		return _monitorConfig;
+	}
+
+	private int _getAttemptTimeoutMillis() {
+		long timeoutSeconds = _monitorConfig.getTimeoutSeconds();
+
+		if (timeoutSeconds <= 0) {
+			timeoutSeconds = _SECONDS_TIMEOUT_DEFAULT;
+		}
+
+		timeoutSeconds = Math.min(timeoutSeconds, Integer.MAX_VALUE / 1000);
+
+		return (int)((timeoutSeconds * 1000) / 3);
+	}
+
+	private String _getCadenceMessage() {
+		return JenkinsResultsParserUtil.combine(
+			"exceeding its cadence of ",
+			JenkinsResultsParserUtil.toDurationString(_cadenceSeconds * 1000),
+			" plus a grace period of ",
+			JenkinsResultsParserUtil.toDurationString(
+				_overdueGraceSeconds * 1000));
+	}
+
+	private String _getInvalidValueMessage(
+		String category, String name, String value) {
+
+		return JenkinsResultsParserUtil.combine(
+			"Invalid ", name, " for ", _getKey(category, name), ": ", value);
+	}
+
+	private JSONObject _getJobJSONObject() throws IOException {
+		return JenkinsResultsParserUtil.toJSONObject(
+			JenkinsResultsParserUtil.combine(
+				_jobURL, "/api/json?tree=",
+				"lastBuild[building,number,timestamp],",
+				"lastCompletedBuild[number,result,timestamp]"),
+			false, 1, null, null, _SECONDS_RETRY_PERIOD,
+			_getAttemptTimeoutMillis(), null);
+	}
+
+	private String _getJobURL(String masterName) {
+		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(masterName);
+
+		String masterURL = jenkinsMaster.getURL();
+
+		if (!masterURL.endsWith("/")) {
+			masterURL += "/";
+		}
+
+		return JenkinsResultsParserUtil.combine(masterURL, "job/", _jobName);
+	}
+
+	private String _getKey(String category, String name) {
+		return JenkinsResultsParserUtil.combine(
+			"monitor[", _monitorConfig.getId(), "].", category, "[", name, "]");
+	}
+
+	private long _getLastBuildTimestamp(
+		JSONObject lastBuildJSONObject,
+		JSONObject lastCompletedBuildJSONObject) {
+
+		if (lastBuildJSONObject != null) {
+			return lastBuildJSONObject.optLong("timestamp");
+		}
+
+		return lastCompletedBuildJSONObject.optLong("timestamp");
+	}
+
+	private long _getLongValue(
+		String category, long defaultValue, String name,
+		Map<String, String> values) {
+
+		String value = values.get(name);
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+			return defaultValue;
+		}
+
+		long longValue = 0;
+
+		try {
+			longValue = Long.parseLong(value);
+		}
+		catch (NumberFormatException numberFormatException) {
+			throw new IllegalArgumentException(
+				_getInvalidValueMessage(category, name, value),
+				numberFormatException);
+		}
+
+		if (longValue < 0) {
+			throw new IllegalArgumentException(
+				_getInvalidValueMessage(category, name, value));
+		}
+
+		return longValue;
+	}
+
+	private String _getOverdueMessage(
+		boolean buildRunning, long lastBuildAgeSeconds) {
+
+		if (buildRunning) {
+			return JenkinsResultsParserUtil.combine(
+				"Job ", _jobName, " has been running for ",
+				JenkinsResultsParserUtil.toDurationString(
+					lastBuildAgeSeconds * 1000),
+				", ", _getCadenceMessage());
+		}
+
+		return JenkinsResultsParserUtil.combine(
+			"Job ", _jobName, " last ran ",
+			JenkinsResultsParserUtil.toDurationString(
+				lastBuildAgeSeconds * 1000),
+			" ago, ", _getCadenceMessage());
+	}
+
+	private String _getRequiredParameter(
+		String name, Map<String, String> parameters) {
+
+		String value = parameters.get(name);
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+			throw new IllegalArgumentException(
+				"Missing required property " + _getKey("parameter", name));
+		}
+
+		return value;
+	}
+
+	private boolean _isBuildRunning(JSONObject lastBuildJSONObject) {
+		if (lastBuildJSONObject == null) {
+			return false;
+		}
+
+		return lastBuildJSONObject.optBoolean("building");
+	}
+
+	private boolean _isExpectedGreen(Map<String, String> parameters) {
+		String expectedGreen = parameters.get("expected.green");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(expectedGreen)) {
+			return true;
+		}
+
+		if (!expectedGreen.equals("false") && !expectedGreen.equals("true")) {
+			throw new IllegalArgumentException(
+				_getInvalidValueMessage(
+					"parameter", "expected.green", expectedGreen));
+		}
+
+		return Boolean.parseBoolean(expectedGreen);
+	}
+
+	private boolean _isOverdue(long lastBuildAgeSeconds) {
+		if (_cadenceSeconds <= 0) {
+			return false;
+		}
+
+		if (lastBuildAgeSeconds > (_cadenceSeconds + _overdueGraceSeconds)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private MonitorResult _newMonitorResult(
+		long currentTimeMillis, List<String> messages,
+		Map<String, String> metrics, List<MonitorResult.Status> statuses) {
+
+		if (statuses.isEmpty()) {
+			return new MonitorResult(
+				JenkinsResultsParserUtil.combine("Job ", _jobName, " is OK"),
+				metrics, MonitorResult.Status.OK, currentTimeMillis);
+		}
+
+		return new MonitorResult(
+			JenkinsResultsParserUtil.join(". ", messages), metrics,
+			MonitorResult.Status.getMostSevere(statuses), currentTimeMillis);
+	}
+
+	private static final long _SECONDS_OVERDUE_GRACE_MINIMUM = 30 * 60;
+
+	private static final int _SECONDS_RETRY_PERIOD = 1;
+
+	private static final long _SECONDS_TIMEOUT_DEFAULT = 60;
+
+	private final long _buildDurationMaximumSeconds;
+	private final long _cadenceSeconds;
+	private final boolean _expectedGreen;
+	private final String _jobName;
+	private final String _jobURL;
+	private final MonitorConfig _monitorConfig;
+	private final long _overdueGraceSeconds;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
@@ -55,8 +55,7 @@ public class JobHealthMonitor implements Monitor {
 		catch (Exception exception) {
 			return new MonitorResult(
 				JenkinsResultsParserUtil.combine(
-					"Unable to read ", _jobURL, ": ",
-					String.valueOf(exception.getMessage())),
+					"Unable to read ", _jobURL, ": ", exception.getMessage()),
 				null, MonitorResult.Status.CRITICAL, currentTimeMillis);
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
@@ -109,12 +109,12 @@ public class JobHealthMonitor implements Monitor {
 			}
 		}
 
-		long lastBuildTimestamp = _getLastBuildTimestamp(
-			lastBuildJSONObject, lastCompletedBuildJSONObject);
-
 		boolean buildRunning = _isBuildRunning(lastBuildJSONObject);
 
 		metrics.put("last.build.running", String.valueOf(buildRunning));
+
+		long lastBuildTimestamp = _getLastBuildTimestamp(
+			lastBuildJSONObject, lastCompletedBuildJSONObject);
 
 		if (lastBuildTimestamp <= 0) {
 			messages.add(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitor.java
@@ -209,13 +209,8 @@ public class JobHealthMonitor implements Monitor {
 	private String _getJobURL(String masterName) {
 		JenkinsMaster jenkinsMaster = JenkinsMaster.getInstance(masterName);
 
-		String masterURL = jenkinsMaster.getURL();
-
-		if (!masterURL.endsWith("/")) {
-			masterURL += "/";
-		}
-
-		return JenkinsResultsParserUtil.combine(masterURL, "job/", _jobName);
+		return JenkinsResultsParserUtil.combine(
+			jenkinsMaster.getURL(), "/job/", _jobName);
 	}
 
 	private String _getKey(String category, String name) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorFactory.java
@@ -5,14 +5,23 @@
 
 package com.liferay.jenkins.results.parser.monitor;
 
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
 /**
  * @author Brittney Nguyen
  */
 public class MonitorFactory {
 
 	public static Monitor newMonitor(MonitorConfig monitorConfig) {
-		throw new IllegalArgumentException(
-			"Unknown monitor type: " + monitorConfig.getType());
+		String type = monitorConfig.getType();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(type) &&
+			type.equals("job-health")) {
+
+			return new JobHealthMonitor(monitorConfig);
+		}
+
+		throw new IllegalArgumentException("Unknown monitor type: " + type);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriter.java
@@ -62,8 +62,8 @@ public class MonitorMetricsWriter {
 		prometheusTextFormatWriter.write(
 			byteArrayOutputStream,
 			MetricSnapshots.of(
-				_newCheckLastRunTimestampSnapshot(), _newCheckStatusSnapshot(),
-				_newHeartbeatTimestampSnapshot()),
+				_newHeartbeatTimestampSnapshot(),
+				_newLastRunTimestampSnapshot(), _newStatusSnapshot()),
 			EscapingScheme.DEFAULT);
 
 		return byteArrayOutputStream.toString("UTF-8");
@@ -87,7 +87,7 @@ public class MonitorMetricsWriter {
 		}
 
 		return Labels.of(
-			"check", monitor.getId(), "severity",
+			"monitor", monitor.getId(), "severity",
 			severityName.toLowerCase(Locale.ENGLISH), "type", type);
 	}
 
@@ -119,38 +119,6 @@ public class MonitorMetricsWriter {
 		return status.getSeverityRank();
 	}
 
-	private GaugeSnapshot _newCheckLastRunTimestampSnapshot() {
-		GaugeSnapshot.Builder gaugeSnapshotBuilder = GaugeSnapshot.builder();
-
-		gaugeSnapshotBuilder.help(
-			"Unix timestamp of the last check run, 0 if never run");
-		gaugeSnapshotBuilder.name("monitor_check_last_run_timestamp_seconds");
-
-		for (Monitor monitor : _monitors) {
-			gaugeSnapshotBuilder.dataPoint(
-				_newGaugeDataPointSnapshot(
-					monitor, _getLastRunTimestampSeconds(monitor)));
-		}
-
-		return gaugeSnapshotBuilder.build();
-	}
-
-	private GaugeSnapshot _newCheckStatusSnapshot() {
-		GaugeSnapshot.Builder gaugeSnapshotBuilder = GaugeSnapshot.builder();
-
-		gaugeSnapshotBuilder.help(
-			"Monitor status severity rank, 0 OK, 1 UNKNOWN, 2 WARN, 3 " +
-				"CRITICAL");
-		gaugeSnapshotBuilder.name("monitor_check_status");
-
-		for (Monitor monitor : _monitors) {
-			gaugeSnapshotBuilder.dataPoint(
-				_newGaugeDataPointSnapshot(monitor, _getSeverityRank(monitor)));
-		}
-
-		return gaugeSnapshotBuilder.build();
-	}
-
 	private GaugeSnapshot.GaugeDataPointSnapshot _newGaugeDataPointSnapshot(
 		Monitor monitor, double value) {
 
@@ -178,6 +146,38 @@ public class MonitorMetricsWriter {
 			JenkinsResultsParserUtil.getCurrentTimeMillis() / 1000);
 
 		gaugeSnapshotBuilder.dataPoint(gaugeDataPointSnapshotBuilder.build());
+
+		return gaugeSnapshotBuilder.build();
+	}
+
+	private GaugeSnapshot _newLastRunTimestampSnapshot() {
+		GaugeSnapshot.Builder gaugeSnapshotBuilder = GaugeSnapshot.builder();
+
+		gaugeSnapshotBuilder.help(
+			"Unix timestamp of the last monitor run, 0 if never run");
+		gaugeSnapshotBuilder.name("monitor_last_run_timestamp_seconds");
+
+		for (Monitor monitor : _monitors) {
+			gaugeSnapshotBuilder.dataPoint(
+				_newGaugeDataPointSnapshot(
+					monitor, _getLastRunTimestampSeconds(monitor)));
+		}
+
+		return gaugeSnapshotBuilder.build();
+	}
+
+	private GaugeSnapshot _newStatusSnapshot() {
+		GaugeSnapshot.Builder gaugeSnapshotBuilder = GaugeSnapshot.builder();
+
+		gaugeSnapshotBuilder.help(
+			"Monitor status severity rank, 0 OK, 1 UNKNOWN, 2 WARN, 3 " +
+				"CRITICAL");
+		gaugeSnapshotBuilder.name("monitor_status");
+
+		for (Monitor monitor : _monitors) {
+			gaugeSnapshotBuilder.dataPoint(
+				_newGaugeDataPointSnapshot(monitor, _getSeverityRank(monitor)));
+		}
 
 		return gaugeSnapshotBuilder.build();
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
@@ -122,7 +122,7 @@ public class MonitorRunner {
 	private MonitorResult _newUnknownMonitorResult(String message) {
 		return new MonitorResult(
 			message, null, MonitorResult.Status.UNKNOWN,
-			System.currentTimeMillis());
+			JenkinsResultsParserUtil.getCurrentTimeMillis());
 	}
 
 	private MonitorResult _resolveMonitorResult(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/RandomTestUtil.java
@@ -17,6 +17,10 @@ public class RandomTestUtil {
 		return _random.nextDouble();
 	}
 
+	public static int randomInt() {
+		return _random.nextInt();
+	}
+
 	public static long randomLong() {
 		return _random.nextLong();
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -448,55 +448,17 @@ public class JobHealthMonitorTest
 	}
 
 	@Test
-	public void testJobHealthMonitorInvalidCadence() {
-		Properties monitorProperties = _newMonitorProperties();
-
-		monitorProperties.setProperty(
+	public void testJobHealthMonitor() {
+		_testJobHealthMonitorInvalidProperty(
+			"monitor[a].parameter[cadence]", "-1");
+		_testJobHealthMonitorInvalidProperty(
 			"monitor[a].parameter[cadence]", "not-a-number");
-
-		_testJobHealthMonitorExpectedIllegalArgumentException(
-			monitorProperties);
-	}
-
-	@Test
-	public void testJobHealthMonitorInvalidExpectedGreen() {
-		Properties monitorProperties = _newMonitorProperties();
-
-		monitorProperties.setProperty(
+		_testJobHealthMonitorInvalidProperty(
 			"monitor[a].parameter[expected.green]", "yes");
 
-		_testJobHealthMonitorExpectedIllegalArgumentException(
-			monitorProperties);
-	}
-
-	@Test
-	public void testJobHealthMonitorMissingJobName() {
-		Properties monitorProperties = _newMonitorProperties();
-
-		monitorProperties.remove("monitor[a].parameter[job.name]");
-
-		_testJobHealthMonitorExpectedIllegalArgumentException(
-			monitorProperties);
-	}
-
-	@Test
-	public void testJobHealthMonitorMissingMasterName() {
-		Properties monitorProperties = _newMonitorProperties();
-
-		monitorProperties.remove("monitor[a].parameter[master.name]");
-
-		_testJobHealthMonitorExpectedIllegalArgumentException(
-			monitorProperties);
-	}
-
-	@Test
-	public void testJobHealthMonitorNegativeCadence() {
-		Properties monitorProperties = _newMonitorProperties();
-
-		monitorProperties.setProperty("monitor[a].parameter[cadence]", "-1");
-
-		_testJobHealthMonitorExpectedIllegalArgumentException(
-			monitorProperties);
+		_testJobHealthMonitorMissingProperty("monitor[a].parameter[job.name]");
+		_testJobHealthMonitorMissingProperty(
+			"monitor[a].parameter[master.name]");
 	}
 
 	private MonitorResult _execute(Properties monitorProperties) {
@@ -597,6 +559,26 @@ public class JobHealthMonitorTest
 		}
 		catch (IllegalArgumentException illegalArgumentException) {
 		}
+	}
+
+	private void _testJobHealthMonitorInvalidProperty(
+		String name, String value) {
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(name, value);
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	private void _testJobHealthMonitorMissingProperty(String name) {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.remove(name);
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
 	}
 
 	private static final String _JOB_API_URL =

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -147,7 +147,7 @@ public class JobHealthMonitorTest
 				).put(
 					"building", false
 				).put(
-					"number", 42
+					"number", RandomTestUtil.randomInt()
 				)
 			));
 
@@ -418,7 +418,7 @@ public class JobHealthMonitorTest
 				).put(
 					"building", true
 				).put(
-					"number", 43
+					"number", RandomTestUtil.randomInt()
 				).put(
 					"timestamp",
 					JenkinsResultsParserUtil.getCurrentTimeMillis() -

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -1,0 +1,632 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsMasterTestUtil;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+import com.liferay.jenkins.results.parser.UrlReader;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class JobHealthMonitorTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		JenkinsMasterTestUtil.getJenkinsMaster(_MASTER_NAME, _MASTER_URL);
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+	}
+
+	@Test
+	public void testExecuteAborted() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "ABORTED",
+				JenkinsResultsParserUtil.getCurrentTimeMillis()));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.WARN, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result ABORTED",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximum() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (1800 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has been running for 30 " +
+				"minutes, exceeding its maximum duration of 15 minutes",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximumWithCadence() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (7200 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(4 * 3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "3600");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has been running for 2 hours, " +
+				"exceeding its maximum duration of 1 hour",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximumWithinBound() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (300 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteBuildDurationMaximumWithoutThreshold()
+		throws Exception {
+
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (7200 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(4 * 3600 * 1000)));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteMasterURLWithTrailingSlash() throws Exception {
+		JenkinsMasterTestUtil.getJenkinsMaster(
+			_MASTER_NAME, _MASTER_URL_TRAILING_SLASH);
+
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(600 * 1000)));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller is OK",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteMissingLastBuildTimestamp() throws Exception {
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild",
+				new JSONObject(
+				).put(
+					"building", false
+				).put(
+					"number", 42
+				)
+			));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.UNKNOWN, monitorResult.getStatus());
+		testEquals(
+			"Unable to determine the last build timestamp for job " +
+				"generate-reports-controller",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreen() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "FAILURE",
+				JenkinsResultsParserUtil.getCurrentTimeMillis()));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result FAILURE",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreenAndOverdue() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "FAILURE",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result FAILURE. Job generate-reports-controller last ran 1 " +
+					"hour ago, exceeding its cadence of 15 minutes plus a " +
+						"grace period of 30 minutes",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreenMissingLastBuildTimestamp()
+		throws Exception {
+
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild",
+				new JSONObject(
+				).put(
+					"building", false
+				).put(
+					"number", 42
+				)
+			).put(
+				"lastCompletedBuild",
+				new JSONObject(
+				).put(
+					"number", 42
+				).put(
+					"result", "FAILURE"
+				).put(
+					"timestamp", JenkinsResultsParserUtil.getCurrentTimeMillis()
+				)
+			));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller completed build 42 with the " +
+				"result FAILURE. Unable to determine the last build " +
+					"timestamp for job generate-reports-controller",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotGreenNotExpectedGreen() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "FAILURE",
+				JenkinsResultsParserUtil.getCurrentTimeMillis()));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[expected.green]", "false");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller is OK",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteNotTriggered() throws Exception {
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild", JSONObject.NULL
+			).put(
+				"lastCompletedBuild", JSONObject.NULL
+			));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has never run",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteOK() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller is OK",
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		testEquals("42", metrics.get("last.completed.build.number"));
+		testEquals("600", metrics.get("last.build.age.seconds"));
+		testEquals("SUCCESS", metrics.get("last.completed.build.result"));
+		testEquals("false", metrics.get("last.build.running"));
+	}
+
+	@Test
+	public void testExecuteOverdue() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.WARN, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller last ran 1 hour ago, exceeding " +
+				"its cadence of 15 minutes plus a grace period of 30 minutes",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteOverdueGraceThreshold() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(3600 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+		monitorProperties.setProperty(
+			"monitor[a].threshold[overdue.grace]", "7200");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteOverdueWithoutCadence() throws Exception {
+		_setJobJSONObject(
+			_newJobJSONObject(
+				42, "SUCCESS",
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(30L * 24 * 3600 * 1000)));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteRunningPastCadence() throws Exception {
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (3600 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.WARN, monitorResult.getStatus());
+		testEquals(
+			"Job generate-reports-controller has been running for 1 hour, " +
+				"exceeding its cadence of 15 minutes plus a grace period of " +
+					"30 minutes",
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		testEquals("true", metrics.get("last.build.running"));
+	}
+
+	@Test
+	public void testExecuteRunningWithinBuildDurationMaximum()
+		throws Exception {
+
+		_setJobJSONObject(
+			_newRunningJobJSONObject(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() - (3600 * 1000),
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(7200 * 1000)));
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "900");
+		monitorProperties.setProperty(
+			"monitor[a].threshold[build.duration.maximum]", "86400");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteRunningWithoutCompletedBuild() throws Exception {
+		_setJobJSONObject(
+			new JSONObject(
+			).put(
+				"lastBuild",
+				new JSONObject(
+				).put(
+					"building", true
+				).put(
+					"number", 43
+				).put(
+					"timestamp",
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(7200 * 1000)
+				)
+			));
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteUnreadableResponse() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			RandomTestUtil.randomString(), _JOB_API_URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			"Unable to read http://test-9-1/job/generate-reports-controller: " +
+				"Unable to create JSON object",
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testJobHealthMonitorInvalidCadence() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[cadence]", "not-a-number");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorInvalidExpectedGreen() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[expected.green]", "yes");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorMissingJobName() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.remove("monitor[a].parameter[job.name]");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorMissingMasterName() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.remove("monitor[a].parameter[master.name]");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	@Test
+	public void testJobHealthMonitorNegativeCadence() {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty("monitor[a].parameter[cadence]", "-1");
+
+		_testJobHealthMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	private MonitorResult _execute(Properties monitorProperties) {
+		JobHealthMonitor jobHealthMonitor = _newJobHealthMonitor(
+			monitorProperties);
+
+		return jobHealthMonitor.execute();
+	}
+
+	private JobHealthMonitor _newJobHealthMonitor(
+		Properties monitorProperties) {
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(monitorProperties);
+
+		return new JobHealthMonitor(monitorConfigs.get(0));
+	}
+
+	private JSONObject _newJobJSONObject(
+		int number, String result, long timestamp) {
+
+		return new JSONObject(
+		).put(
+			"lastBuild",
+			new JSONObject(
+			).put(
+				"building", false
+			).put(
+				"number", number
+			).put(
+				"timestamp", timestamp
+			)
+		).put(
+			"lastCompletedBuild",
+			new JSONObject(
+			).put(
+				"number", number
+			).put(
+				"result", result
+			).put(
+				"timestamp", timestamp
+			)
+		);
+	}
+
+	private Properties _newMonitorProperties() {
+		Properties monitorProperties = new Properties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[job.name]", _JOB_NAME);
+		monitorProperties.setProperty(
+			"monitor[a].parameter[master.name]", _MASTER_NAME);
+		monitorProperties.setProperty("monitor[a].type", "job-health");
+
+		return monitorProperties;
+	}
+
+	private JSONObject _newRunningJobJSONObject(
+		long lastBuildTimestamp, long lastCompletedBuildTimestamp) {
+
+		return new JSONObject(
+		).put(
+			"lastBuild",
+			new JSONObject(
+			).put(
+				"building", true
+			).put(
+				"number", 43
+			).put(
+				"timestamp", lastBuildTimestamp
+			)
+		).put(
+			"lastCompletedBuild",
+			new JSONObject(
+			).put(
+				"number", 42
+			).put(
+				"result", "SUCCESS"
+			).put(
+				"timestamp", lastCompletedBuildTimestamp
+			)
+		);
+	}
+
+	private void _setJobJSONObject(JSONObject jobJSONObject) throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(jobJSONObject.toString(), _JOB_API_URL, urlReader);
+	}
+
+	private void _testJobHealthMonitorExpectedIllegalArgumentException(
+		Properties monitorProperties) {
+
+		try {
+			_newJobHealthMonitor(monitorProperties);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+		}
+	}
+
+	private static final String _JOB_API_URL =
+		"http://test-9-1/job/generate-reports-controller/api/json";
+
+	private static final String _JOB_NAME = "generate-reports-controller";
+
+	private static final String _MASTER_NAME = "test-9-1";
+
+	private static final String _MASTER_URL = "http://test-9-1";
+
+	private static final String _MASTER_URL_TRAILING_SLASH = "http://test-9-1/";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -138,25 +138,6 @@ public class JobHealthMonitorTest
 	}
 
 	@Test
-	public void testExecuteMasterURLWithTrailingSlash() throws Exception {
-		JenkinsMasterTestUtil.getJenkinsMaster(
-			_MASTER_NAME, _MASTER_URL_TRAILING_SLASH);
-
-		_setJobJSONObject(
-			_newJobJSONObject(
-				42, "SUCCESS",
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					(600 * 1000)));
-
-		MonitorResult monitorResult = _execute(_newMonitorProperties());
-
-		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
-		testEquals(
-			"Job generate-reports-controller is OK",
-			monitorResult.getMessage());
-	}
-
-	@Test
 	public void testExecuteMissingLastBuildTimestamp() throws Exception {
 		_setJobJSONObject(
 			new JSONObject(
@@ -626,7 +607,5 @@ public class JobHealthMonitorTest
 	private static final String _MASTER_NAME = "test-9-1";
 
 	private static final String _MASTER_URL = "http://test-9-1";
-
-	private static final String _MASTER_URL_TRAILING_SLASH = "http://test-9-1/";
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -32,7 +32,8 @@ public class JobHealthMonitorTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		JenkinsMasterTestUtil.getJenkinsMaster(_MASTER_NAME, _MASTER_URL);
+		JenkinsMasterTestUtil.getJenkinsMaster(
+			_MASTER_NAME, "http://" + _MASTER_NAME);
 	}
 
 	@After
@@ -587,7 +588,5 @@ public class JobHealthMonitorTest
 	private static final String _JOB_NAME = "generate-reports-controller";
 
 	private static final String _MASTER_NAME = "test-9-1";
-
-	private static final String _MASTER_URL = "http://test-9-1";
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -6,6 +6,7 @@
 package com.liferay.jenkins.results.parser.monitor;
 
 import com.liferay.jenkins.results.parser.JenkinsMasterTestUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
 
 import java.util.List;
 import java.util.Properties;
@@ -30,14 +31,17 @@ public class MonitorFactoryTest
 
 	@Test
 	public void testNewMonitorJobHealth() {
-		JenkinsMasterTestUtil.getJenkinsMaster("test-9-1", "http://test-9-1/");
+		String masterName = RandomTestUtil.randomString();
+
+		JenkinsMasterTestUtil.getJenkinsMaster(
+			masterName, "http://" + masterName);
 
 		Properties monitorProperties = new Properties();
 
 		monitorProperties.setProperty(
-			"monitor[a].parameter[job.name]", "generate-reports-controller");
+			"monitor[a].parameter[job.name]", RandomTestUtil.randomString());
 		monitorProperties.setProperty(
-			"monitor[a].parameter[master.name]", "test-9-1");
+			"monitor[a].parameter[master.name]", masterName);
 		monitorProperties.setProperty("monitor[a].type", "job-health");
 
 		List<MonitorConfig> monitorConfigs =

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -5,6 +5,12 @@
 
 package com.liferay.jenkins.results.parser.monitor;
 
+import com.liferay.jenkins.results.parser.JenkinsMasterTestUtil;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -14,11 +20,51 @@ import org.junit.Test;
 public class MonitorFactoryTest
 	extends com.liferay.jenkins.results.parser.Test {
 
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+	}
+
+	@Test
+	public void testNewMonitorJobHealth() {
+		JenkinsMasterTestUtil.getJenkinsMaster("test-9-1", "http://test-9-1/");
+
+		Properties monitorProperties = new Properties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[job.name]", "generate-reports-controller");
+		monitorProperties.setProperty(
+			"monitor[a].parameter[master.name]", "test-9-1");
+		monitorProperties.setProperty("monitor[a].type", "job-health");
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(monitorProperties);
+
+		Monitor monitor = MonitorFactory.newMonitor(monitorConfigs.get(0));
+
+		Assert.assertTrue(monitor instanceof JobHealthMonitor);
+	}
+
+	@Test
+	public void testNewMonitorNullType() {
+		_testNewMonitorExpectedIllegalArgumentException(
+			new MonitorConfig(
+				"a", 0, null, MonitorConfig.Severity.MEDIUM, null, 60, null));
+	}
+
 	@Test
 	public void testNewMonitorUnknownType() {
-		MonitorConfig monitorConfig = new MonitorConfig(
-			"a", 0, null, MonitorConfig.Severity.MEDIUM, null, 60,
-			"unknown-type");
+		_testNewMonitorExpectedIllegalArgumentException(
+			new MonitorConfig(
+				"a", 0, null, MonitorConfig.Severity.MEDIUM, null, 60,
+				"unknown-type"));
+	}
+
+	private void _testNewMonitorExpectedIllegalArgumentException(
+		MonitorConfig monitorConfig) {
 
 		try {
 			MonitorFactory.newMonitor(monitorConfig);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorMetricsWriterTest.java
@@ -71,28 +71,28 @@ public class MonitorMetricsWriterTest
 
 		testEquals(
 			JenkinsResultsParserUtil.combine(
-				"# HELP monitor_check_last_run_timestamp_seconds Unix ",
-				"timestamp of the last check run, 0 if never run\n",
-				"# TYPE monitor_check_last_run_timestamp_seconds gauge\n",
-				"monitor_check_last_run_timestamp_seconds{check=\"disk\",",
-				"severity=\"high\",type=\"resource-threshold\"} 1.75E9\n",
-				"monitor_check_last_run_timestamp_seconds{check=\"queue\",",
-				"severity=\"medium\",type=\"job-health\"} 1.749999E9\n",
-				"monitor_check_last_run_timestamp_seconds{check=\"testray\",",
-				"severity=\"low\",type=\"external-status\"} 0.0\n",
-				"# HELP monitor_check_status Monitor status severity rank, ",
-				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
-				"# TYPE monitor_check_status gauge\n",
-				"monitor_check_status{check=\"disk\",severity=\"high\",",
-				"type=\"resource-threshold\"} 3.0\n",
-				"monitor_check_status{check=\"queue\",severity=\"medium\",",
-				"type=\"job-health\"} 0.0\n",
-				"monitor_check_status{check=\"testray\",severity=\"low\",",
-				"type=\"external-status\"} 1.0\n",
 				"# HELP monitor_heartbeat_timestamp_seconds Unix timestamp of ",
 				"the last metrics write\n",
 				"# TYPE monitor_heartbeat_timestamp_seconds gauge\n",
-				"monitor_heartbeat_timestamp_seconds 1.75E9\n"),
+				"monitor_heartbeat_timestamp_seconds 1.75E9\n",
+				"# HELP monitor_last_run_timestamp_seconds Unix ",
+				"timestamp of the last monitor run, 0 if never run\n",
+				"# TYPE monitor_last_run_timestamp_seconds gauge\n",
+				"monitor_last_run_timestamp_seconds{monitor=\"disk\",",
+				"severity=\"high\",type=\"resource-threshold\"} 1.75E9\n",
+				"monitor_last_run_timestamp_seconds{monitor=\"queue\",",
+				"severity=\"medium\",type=\"job-health\"} 1.749999E9\n",
+				"monitor_last_run_timestamp_seconds{monitor=\"testray\",",
+				"severity=\"low\",type=\"external-status\"} 0.0\n",
+				"# HELP monitor_status Monitor status severity rank, ",
+				"0 OK, 1 UNKNOWN, 2 WARN, 3 CRITICAL\n",
+				"# TYPE monitor_status gauge\n",
+				"monitor_status{monitor=\"disk\",severity=\"high\",",
+				"type=\"resource-threshold\"} 3.0\n",
+				"monitor_status{monitor=\"queue\",severity=\"medium\",",
+				"type=\"job-health\"} 0.0\n",
+				"monitor_status{monitor=\"testray\",severity=\"low\",",
+				"type=\"external-status\"} 1.0\n"),
 			read(metricsFile));
 	}
 
@@ -120,7 +120,7 @@ public class MonitorMetricsWriterTest
 		Assert.assertTrue(
 			content,
 			content.contains(
-				"monitor_check_status{check=\"disk\",severity=\"high\"," +
+				"monitor_status{monitor=\"disk\",severity=\"high\"," +
 					"type=\"unknown\"} 0.0\n"));
 	}
 
@@ -148,7 +148,7 @@ public class MonitorMetricsWriterTest
 		Assert.assertTrue(
 			content,
 			content.contains(
-				"monitor_check_status{check=\"a\\\"b\\\\c\"," +
+				"monitor_status{monitor=\"a\\\"b\\\\c\"," +
 					"severity=\"medium\",type=\"d\\ne\"} 2.0\n"));
 	}
 
@@ -180,8 +180,8 @@ public class MonitorMetricsWriterTest
 
 		String content = read(metricsFile);
 
-		Assert.assertTrue(content, content.contains("check=\"disk\""));
-		Assert.assertFalse(content, content.contains("check=\"queue\""));
+		Assert.assertTrue(content, content.contains("monitor=\"disk\""));
+		Assert.assertFalse(content, content.contains("monitor=\"queue\""));
 	}
 
 	@Test
@@ -209,7 +209,7 @@ public class MonitorMetricsWriterTest
 		Assert.assertTrue(
 			content,
 			content.contains(
-				"monitor_check_status{check=\"disk\"," +
+				"monitor_status{monitor=\"disk\"," +
 					"severity=\"medium\",type=\"unknown\"} 0.0\n"));
 	}
 
@@ -236,7 +236,7 @@ public class MonitorMetricsWriterTest
 		Assert.assertTrue(
 			content,
 			content.contains(
-				"monitor_check_status{check=\"disk\",severity=\"high\"," +
+				"monitor_status{monitor=\"disk\",severity=\"high\"," +
 					"type=\"resource-threshold\"} 1.0\n"));
 	}
 


### PR DESCRIPTION
[LRCI-7820](https://liferay.atlassian.net/browse/LRCI-7820)

Revises [#4507](https://github.com/pyoo47/liferay-portal/pull/4507) (opened by @brittneyq) with the following follow-up commits:

- [1d4047fb6f64](https://github.com/pyoo47/liferay-portal/commit/1d4047fb6f641e92db1f9dcc67324feab431576b) LRCI-7820 Reuse the existing job URL form
- [3a0457b720dd](https://github.com/pyoo47/liferay-portal/commit/3a0457b720ddda5e17ee1c181399d7d8b5016f7c) LRCI-7820 Declare the last build timestamp at its first use
- [c826a11cdaa5](https://github.com/pyoo47/liferay-portal/commit/c826a11cdaa51813121d70c8182dd21ac9059f2a) LRCI-7820 Remove the redundant String.valueOf
- [a6a6e66e6a8d](https://github.com/pyoo47/liferay-portal/commit/a6a6e66e6a8d637cac54e0c99f37b8cc864e9b81) LRCI-7820 Remove the master URL trailing slash test
- [b60298edc756](https://github.com/pyoo47/liferay-portal/commit/b60298edc756ded221ed71c8f495799880d19f7c) LRCI-7820 Consolidate the invalid configuration tests
- [2e3de62c9ee7](https://github.com/pyoo47/liferay-portal/commit/2e3de62c9ee7a939fc649e0e9852235282921268) LRCI-7820 Use RandomTestUtil for unasserted literals
- [49045a545693](https://github.com/pyoo47/liferay-portal/commit/49045a5456936c389fecf90dee8ba39fa2297680) LRCI-7820 Inline the single use master URL constant
- [9eca9fc98d4f](https://github.com/pyoo47/liferay-portal/commit/9eca9fc98d4fe6fd82acf3e6aaf778eba05a5f76) LRCI-7820 Extract BaseMonitor from the job health monitor
- [72421bf88439](https://github.com/pyoo47/liferay-portal/commit/72421bf884396c3396c90e3592e404742b6d89d2) LRCI-7820 Consistency
- [0ce9ca2cf388](https://github.com/pyoo47/liferay-portal/commit/0ce9ca2cf38808066d992a6287eaefc43f536db8) LRCI-7820 Update the monitor metric name assertions
- [f7d8d9f59b0c](https://github.com/pyoo47/liferay-portal/commit/f7d8d9f59b0c052fc9ebc33082a4a67bb93ef220) LRCI-7820 Make the monitor key method private
