### PR TITLE
LRCI-8036 Remove double escaping when writing properties files

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -104,7 +104,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5734,10 +5734,7 @@ public class JenkinsResultsParserUtil {
 		for (String propertyName : propertyNames) {
 			sb.append(propertyName);
 			sb.append("=");
-
-			sb.append(
-				StringEscapeUtils.escapeJava(
-					getProperty(properties, propertyName)));
+			sb.append(getProperty(properties, propertyName));
 
 			sb.append("\n");
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8036

## What Is Being Fixed

When `JenkinsResultsParserUtil` wrote a properties file, it passed each value through `StringEscapeUtils.escapeJava` before appending it. The values were already escaped, so the extra pass escaped them a second time — backslashes were doubled and any embedded newline, tab, or quote was rewritten into its literal escape sequence. Anything reading the resulting file back got a corrupted value rather than the original one. A digital signature is a concrete case where this matters, since the value cannot survive being re-escaped.

## How It Is Being Fixed

The `StringEscapeUtils.escapeJava` call is dropped so the property value is appended as-is, leaving the single layer of escaping the value already carries. The now-unused `org.apache.commons.lang3.StringEscapeUtils` import is removed with it.

## Why Are There No Tests?

`JenkinsResultsParserUtil` is CI infrastructure that sits outside the portal test layers, so there is no test harness for it here; correctness is validated by the CI runs themselves.

## PR Check

**pr-check: PASS** — tested on `12841092bb600a6a14c01ae79b974957fcd0a548`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "12841092bb600a6a14c01ae79b974957fcd0a548"} -->
