### PR TITLE
LRCI-8033 Add ability to generate Jenkins API tokens (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -6401,7 +6401,8 @@ public class JenkinsResultsParserUtil {
 			return _forbiddenRedactTokens;
 		}
 
-		Set<String> forbiddenRedactTokens = new HashSet<>();
+		Set<String> forbiddenRedactTokens = new HashSet<>(
+			Arrays.asList("admin", "liferay", "test"));
 
 		try {
 			for (String forbiddenRedactToken :
@@ -6417,7 +6418,8 @@ public class JenkinsResultsParserUtil {
 			}
 		}
 		catch (IOException ioException) {
-			forbiddenRedactTokens = new HashSet<>();
+			System.out.println(
+				"WARNING: Unable to get forbidden redact tokens");
 		}
 
 		_forbiddenRedactTokens = forbiddenRedactTokens;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -6404,15 +6404,15 @@ public class JenkinsResultsParserUtil {
 		Set<String> forbiddenRedactTokens = new HashSet<>();
 
 		try {
-			forbiddenRedactTokens.addAll(
-				getBuildPropertyAsList(
-					true, "liferay.jenkins.plugin.op.connect.ignored.values"));
+			for (String forbiddenRedactToken :
+					getBuildPropertyAsList(
+						true,
+						"liferay.jenkins.plugin.op.connect.ignored.values")) {
 
-			for (String fobiddenRedactToken : forbiddenRedactTokens) {
-				fobiddenRedactToken = fobiddenRedactToken.trim();
+				forbiddenRedactToken = forbiddenRedactToken.trim();
 
-				if (!isNullOrEmpty(fobiddenRedactToken)) {
-					forbiddenRedactTokens.add(fobiddenRedactToken);
+				if (!isNullOrEmpty(forbiddenRedactToken)) {
+					forbiddenRedactTokens.add(forbiddenRedactToken);
 				}
 			}
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -6396,35 +6396,14 @@ public class JenkinsResultsParserUtil {
 		}
 	}
 
-	private static synchronized Set<String> _getForbiddenRedactTokens() {
-		if (_forbiddenRedactTokens != null) {
-			return _forbiddenRedactTokens;
+	private static Set<String> _getForbiddenRedactTokens() {
+		Set<String> forbiddenRedactTokens = _forbiddenRedactTokens;
+
+		if (forbiddenRedactTokens != null) {
+			return forbiddenRedactTokens;
 		}
 
-		Set<String> forbiddenRedactTokens = new HashSet<>(
-			Arrays.asList("admin", "liferay", "test"));
-
-		try {
-			for (String forbiddenRedactToken :
-					getBuildPropertyAsList(
-						true,
-						"liferay.jenkins.plugin.op.connect.ignored.values")) {
-
-				forbiddenRedactToken = forbiddenRedactToken.trim();
-
-				if (!isNullOrEmpty(forbiddenRedactToken)) {
-					forbiddenRedactTokens.add(forbiddenRedactToken);
-				}
-			}
-		}
-		catch (IOException ioException) {
-			System.out.println(
-				"WARNING: Unable to get forbidden redact tokens");
-		}
-
-		_forbiddenRedactTokens = forbiddenRedactTokens;
-
-		return _forbiddenRedactTokens;
+		return _loadForbiddenRedactTokens();
 	}
 
 	private static synchronized JSONArray _getGitDirectoriesJSONArray() {
@@ -6896,6 +6875,37 @@ public class JenkinsResultsParserUtil {
 		return true;
 	}
 
+	private static synchronized Set<String> _loadForbiddenRedactTokens() {
+		if (_forbiddenRedactTokens != null) {
+			return _forbiddenRedactTokens;
+		}
+
+		Set<String> forbiddenRedactTokens = new HashSet<>(
+			Arrays.asList("admin", "liferay", "test"));
+
+		try {
+			for (String forbiddenRedactToken :
+					getBuildPropertyAsList(
+						true,
+						"liferay.jenkins.plugin.op.connect.ignored.values")) {
+
+				forbiddenRedactToken = forbiddenRedactToken.trim();
+
+				if (!isNullOrEmpty(forbiddenRedactToken)) {
+					forbiddenRedactTokens.add(forbiddenRedactToken);
+				}
+			}
+		}
+		catch (IOException ioException) {
+			System.out.println(
+				"WARNING: Unable to get forbidden redact tokens");
+		}
+
+		_forbiddenRedactTokens = forbiddenRedactTokens;
+
+		return _forbiddenRedactTokens;
+	}
+
 	private static final long _BYTES_GIGA = 1024 * 1024 * 1024;
 
 	private static final long _BYTES_KILO = 1024;
@@ -6968,7 +6978,7 @@ public class JenkinsResultsParserUtil {
 		"(?<ecrDockerImageName>((?<repository>[^/\\s]+)/)?" +
 			"(?<name>[^/:\\s]+)(:(?<version>[^@:\\s]+))?)" +
 				"(@sha256:[^\\s]+)?");
-	private static Set<String> _forbiddenRedactTokens;
+	private static volatile Set<String> _forbiddenRedactTokens;
 	private static JSONArray _gitDirectoriesJSONArray;
 	private static final DateFormat _gitHubDateFormat;
 	private static final Pattern _gitSHAPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -131,7 +131,9 @@ public class JenkinsResultsParserUtil {
 	public static boolean debug;
 
 	public static void addRedactToken(String token) {
-		if (isNullOrEmpty(token) || _forbiddenRedactTokens.contains(token)) {
+		Set<String> forbiddenRedactTokens = _getForbiddenRedactTokens();
+
+		if (isNullOrEmpty(token) || forbiddenRedactTokens.contains(token)) {
 			return;
 		}
 
@@ -4678,9 +4680,11 @@ public class JenkinsResultsParserUtil {
 			return string;
 		}
 
+		Set<String> forbiddenRedactTokens = _getForbiddenRedactTokens();
+
 		synchronized (_redactTokens) {
 			for (String redactToken : _redactTokens) {
-				if (_forbiddenRedactTokens.contains(redactToken)) {
+				if (forbiddenRedactTokens.contains(redactToken)) {
 					continue;
 				}
 
@@ -6392,6 +6396,35 @@ public class JenkinsResultsParserUtil {
 		}
 	}
 
+	private static synchronized Set<String> _getForbiddenRedactTokens() {
+		if (_forbiddenRedactTokens != null) {
+			return _forbiddenRedactTokens;
+		}
+
+		Set<String> forbiddenRedactTokens = new HashSet<>();
+
+		try {
+			forbiddenRedactTokens.addAll(
+				getBuildPropertyAsList(
+					true, "liferay.jenkins.plugin.op.connect.ignored.values"));
+
+			for (String fobiddenRedactToken : forbiddenRedactTokens) {
+				fobiddenRedactToken = fobiddenRedactToken.trim();
+
+				if (!isNullOrEmpty(fobiddenRedactToken)) {
+					forbiddenRedactTokens.add(fobiddenRedactToken);
+				}
+			}
+		}
+		catch (IOException ioException) {
+			forbiddenRedactTokens = new HashSet<>();
+		}
+
+		_forbiddenRedactTokens = forbiddenRedactTokens;
+
+		return _forbiddenRedactTokens;
+	}
+
 	private static synchronized JSONArray _getGitDirectoriesJSONArray() {
 		if (_gitDirectoriesJSONArray != null) {
 			return _gitDirectoriesJSONArray;
@@ -6817,13 +6850,15 @@ public class JenkinsResultsParserUtil {
 				"Unable to get build properties", ioException);
 		}
 
+		Set<String> forbiddenRedactTokens = _getForbiddenRedactTokens();
+
 		for (int i = 1; properties.containsKey(_getRedactTokenKey(i)); i++) {
 			String key = _getRedactTokenKey(i);
 
 			String redactToken = getProperty(properties, key);
 
 			if (isNullOrEmpty(redactToken) ||
-				_forbiddenRedactTokens.contains(redactToken) ||
+				forbiddenRedactTokens.contains(redactToken) ||
 				redactToken.matches("^\\s*\\d{5}\\s*$")) {
 
 				continue;
@@ -6931,8 +6966,7 @@ public class JenkinsResultsParserUtil {
 		"(?<ecrDockerImageName>((?<repository>[^/\\s]+)/)?" +
 			"(?<name>[^/:\\s]+)(:(?<version>[^@:\\s]+))?)" +
 				"(@sha256:[^\\s]+)?");
-	private static final List<String> _forbiddenRedactTokens = Arrays.asList(
-		"admin", "liferay", "test");
+	private static Set<String> _forbiddenRedactTokens;
 	private static JSONArray _gitDirectoriesJSONArray;
 	private static final DateFormat _gitHubDateFormat;
 	private static final Pattern _gitSHAPattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -163,13 +163,18 @@ public abstract class SecretsUtil {
 
 		vault.addItem(item);
 
-		for (Map.Entry<String, String> entry : itemFieldsMap.entrySet()) {
-			ItemField itemField = new ItemField(
-				"", entry.getKey(), entry.getValue());
+		JSONArray itemFieldsJSONArray = itemJSONObject.optJSONArray(
+			"fields", new JSONArray());
 
-			item.addItemField(itemField);
+		for (int i = 0; i < itemFieldsJSONArray.length(); i++) {
+			JSONObject itemFieldJSONObject = itemFieldsJSONArray.getJSONObject(
+				i);
 
-			_loadItemField(vault, item, itemField);
+			item.addItemField(
+				new ItemField(
+					itemFieldJSONObject.getString("id"),
+					itemFieldJSONObject.getString("label"),
+					itemFieldJSONObject.getString("value")));
 		}
 	}
 
@@ -555,7 +560,7 @@ public abstract class SecretsUtil {
 		public void addItemField(ItemField itemField) {
 			synchronized (_vault) {
 				if (_itemFields == null) {
-					return;
+					_itemFields = new ArrayList<>();
 				}
 
 				_itemFields.add(itemField);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -508,7 +508,7 @@ public abstract class SecretsUtil {
 		try {
 			return JenkinsResultsParserUtil.toJSONObject(
 				_getConnectURL() + path, false, 0, httpRequestMethod,
-				postContent, 0, 0, _getHTTPAuthorization());
+				postContent, 0, 1000 * 60 * 5, _getHTTPAuthorization());
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -67,7 +67,7 @@ public abstract class SecretsUtil {
 					vaultName));
 		}
 
-		_createItem(vault, itemTitle, _generateJenkinsAPITokenMap());
+		_createItem(_generateJenkinsAPITokenMap(), itemTitle, vault);
 	}
 
 	public static String getSecret(String key) {
@@ -90,7 +90,7 @@ public abstract class SecretsUtil {
 		String vaultName, String itemTitle, String fieldLabel) {
 
 		String secretReference = _getSecretReference(
-			vaultName, itemTitle, fieldLabel);
+			fieldLabel, itemTitle, vaultName);
 
 		String secret = _connectSecrets.get(secretReference);
 
@@ -120,7 +120,7 @@ public abstract class SecretsUtil {
 	}
 
 	private static void _createItem(
-		Vault vault, String itemTitle, Map<String, String> itemFieldsMap) {
+		Map<String, String> itemFieldsMap, String itemTitle, Vault vault) {
 
 		JSONArray fieldsJSONArray = new JSONArray();
 
@@ -325,7 +325,7 @@ public abstract class SecretsUtil {
 	}
 
 	private static String _getSecretReference(
-		String vaultName, String itemTitle, String fieldLabel) {
+		String fieldLabel, String itemTitle, String vaultName) {
 
 		return JenkinsResultsParserUtil.combine(
 			"op://", vaultName, "/", itemTitle, "/", fieldLabel);
@@ -373,11 +373,11 @@ public abstract class SecretsUtil {
 			for (Vault vault : Vault.getInstances()) {
 				for (Item item : vault.getItems()) {
 					for (ItemField itemField : item.getItemFields()) {
-						_loadItemField(vault, item, itemField);
+						_loadItemField(item, itemField, vault);
 					}
 
 					for (ItemFile itemFile : item.getItemFiles()) {
-						_loadItemFile(vault, item, itemFile);
+						_loadItemFile(item, itemFile, vault);
 					}
 				}
 			}
@@ -397,7 +397,7 @@ public abstract class SecretsUtil {
 	}
 
 	private static void _loadItemField(
-		Vault vault, Item item, ItemField itemField) {
+		Item item, ItemField itemField, Vault vault) {
 
 		String itemFieldValue = itemField.getValue();
 
@@ -414,10 +414,10 @@ public abstract class SecretsUtil {
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(itemFieldId)) {
 			_connectSecrets.put(
-				_getSecretReference(vaultName, itemId, itemFieldId),
+				_getSecretReference(itemFieldId, itemId, vaultName),
 				itemFieldValue);
 			_connectSecrets.put(
-				_getSecretReference(vaultName, itemTitle, itemFieldId),
+				_getSecretReference(itemFieldId, itemTitle, vaultName),
 				itemFieldValue);
 		}
 
@@ -425,16 +425,16 @@ public abstract class SecretsUtil {
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(itemFieldLabel)) {
 			_connectSecrets.put(
-				_getSecretReference(vaultName, itemId, itemFieldLabel),
+				_getSecretReference(itemFieldLabel, itemId, vaultName),
 				itemFieldValue);
 			_connectSecrets.put(
-				_getSecretReference(vaultName, itemTitle, itemFieldLabel),
+				_getSecretReference(itemFieldLabel, itemTitle, vaultName),
 				itemFieldValue);
 		}
 	}
 
 	private static void _loadItemFile(
-		Vault vault, Item item, ItemFile itemFile) {
+		Item item, ItemFile itemFile, Vault vault) {
 
 		String itemFieldValue = itemFile.getValue();
 
@@ -450,10 +450,10 @@ public abstract class SecretsUtil {
 		String itemFileName = itemFile.getName();
 
 		_connectSecrets.put(
-			_getSecretReference(vaultName, itemId, itemFileName),
+			_getSecretReference(itemFileName, itemId, vaultName),
 			itemFieldValue);
 		_connectSecrets.put(
-			_getSecretReference(vaultName, itemTitle, itemFileName),
+			_getSecretReference(itemFileName, itemTitle, vaultName),
 			itemFieldValue);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.BearerHTTPAuthorization;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthorization;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,6 +30,60 @@ import org.json.JSONObject;
  * @author Peter Yoo
  */
 public abstract class SecretsUtil {
+
+	public static void createItem(
+		Vault vault, String itemTitle, Map<String, String> itemFieldsMap) {
+
+		JSONArray fieldsJSONArray = new JSONArray();
+
+		for (Map.Entry<String, String> itemFieldEntry :
+				itemFieldsMap.entrySet()) {
+
+			fieldsJSONArray.put(
+				_getItemFieldJSONObject(
+					itemFieldEntry.getKey(), itemFieldEntry.getValue()));
+		}
+
+		JSONObject itemJSONObject = _toJSONObject(
+			JenkinsResultsParserUtil.combine(
+				"/v1/vaults/", vault.getId(), "/items"),
+			HttpRequestMethod.POST,
+			String.valueOf(
+				new JSONObject(
+				).put(
+					"category", Item.Category.SECURE_NOTE
+				).put(
+					"fields", fieldsJSONArray
+				).put(
+					"title", itemTitle
+				).put(
+					"vault",
+					new JSONObject(
+					).put(
+						"id", vault.getId()
+					)
+				)));
+
+		if ((itemJSONObject == null) || !itemJSONObject.has("id")) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to create item ", itemTitle, " in vault ",
+					vault.getSecretReference()));
+		}
+
+		Item item = new Item(itemJSONObject.getString("id"), itemTitle, vault);
+
+		vault.addItem(item);
+
+		for (Map.Entry<String, String> entry : itemFieldsMap.entrySet()) {
+			ItemField itemField = new ItemField(
+				"", entry.getKey(), entry.getValue());
+
+			item.addItemField(itemField);
+
+			_loadItemField(vault, item, itemField);
+		}
+	}
 
 	public static String getSecret(String key) {
 		Matcher matcher = _secretReferencePattern.matcher(key);
@@ -171,6 +226,19 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
+	private static JSONObject _getItemFieldJSONObject(
+		String fieldLabel, String fieldValue) {
+
+		return new JSONObject(
+		).put(
+			"label", fieldLabel
+		).put(
+			"type", ItemField.Type.CONCEALED
+		).put(
+			"value", fieldValue
+		);
+	}
+
 	private static String _getSecretReference(
 		String vaultName, String itemTitle, String fieldLabel) {
 
@@ -218,60 +286,13 @@ public abstract class SecretsUtil {
 
 		try {
 			for (Vault vault : Vault.getInstances()) {
-				String vaultName = vault.getName();
-
 				for (Item item : vault.getItems()) {
-					String itemId = item.getId();
-					String itemTitle = item.getTitle();
-
 					for (ItemField itemField : item.getItemFields()) {
-						String itemFieldValue = itemField.getValue();
-
-						if (JenkinsResultsParserUtil.isNullOrEmpty(
-								itemFieldValue)) {
-
-							continue;
-						}
-
-						String itemFieldId = itemField.getId();
-						String itemFieldLabel = itemField.getLabel();
-
-						_connectSecrets.put(
-							_getSecretReference(vaultName, itemId, itemFieldId),
-							itemFieldValue);
-						_connectSecrets.put(
-							_getSecretReference(
-								vaultName, itemId, itemFieldLabel),
-							itemFieldValue);
-						_connectSecrets.put(
-							_getSecretReference(
-								vaultName, itemTitle, itemFieldId),
-							itemFieldValue);
-						_connectSecrets.put(
-							_getSecretReference(
-								vaultName, itemTitle, itemFieldLabel),
-							itemFieldValue);
+						_loadItemField(vault, item, itemField);
 					}
 
 					for (ItemFile itemFile : item.getItemFiles()) {
-						String itemFileValue = itemFile.getValue();
-
-						if (JenkinsResultsParserUtil.isNullOrEmpty(
-								itemFileValue)) {
-
-							continue;
-						}
-
-						String itemFileName = itemFile.getName();
-
-						_connectSecrets.put(
-							_getSecretReference(
-								vaultName, itemId, itemFileName),
-							itemFileValue);
-						_connectSecrets.put(
-							_getSecretReference(
-								vaultName, itemTitle, itemFileName),
-							itemFileValue);
+						_loadItemFile(vault, item, itemFile);
 					}
 				}
 			}
@@ -288,6 +309,67 @@ public abstract class SecretsUtil {
 
 			_connectSecrets.clear();
 		}
+	}
+
+	private static void _loadItemField(
+		Vault vault, Item item, ItemField itemField) {
+
+		String itemFieldValue = itemField.getValue();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(itemFieldValue)) {
+			return;
+		}
+
+		String vaultName = vault.getName();
+
+		String itemId = item.getId();
+		String itemTitle = item.getTitle();
+
+		String itemFieldId = itemField.getId();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(itemFieldId)) {
+			_connectSecrets.put(
+				_getSecretReference(vaultName, itemId, itemFieldId),
+				itemFieldValue);
+			_connectSecrets.put(
+				_getSecretReference(vaultName, itemTitle, itemFieldId),
+				itemFieldValue);
+		}
+
+		String itemFieldLabel = itemField.getLabel();
+
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(itemFieldLabel)) {
+			_connectSecrets.put(
+				_getSecretReference(vaultName, itemId, itemFieldLabel),
+				itemFieldValue);
+			_connectSecrets.put(
+				_getSecretReference(vaultName, itemTitle, itemFieldLabel),
+				itemFieldValue);
+		}
+	}
+
+	private static void _loadItemFile(
+		Vault vault, Item item, ItemFile itemFile) {
+
+		String itemFieldValue = itemFile.getValue();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(itemFieldValue)) {
+			return;
+		}
+
+		String vaultName = vault.getName();
+
+		String itemId = item.getId();
+		String itemTitle = item.getTitle();
+
+		String itemFileName = itemFile.getName();
+
+		_connectSecrets.put(
+			_getSecretReference(vaultName, itemId, itemFileName),
+			itemFieldValue);
+		_connectSecrets.put(
+			_getSecretReference(vaultName, itemTitle, itemFileName),
+			itemFieldValue);
 	}
 
 	private static JSONArray _toJSONArray(String path) {
@@ -326,6 +408,25 @@ public abstract class SecretsUtil {
 		}
 	}
 
+	private static JSONObject _toJSONObject(
+		String path, HttpRequestMethod httpRequestMethod, String postContent) {
+
+		if (!_isSecretsConfigured()) {
+			throw new RuntimeException("Secrets are not configured");
+		}
+
+		try {
+			return JenkinsResultsParserUtil.toJSONObject(
+				_getConnectURL() + path, false, 0, httpRequestMethod,
+				postContent, 0, 0, _getHTTPAuthorization());
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to send " + httpRequestMethod + " to " + path,
+				ioException);
+		}
+	}
+
 	private static String _toString(String path) {
 		if (!_isSecretsConfigured()) {
 			return "";
@@ -354,6 +455,16 @@ public abstract class SecretsUtil {
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
 
 	private static class Item {
+
+		public void addItemField(ItemField itemField) {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					return;
+				}
+
+				_itemFields.add(itemField);
+			}
+		}
 
 		public String getId() {
 			return _id;
@@ -550,6 +661,16 @@ public abstract class SecretsUtil {
 		private final String _title;
 		private final Vault _vault;
 
+		private static enum Category {
+
+			API_CREDENTIAL, BANK_ACCOUNT, CREDIT_CARD, CUSTOM, DATABASE,
+			DOCUMENT, DRIVER_LICENSE, EMAIL_ACCOUNT, IDENTITY, LOGIN,
+			MEDICAL_RECORD, MEMBERSHIP, OUTDOOR_LICENSE, PASSPORT, PASSWORD,
+			REWARD_PROGRAM, SECURE_NOTE, SERVER, SOCIAL_SECURITY_NUMBER,
+			SOFTWARE_LICENSE, SSH_KEY, WIRELESS_ROUTER
+
+		}
+
 	}
 
 	private static class ItemField {
@@ -579,6 +700,13 @@ public abstract class SecretsUtil {
 		private final String _id;
 		private final String _label;
 		private final String _value;
+
+		private static enum Type {
+
+			ADDRESS, CONCEALED, CREDIT_CARD_NUMBER, CREDIT_CARD_TYPE, DATE,
+			EMAIL, GENDER, MENU, MONTH_YEAR, OTP, PHONE, REFERENCE, STRING, URL
+
+		}
 
 	}
 
@@ -639,6 +767,16 @@ public abstract class SecretsUtil {
 			return vaults;
 		}
 
+		public void addItem(Item item) {
+			synchronized (_vaultsMap) {
+				if (_items == null) {
+					return;
+				}
+
+				_items.add(item);
+			}
+		}
+
 		public String getId() {
 			return _id;
 		}
@@ -673,6 +811,10 @@ public abstract class SecretsUtil {
 
 		public String getName() {
 			return _name;
+		}
+
+		public String getSecretReference() {
+			return "op://" + getName();
 		}
 
 		public void loadAllItems() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -195,25 +195,28 @@ public abstract class SecretsUtil {
 				"Unable to generate API token hash", noSuchAlgorithmException);
 		}
 
-		String secretValue = _toHexString(randomBytes);
+		Map<String, String> apiTokenMap = new LinkedHashMap<>();
 
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd HH:mm:ss.SSS z");
 
 		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-		UUID uuid = UUID.randomUUID();
-
-		Map<String, String> apiTokenMap = new LinkedHashMap<>();
-
 		apiTokenMap.put("creationDate", simpleDateFormat.format(new Date()));
+
+		String secretValue = _toHexString(randomBytes);
+
 		apiTokenMap.put(
 			"hash",
 			_toHexString(
 				messageDigest.digest(
 					secretValue.getBytes(StandardCharsets.US_ASCII))));
 		apiTokenMap.put("plainValue", _API_TOKEN_VERSION + secretValue);
+
+		UUID uuid = UUID.randomUUID();
+
 		apiTokenMap.put("uuid", uuid.toString());
+
 		apiTokenMap.put("version", _API_TOKEN_VERSION);
 
 		return apiTokenMap;
@@ -405,12 +408,10 @@ public abstract class SecretsUtil {
 			return;
 		}
 
-		String vaultName = vault.getName();
-
+		String itemFieldId = itemField.getId();
 		String itemId = item.getId();
 		String itemTitle = item.getTitle();
-
-		String itemFieldId = itemField.getId();
+		String vaultName = vault.getName();
 
 		if (!JenkinsResultsParserUtil.isNullOrEmpty(itemFieldId)) {
 			_connectSecrets.put(
@@ -442,12 +443,10 @@ public abstract class SecretsUtil {
 			return;
 		}
 
-		String vaultName = vault.getName();
-
+		String itemFileName = itemFile.getName();
 		String itemId = item.getId();
 		String itemTitle = item.getTitle();
-
-		String itemFileName = itemFile.getName();
+		String vaultName = vault.getName();
 
 		_connectSecrets.put(
 			_getSecretReference(itemFileName, itemId, vaultName),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -12,11 +12,23 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMe
 import java.io.File;
 import java.io.IOException;
 
+import java.nio.charset.StandardCharsets;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import java.text.SimpleDateFormat;
+
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -31,7 +43,83 @@ import org.json.JSONObject;
  */
 public abstract class SecretsUtil {
 
-	public static void createItem(
+	public static void generateJenkinsAPITokenSecret(String key) {
+		Matcher matcher = _itemReferencePattern.matcher(key);
+
+		if (!matcher.matches()) {
+			throw new RuntimeException("Invalid item reference " + key);
+		}
+
+		String vaultName = matcher.group("vaultName");
+
+		Vault vault = Vault.getInstance(vaultName);
+
+		if (vault == null) {
+			throw new RuntimeException("Unable to find vault " + vaultName);
+		}
+
+		String itemTitle = matcher.group("itemTitle");
+
+		if (vault.getItem(itemTitle) != null) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Item ", itemTitle, " already exists in vault ",
+					vaultName));
+		}
+
+		_createItem(vault, itemTitle, _generateJenkinsAPITokenMap());
+	}
+
+	public static String getSecret(String key) {
+		Matcher matcher = _secretReferencePattern.matcher(key);
+
+		if (matcher.matches()) {
+			String secret = getSecret(
+				matcher.group("vaultName"), matcher.group("itemTitle"),
+				matcher.group("fieldLabel"));
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
+				return secret;
+			}
+		}
+
+		return key;
+	}
+
+	public static String getSecret(
+		String vaultName, String itemTitle, String fieldLabel) {
+
+		String secretReference = _getSecretReference(
+			vaultName, itemTitle, fieldLabel);
+
+		String secret = _connectSecrets.get(secretReference);
+
+		if (secret != null) {
+			return secret;
+		}
+
+		_loadConnectSecrets();
+
+		secret = _connectSecrets.get(secretReference);
+
+		if (secret == null) {
+			System.out.println("Unable to find secret " + secretReference);
+		}
+
+		return secret;
+	}
+
+	public static boolean isSecretProperty(String value) {
+		if (value == null) {
+			return false;
+		}
+
+		Matcher matcher = _secretReferencePattern.matcher(value);
+
+		return matcher.matches();
+	}
+
+	private static void _createItem(
 		Vault vault, String itemTitle, Map<String, String> itemFieldsMap) {
 
 		JSONArray fieldsJSONArray = new JSONArray();
@@ -85,53 +173,45 @@ public abstract class SecretsUtil {
 		}
 	}
 
-	public static String getSecret(String key) {
-		Matcher matcher = _secretReferencePattern.matcher(key);
+	private static Map<String, String> _generateJenkinsAPITokenMap() {
+		byte[] randomBytes = new byte[16];
 
-		if (matcher.matches()) {
-			String secret = getSecret(
-				matcher.group("vaultName"), matcher.group("itemTitle"),
-				matcher.group("fieldLabel"));
+		SecureRandom secureRandom = new SecureRandom();
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
-				return secret;
-			}
+		secureRandom.nextBytes(randomBytes);
+
+		MessageDigest messageDigest = null;
+
+		try {
+			messageDigest = MessageDigest.getInstance(_API_TOKEN_ALGORITHM);
+		}
+		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+			throw new RuntimeException(
+				"Unable to generate API token hash", noSuchAlgorithmException);
 		}
 
-		return key;
-	}
+		String secretValue = _toHexString(randomBytes);
 
-	public static String getSecret(
-		String vaultName, String itemTitle, String fieldLabel) {
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd HH:mm:ss.SSS z");
 
-		String secretReference = _getSecretReference(
-			vaultName, itemTitle, fieldLabel);
+		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-		String secret = _connectSecrets.get(secretReference);
+		UUID uuid = UUID.randomUUID();
 
-		if (secret != null) {
-			return secret;
-		}
+		Map<String, String> apiTokenMap = new LinkedHashMap<>();
 
-		_loadConnectSecrets();
+		apiTokenMap.put("creationDate", simpleDateFormat.format(new Date()));
+		apiTokenMap.put(
+			"hash",
+			_toHexString(
+				messageDigest.digest(
+					secretValue.getBytes(StandardCharsets.US_ASCII))));
+		apiTokenMap.put("plainValue", _API_TOKEN_VERSION + secretValue);
+		apiTokenMap.put("uuid", uuid.toString());
+		apiTokenMap.put("version", _API_TOKEN_VERSION);
 
-		secret = _connectSecrets.get(secretReference);
-
-		if (secret == null) {
-			System.out.println("Unable to find secret " + secretReference);
-		}
-
-		return secret;
-	}
-
-	public static boolean isSecretProperty(String value) {
-		if (value == null) {
-			return false;
-		}
-
-		Matcher matcher = _secretReferencePattern.matcher(value);
-
-		return matcher.matches();
+		return apiTokenMap;
 	}
 
 	private static synchronized String _getAccessToken() {
@@ -372,6 +452,16 @@ public abstract class SecretsUtil {
 			itemFieldValue);
 	}
 
+	private static String _toHexString(byte[] bytes) {
+		StringBuilder sb = new StringBuilder();
+
+		for (byte b : bytes) {
+			sb.append(String.format("%02x", b & 0xff));
+		}
+
+		return sb.toString();
+	}
+
 	private static JSONArray _toJSONArray(String path) {
 		if (!_isSecretsConfigured()) {
 			return new JSONArray();
@@ -445,12 +535,18 @@ public abstract class SecretsUtil {
 		}
 	}
 
+	private static final String _API_TOKEN_ALGORITHM = "SHA-256";
+
+	private static final String _API_TOKEN_VERSION = "11";
+
 	private static String _accessToken;
 	private static final Map<String, String> _connectSecrets =
 		new ConcurrentHashMap<>();
 	private static boolean _connectSecretsLoaded;
 	private static String _connectURL;
 	private static BearerHTTPAuthorization _httpAuthorization;
+	private static final Pattern _itemReferencePattern = Pattern.compile(
+		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)");
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
 


### PR DESCRIPTION
[LRCI-8033](https://liferay.atlassian.net/browse/LRCI-8033)

Revises [#4506](https://github.com/pyoo47/liferay-portal/pull/4506) (opened by @michaelhashimoto) with the following follow-up commits:

- [e700b65f4f7e](https://github.com/pyoo47/liferay-portal/commit/e700b65f4f7eee90c61c810e1736cbc29a9d4b12) LRCI-8033 Avoid modifying the ignored redact token set while iterating it
- [d1b91783916b](https://github.com/pyoo47/liferay-portal/commit/d1b91783916bdb63c2aa1d3c448235012a05b9f4) LRCI-8033 Always forbid redacting admin, liferay, and test
- [4c90deb41866](https://github.com/pyoo47/liferay-portal/commit/4c90deb418660f438c3c434075fddcd9b49b16a7) LRCI-8033 Read the ignored redact tokens without synchronizing
- [46310d905e46](https://github.com/pyoo47/liferay-portal/commit/46310d905e46ec8223739dc4f7af520ffbfc5879) LRCI-8033 Set a timeout when posting to op connect
- [a9acfa1d42a5](https://github.com/pyoo47/liferay-portal/commit/a9acfa1d42a56083dabaabbc7e6e7c002dc8ef68) LRCI-8033 Add the created item fields to the item
- [d6fc1453cdb9](https://github.com/pyoo47/liferay-portal/commit/d6fc1453cdb9fc6ff8ba45d78cfb4b7e4a7eeb6d) LRCI-8033 Sort
- [79c3a55521d5](https://github.com/pyoo47/liferay-portal/commit/79c3a55521d58441e637bc12eac05ceb0617fd0a) LRCI-8033 Consistency

The last two apply the parameter sorting and declaration ordering requested in [brianchandotcom#179895](https://github.com/brianchandotcom/liferay-portal/pull/179895#issuecomment-5213420982).

**pr-check: PASS** — tested on `79c3a55521d58441e637bc12eac05ceb0617fd0a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "79c3a55521d58441e637bc12eac05ceb0617fd0a"} -->
