### PR TITLE
LRCI-7904 Detect and abort builds that hang holding an executor

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -822,8 +822,13 @@ public class JenkinsCohort {
 				JenkinsResultsParserUtil.getBuildProperty(
 					"jenkins.load.balancer.blacklist");
 
-			Collections.addAll(
-				_jenkinsMastersBlacklist, jenkinsMastersBlacklist.split(","));
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(
+					jenkinsMastersBlacklist)) {
+
+				Collections.addAll(
+					_jenkinsMastersBlacklist,
+					jenkinsMastersBlacklist.split(","));
+			}
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -516,6 +516,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return new ArrayList<>(_jenkinsSlavesMap.values());
 	}
 
+	public int getMaxRunningBuildCount() {
+		return Math.max(_busyExecutorCount, _runningBuilds.size());
+	}
+
 	@Override
 	public String getName() {
 		return _masterName;
@@ -766,6 +770,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _masterRemoteURL;
 	}
 
+	public List<RunningBuild> getRunningBuilds() {
+		return new ArrayList<>(_runningBuilds);
+	}
+
 	public Integer getSlaveRAM() {
 		return _slaveRAM;
 	}
@@ -854,12 +862,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				_AVAILABLE_TIMEOUT)) {
 
 			try {
-				if (!isBlacklisted()) {
-					JenkinsResultsParserUtil.toJSONObject(
-						getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
+				JenkinsResultsParserUtil.toJSONObject(
+					getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
 
-					_available = true;
-				}
+				_available = true;
 			}
 			catch (Exception exception) {
 				System.out.println(getName() + " is unreachable.");
@@ -956,7 +962,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public synchronized void update(boolean minimal) {
-		if (_isUpdated()) {
+		if (_isUpdated(minimal)) {
 			return;
 		}
 
@@ -965,7 +971,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		if (!isAvailable()) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
+			_busyExecutorCount = 0;
 			_jenkinsSlavesMap.clear();
+			_runningBuilds.clear();
 
 			return;
 		}
@@ -975,19 +983,33 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		JSONObject computerAPIJSONObject = null;
 
 		try {
+			String treeQuery = JenkinsResultsParserUtil.combine(
+				"/computer/api/json?tree=computer[assignedLabels[name],",
+				"displayName,executors[currentExecutable[url]],idle,offline,",
+				"offlineCauseReason]");
+
+			if (!minimal) {
+				treeQuery = JenkinsResultsParserUtil.combine(
+					"/computer/api/json?tree=busyExecutors,computer",
+					"[assignedLabels[name],displayName,executors",
+					"[currentExecutable[building,estimatedDuration,",
+					"fullDisplayName,timestamp,url],likelyStuck],idle,",
+					"offline,offlineCause[timestamp],offlineCauseReason,",
+					"oneOffExecutors[currentExecutable[building,",
+					"estimatedDuration,fullDisplayName,timestamp,url],",
+					"likelyStuck],temporarilyOffline]");
+			}
+
 			computerAPIJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					getURL(), "/computer/api/json?tree=computer",
-					"[assignedLabels[name],displayName,",
-					"executors[currentExecutable[url]],idle,offline,",
-					"offlineCauseReason]"),
-				false, 5000);
+				getURL() + treeQuery, false, 5000);
 		}
 		catch (Exception exception) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
+			_busyExecutorCount = 0;
 			_jenkinsSlavesMap.clear();
 			_labelExpressionLabels.clear();
+			_runningBuilds.clear();
 
 			System.out.println("Unable to read " + _masterURL);
 
@@ -995,6 +1017,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		List<String> buildURLs = new ArrayList<>();
+		List<RunningBuild> runningBuilds = new ArrayList<>();
 
 		JSONArray computerJSONArray = computerAPIJSONObject.getJSONArray(
 			"computer");
@@ -1004,6 +1027,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 			String jenkinsSlaveName = JenkinsSlave.getDisplayName(
 				computerJSONObject);
+
+			if (!minimal) {
+				_addRunningBuilds(
+					computerJSONObject, jenkinsSlaveName, runningBuilds);
+			}
 
 			if (jenkinsSlaveName.equals("Built-In Node") ||
 				jenkinsSlaveName.equals("master")) {
@@ -1080,6 +1108,20 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		_buildURLs.clear();
 
 		_buildURLs.addAll(buildURLs);
+
+		if (minimal) {
+			_busyExecutorCount = 0;
+
+			_runningBuilds.clear();
+
+			return;
+		}
+
+		_busyExecutorCount = computerAPIJSONObject.optInt("busyExecutors", 0);
+
+		_runningBuilds.clear();
+
+		_runningBuilds.addAll(runningBuilds);
 	}
 
 	public static class QueueItem implements Comparable<QueueItem> {
@@ -1236,6 +1278,137 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 	}
 
+	public static class RunningBuild {
+
+		public long getDuration(long currentTimeMillis) {
+			long startTime = _getStartTime();
+
+			if (startTime <= 0) {
+				return 0;
+			}
+
+			return currentTimeMillis - startTime;
+		}
+
+		public long getEstimatedDuration() {
+			return _jsonObject.optLong("estimatedDuration", -1);
+		}
+
+		public String getFullDisplayName() {
+			return _jsonObject.optString("fullDisplayName");
+		}
+
+		public JenkinsMaster getJenkinsMaster() {
+			return _jenkinsMaster;
+		}
+
+		public String getJenkinsSlaveName() {
+			return _jenkinsSlaveName;
+		}
+
+		public long getJenkinsSlaveOfflineDuration(long currentTimeMillis) {
+			long jenkinsSlaveOfflineTime = _getJenkinsSlaveOfflineTime();
+
+			if (!_isJenkinsSlaveOffline() || (jenkinsSlaveOfflineTime <= 0)) {
+				return 0;
+			}
+
+			return currentTimeMillis - jenkinsSlaveOfflineTime;
+		}
+
+		public String getOfflineCauseReason() {
+			return _computerJSONObject.optString("offlineCauseReason");
+		}
+
+		public String getURL() {
+			return _jsonObject.optString("url");
+		}
+
+		public boolean isBuilding() {
+			return _jsonObject.optBoolean("building", false);
+		}
+
+		public boolean isJenkinsSlaveBeingRemoved() {
+			String offlineCauseReason = getOfflineCauseReason();
+
+			if (!_isJenkinsSlaveOffline() ||
+				JenkinsResultsParserUtil.isNullOrEmpty(offlineCauseReason)) {
+
+				return false;
+			}
+
+			return offlineCauseReason.contains("is being removed");
+		}
+
+		public boolean isJenkinsSlaveOffline() {
+			if (_isJenkinsSlaveOffline() &&
+				!_isJenkinsSlaveTemporarilyOffline()) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		public boolean isLikelyStuck() {
+			return _likelyStuck;
+		}
+
+		@Override
+		public String toString() {
+			return JenkinsResultsParserUtil.combine(
+				_jenkinsMaster.getName(), " ", getFullDisplayName(), " (",
+				getURL(), ")");
+		}
+
+		protected RunningBuild(
+			JSONObject computerJSONObject,
+			JSONObject currentExecutableJSONObject, JenkinsMaster jenkinsMaster,
+			String jenkinsSlaveName, boolean likelyStuck) {
+
+			_computerJSONObject = computerJSONObject;
+			_jenkinsMaster = jenkinsMaster;
+			_jenkinsSlaveName = jenkinsSlaveName;
+			_likelyStuck = likelyStuck;
+
+			_jsonObject = currentExecutableJSONObject;
+		}
+
+		private long _getJenkinsSlaveOfflineTime() {
+			JSONObject offlineCauseJSONObject =
+				_computerJSONObject.optJSONObject("offlineCause");
+
+			if (offlineCauseJSONObject == null) {
+				return -1;
+			}
+
+			return offlineCauseJSONObject.optLong("timestamp", -1);
+		}
+
+		private long _getStartTime() {
+			return _jsonObject.optLong("timestamp", -1);
+		}
+
+		private boolean _isJenkinsSlaveOffline() {
+			return _computerJSONObject.optBoolean("offline", false);
+		}
+
+		private boolean _isJenkinsSlaveTemporarilyOffline() {
+
+			// Absent means the payload never carried the field, so assume the
+			// node was drained deliberately rather than reaping its builds.
+
+			return _computerJSONObject.optBoolean("temporarilyOffline", true);
+		}
+
+		private final JSONObject _computerJSONObject;
+		private final JenkinsMaster _jenkinsMaster;
+		private final String _jenkinsSlaveName;
+		private final JSONObject _jsonObject;
+		private final boolean _likelyStuck;
+
+	}
+
 	protected static long maxRecentBatchAge = 120 * 1000;
 
 	private static Map<String, String> _getParameters(JSONObject jsonObject) {
@@ -1345,6 +1518,39 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		catch (Exception exception) {
 			throw new RuntimeException(
 				"Unable to determine URL for master " + _masterName, exception);
+		}
+	}
+
+	private void _addRunningBuilds(
+		JSONObject computerJSONObject, String jenkinsSlaveName,
+		List<RunningBuild> runningBuilds) {
+
+		for (String key : new String[] {"executors", "oneOffExecutors"}) {
+			JSONArray executorsJSONArray = computerJSONObject.optJSONArray(key);
+
+			if (executorsJSONArray == null) {
+				continue;
+			}
+
+			for (int i = 0; i < executorsJSONArray.length(); i++) {
+				JSONObject executorJSONObject =
+					executorsJSONArray.getJSONObject(i);
+
+				JSONObject currentExecutableJSONObject =
+					executorJSONObject.optJSONObject("currentExecutable");
+
+				if ((currentExecutableJSONObject == null) ||
+					!currentExecutableJSONObject.has("url")) {
+
+					continue;
+				}
+
+				runningBuilds.add(
+					new RunningBuild(
+						computerJSONObject, currentExecutableJSONObject, this,
+						jenkinsSlaveName,
+						executorJSONObject.optBoolean("likelyStuck", false)));
+			}
 		}
 	}
 
@@ -1618,11 +1824,20 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _topLevelJobNames.contains(jobName);
 	}
 
-	private synchronized boolean _isUpdated() {
+	private synchronized boolean _isUpdated(boolean minimal) {
+
+		// A minimal update leaves out the executor detail a full update
+		// collects, so it can satisfy a later minimal request but never a
+		// full one. Without this a caller asking for the full payload can be
+		// handed a minimal snapshot and read every missing field as a
+		// default.
+
 		if ((_updateTimestamp == -1) ||
 			((System.currentTimeMillis() - _updateTimestamp) >
-				_MAXIMUM_UPDATE_DURATION)) {
+				_MAXIMUM_UPDATE_DURATION) ||
+			(_updateMinimal && !minimal)) {
 
+			_updateMinimal = minimal;
 			_updateTimestamp = System.currentTimeMillis();
 
 			return false;
@@ -1717,6 +1932,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		new HashMap<>();
 	private final Map<String, Long> _buildsUpdateTimes = new HashMap<>();
 	private final List<String> _buildURLs = new CopyOnWriteArrayList<>();
+	private int _busyExecutorCount;
 	private final List<DefaultBuild> _defaultBuilds = new ArrayList<>();
 	private Map<String, String> _globalEnvironmentVariables;
 	private boolean _idle;
@@ -1733,9 +1949,12 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	private boolean _offline;
 	private final List<QueueItem> _queueItems = new ArrayList<>();
 	private Long _queueUpdateTime;
+	private final List<RunningBuild> _runningBuilds =
+		new CopyOnWriteArrayList<>();
 	private final Integer _slaveRAM;
 	private final Integer _slavesPerHost;
 	private List<String> _topLevelJobNames;
+	private boolean _updateMinimal = true;
 	private long _updateTimestamp = -1;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -22,6 +22,49 @@ import org.json.JSONObject;
  */
 public class JenkinsStopBuildUtil {
 
+	public static void abortBuild(String buildURL) throws Exception {
+		String normalizedBuildURL = JenkinsResultsParserUtil.fixURL(
+			JenkinsResultsParserUtil.getLocalURL(buildURL));
+
+		if (!_isBuilding(normalizedBuildURL)) {
+			return;
+		}
+
+		int responseCode = _post(normalizedBuildURL + "/stop");
+
+		if (responseCode >= 400) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to stop ", normalizedBuildURL,
+					", received response ", String.valueOf(responseCode)));
+		}
+
+		// Jenkins answers /stop as soon as it has interrupted the executor
+		// thread, whether or not that thread ever reacts. A build wedged in a
+		// native call or an unresponsive socket read takes the interrupt and
+		// keeps its executor, so the response alone does not mean the build
+		// stopped.
+
+		for (int i = 0; i < _ABORT_VERIFICATION_RETRIES; i++) {
+			JenkinsResultsParserUtil.sleep(_ABORT_VERIFICATION_PERIOD);
+
+			if (!_isBuilding(normalizedBuildURL)) {
+				return;
+			}
+		}
+
+		long abortVerificationDuration =
+			_ABORT_VERIFICATION_PERIOD * _ABORT_VERIFICATION_RETRIES;
+
+		throw new RuntimeException(
+			JenkinsResultsParserUtil.combine(
+				"Unable to stop ", normalizedBuildURL, ", it was still ",
+				"running ",
+				JenkinsResultsParserUtil.toDurationString(
+					abortVerificationDuration),
+				" after being interrupted"));
+	}
+
 	public static void cancelQueueItem(
 			JenkinsMaster jenkinsMaster, long queueId)
 		throws Exception {
@@ -29,20 +72,7 @@ public class JenkinsStopBuildUtil {
 		String normalizedURL = JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.getLocalURL(jenkinsMaster.getURL()));
 
-		URL urlObject = new URL(
-			normalizedURL + "/queue/cancelItem?id=" + queueId);
-
-		HttpURLConnection httpConnection =
-			(HttpURLConnection)urlObject.openConnection();
-
-		httpConnection.setRequestMethod("POST");
-
-		_setAuthorization(httpConnection);
-
-		System.out.println(
-			"Response from " + urlObject.toString() + ": " +
-				httpConnection.getResponseCode() + " " +
-					httpConnection.getResponseMessage());
+		_post(normalizedURL + "/queue/cancelItem?id=" + queueId);
 	}
 
 	public static void stopBuild(String buildURL) throws Exception {
@@ -102,6 +132,39 @@ public class JenkinsStopBuildUtil {
 		return downstreamURLs;
 	}
 
+	private static boolean _isBuilding(String normalizedBuildURL)
+		throws Exception {
+
+		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
+			normalizedBuildURL + "/api/json?tree=result", false);
+
+		if (jsonObject.has("result") && jsonObject.isNull("result")) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static int _post(String urlString) throws Exception {
+		URL urlObject = new URL(urlString);
+
+		HttpURLConnection httpConnection =
+			(HttpURLConnection)urlObject.openConnection();
+
+		httpConnection.setRequestMethod("POST");
+
+		_setAuthorization(httpConnection);
+
+		int responseCode = httpConnection.getResponseCode();
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Response from ", urlString, ": ", String.valueOf(responseCode),
+				" ", httpConnection.getResponseMessage()));
+
+		return responseCode;
+	}
+
 	private static void _setAuthorization(HttpURLConnection httpConnection)
 		throws Exception {
 
@@ -123,24 +186,11 @@ public class JenkinsStopBuildUtil {
 		String normalizedBuildURL = JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.getLocalURL(buildURL));
 
-		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-			normalizedBuildURL + "/api/json?tree=result", false);
-
-		if (jsonObject.has("result") && jsonObject.isNull("result")) {
-			URL urlObject = new URL(normalizedBuildURL + "/stop");
-
-			HttpURLConnection httpConnection =
-				(HttpURLConnection)urlObject.openConnection();
-
-			httpConnection.setRequestMethod("POST");
-
-			_setAuthorization(httpConnection);
-
-			System.out.println(
-				"Response from " + urlObject.toString() + ": " +
-					httpConnection.getResponseCode() + " " +
-						httpConnection.getResponseMessage());
+		if (!_isBuilding(normalizedBuildURL)) {
+			return;
 		}
+
+		_post(normalizedBuildURL + "/stop");
 	}
 
 	private static void _stopDownstreamBuilds(String buildURL)
@@ -152,6 +202,10 @@ public class JenkinsStopBuildUtil {
 			_stopBuild(downstreamURL);
 		}
 	}
+
+	private static final long _ABORT_VERIFICATION_PERIOD = 5 * 1000L;
+
+	private static final int _ABORT_VERIFICATION_RETRIES = 6;
 
 	private static final Pattern _buildURLPattern = Pattern.compile(
 		".+://(?<hostName>[^.]+)(.liferay.com)?/job/(?<jobName>[^/]+).*/" +

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -1,0 +1,329 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Calum Ragan
+ */
+public class StaleBuildReaper {
+
+	public StaleBuildReaper(boolean dryRun, JenkinsCohort jenkinsCohort) {
+		_dryRun = dryRun;
+		_jenkinsCohort = jenkinsCohort;
+	}
+
+	public int getReapedBuildCount() {
+		int reapedBuildCount = 0;
+
+		for (ReapAction reapAction : _reapActions) {
+			if (reapAction.isExecuted()) {
+				reapedBuildCount++;
+			}
+		}
+
+		return reapedBuildCount;
+	}
+
+	public int getStaleBuildCount() {
+		return _reapActions.size();
+	}
+
+	public String getSummary() {
+		StringBuilder sb = new StringBuilder();
+
+		int staleBuildCount = getStaleBuildCount();
+
+		String nounForm = JenkinsResultsParserUtil.getNounForm(
+			staleBuildCount, "stale builds", "stale build");
+
+		if (_dryRun) {
+			sb.append("Found ");
+			sb.append(staleBuildCount);
+			sb.append(" ");
+			sb.append(nounForm);
+			sb.append(". No build was aborted because DRY_RUN is enabled.");
+		}
+		else {
+			sb.append("Reaped ");
+			sb.append(getReapedBuildCount());
+			sb.append(" of ");
+			sb.append(staleBuildCount);
+			sb.append(" ");
+			sb.append(nounForm);
+			sb.append(".");
+		}
+
+		for (ReapAction reapAction : _reapActions) {
+			sb.append("\n");
+			sb.append(reapAction.getSummary());
+		}
+
+		return sb.toString();
+	}
+
+	public void reap() {
+		_generateReapActions();
+
+		_executeReapActions();
+
+		String summary = getSummary();
+
+		System.out.println(summary);
+
+		_sendSlackNotification(summary);
+	}
+
+	public static enum Reason {
+
+		JENKINS_SLAVE_BEING_REMOVED("its node is being removed"),
+		JENKINS_SLAVE_OFFLINE("its node has been offline"),
+		LIKELY_STUCK("its executor reports likelyStuck");
+
+		public String getDescription() {
+			return _description;
+		}
+
+		private Reason(String description) {
+			_description = description;
+		}
+
+		private final String _description;
+
+	}
+
+	private void _executeReapActions() {
+		if (_dryRun) {
+			return;
+		}
+
+		for (ReapAction reapAction : _reapActions) {
+			reapAction.execute();
+		}
+	}
+
+	private void _generateReapActions() {
+		long currentTimeMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		for (JenkinsMaster jenkinsMaster : _getJenkinsMasters()) {
+			jenkinsMaster.update(false);
+
+			List<JenkinsMaster.RunningBuild> runningBuilds =
+				jenkinsMaster.getRunningBuilds();
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					jenkinsMaster.getName(), " reports at most ",
+					String.valueOf(jenkinsMaster.getMaxRunningBuildCount()),
+					" running build(s). Enumerated ",
+					String.valueOf(runningBuilds.size()), "."));
+
+			for (JenkinsMaster.RunningBuild runningBuild : runningBuilds) {
+				List<Reason> reasons = _getReasons(
+					currentTimeMillis, runningBuild);
+
+				if (reasons.isEmpty()) {
+					continue;
+				}
+
+				_reapActions.add(
+					new ReapAction(
+						runningBuild.getDuration(currentTimeMillis), reasons,
+						runningBuild));
+			}
+		}
+	}
+
+	private List<JenkinsMaster> _getJenkinsMasters() {
+		List<JenkinsMaster> jenkinsMasters = new ArrayList<>(
+			_jenkinsCohort.getAvailableJenkinsMasters());
+
+		jenkinsMasters.addAll(_jenkinsCohort.getBlacklistedJenkinsMasters());
+
+		return jenkinsMasters;
+	}
+
+	private List<Reason> _getJenkinsSlaveReasons(
+		long currentTimeMillis, JenkinsMaster.RunningBuild runningBuild) {
+
+		List<Reason> reasons = new ArrayList<>();
+
+		if (runningBuild.isJenkinsSlaveBeingRemoved()) {
+			reasons.add(Reason.JENKINS_SLAVE_BEING_REMOVED);
+
+			return reasons;
+		}
+
+		if (!runningBuild.isJenkinsSlaveOffline()) {
+			return reasons;
+		}
+
+		// The grace period runs from the moment the node went offline, not
+		// from the moment the build started, so a node that is reconnecting
+		// gets the whole window however long its build has been running.
+		// Jenkins does not always report when the node went offline, and
+		// without that there is no way to tell a momentary drop from a dead
+		// channel, so the build is left for a later pass.
+
+		long jenkinsSlaveOfflineDuration =
+			runningBuild.getJenkinsSlaveOfflineDuration(currentTimeMillis);
+
+		if (jenkinsSlaveOfflineDuration >= _MINIMUM_OFFLINE_DURATION) {
+			reasons.add(Reason.JENKINS_SLAVE_OFFLINE);
+		}
+
+		return reasons;
+	}
+
+	private List<Reason> _getReasons(
+		long currentTimeMillis, JenkinsMaster.RunningBuild runningBuild) {
+
+		List<Reason> reasons = new ArrayList<>();
+
+		if (!runningBuild.isBuilding()) {
+			return reasons;
+		}
+
+		// Jenkins derives likelyStuck as ten times the estimate when an
+		// estimate exists, and a flat twenty four hours when it does not, so
+		// it already is the "far past its estimate" signal. Recomputing that
+		// here would only count one signal twice. It is scaled to the job
+		// though, and the flyweight builds occupying a one off executor
+		// finish in under a minute, which puts their likelyStuck window
+		// minutes rather than hours away. The floor keeps a slow report from
+		// being reaped as a hung batch.
+
+		long duration = runningBuild.getDuration(currentTimeMillis);
+
+		if (runningBuild.isLikelyStuck() &&
+			(duration >= _MINIMUM_LIKELY_STUCK_DURATION)) {
+
+			reasons.add(Reason.LIKELY_STUCK);
+		}
+
+		reasons.addAll(
+			_getJenkinsSlaveReasons(currentTimeMillis, runningBuild));
+
+		return reasons;
+	}
+
+	private void _sendSlackNotification(String summary) {
+		if (_reapActions.isEmpty()) {
+			return;
+		}
+
+		String subject = "Stale builds reaped";
+
+		if (_dryRun) {
+			subject = "Stale builds detected";
+		}
+
+		NotificationUtil.sendSlackNotification(
+			summary, "ci-notifications", subject);
+	}
+
+	private static final long _MINIMUM_LIKELY_STUCK_DURATION = 60 * 60 * 1000L;
+
+	private static final long _MINIMUM_OFFLINE_DURATION = 15 * 60 * 1000L;
+
+	private final boolean _dryRun;
+	private final JenkinsCohort _jenkinsCohort;
+	private final List<ReapAction> _reapActions = new ArrayList<>();
+
+	private class ReapAction {
+
+		public void execute() {
+			String buildURL = _runningBuild.getURL();
+
+			try {
+				JenkinsStopBuildUtil.abortBuild(buildURL);
+
+				_executed = true;
+			}
+			catch (Exception exception) {
+				System.out.println("Unable to reap " + buildURL);
+
+				exception.printStackTrace();
+			}
+		}
+
+		public String getSummary() {
+			StringBuilder sb = new StringBuilder();
+
+			JenkinsMaster jenkinsMaster = _runningBuild.getJenkinsMaster();
+
+			sb.append(jenkinsMaster.getName());
+
+			sb.append(" ");
+			sb.append(_runningBuild.getFullDisplayName());
+			sb.append(" on ");
+			sb.append(_runningBuild.getJenkinsSlaveName());
+			sb.append(" has been running for ");
+			sb.append(JenkinsResultsParserUtil.toDurationString(_duration));
+
+			long estimatedDuration = _runningBuild.getEstimatedDuration();
+
+			if (estimatedDuration > 0) {
+				sb.append(" against an estimate of ");
+				sb.append(
+					JenkinsResultsParserUtil.toDurationString(
+						estimatedDuration));
+			}
+
+			sb.append(". Flagged because ");
+
+			List<String> descriptions = new ArrayList<>();
+
+			for (Reason reason : _reasons) {
+				descriptions.add(reason.getDescription());
+			}
+
+			sb.append(JenkinsResultsParserUtil.join(", and ", descriptions));
+
+			sb.append(". ");
+			sb.append(_getOutcome());
+			sb.append(" ");
+			sb.append(_runningBuild.getURL());
+
+			return sb.toString();
+		}
+
+		public boolean isExecuted() {
+			return _executed;
+		}
+
+		private ReapAction(
+			long duration, List<Reason> reasons,
+			JenkinsMaster.RunningBuild runningBuild) {
+
+			_duration = duration;
+			_reasons = reasons;
+			_runningBuild = runningBuild;
+		}
+
+		private String _getOutcome() {
+			if (_dryRun) {
+				return "Not aborted (DRY_RUN).";
+			}
+
+			if (_executed) {
+				return "Aborted.";
+			}
+
+			return "Abort failed.";
+		}
+
+		private final long _duration;
+		private boolean _executed;
+		private final List<Reason> _reasons;
+		private final JenkinsMaster.RunningBuild _runningBuild;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 
+import java.util.List;
 import java.util.Map;
 
 import org.json.JSONArray;
@@ -36,6 +37,8 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		UrlReader urlReader = mockUrlReader();
 
+		_likelyStuckEstimatedDuration = RandomTestUtil.randomLong();
+
 		setUrlReaderOutput(
 			new JSONObject(
 			).put(
@@ -51,6 +54,22 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		setUrlReaderOutput(
 			read(new File(dependenciesDirs.get(0), "computer-api.json")),
 			"http://test-9-1/computer/api/json", urlReader);
+
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"items", new JSONArray()
+			).toString(),
+			"http://test-9-2/queue/api/json", urlReader);
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"mode", "NORMAL"
+			).toString(),
+			"http://test-9-2/api/json?tree=mode", urlReader);
+		setUrlReaderOutput(
+			_getRunningBuildsComputerAPIJSONObject().toString(),
+			"http://test-9-2/computer/api/json", urlReader);
 
 		_jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
 			"test-9-1", "http://test-9-1");
@@ -144,6 +163,57 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
+	public void testGetRunningBuilds() {
+		JenkinsMaster jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
+			"test-9-2", "http://test-9-2");
+
+		jenkinsMaster.update(false);
+
+		List<JenkinsMaster.RunningBuild> runningBuilds =
+			jenkinsMaster.getRunningBuilds();
+
+		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
+
+		// The busyExecutors metric is 7 while only 3 builds could be
+		// enumerated, so the count must come from what Jenkins reported
+		// rather than from the list.
+
+		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
+
+		List<String> buildURLs = jenkinsMaster.getBuildURLs();
+
+		Assert.assertEquals(buildURLs.toString(), 2, buildURLs.size());
+
+		Assert.assertFalse(
+			buildURLs.toString(), buildURLs.contains(_BUILD_URL_FLYWEIGHT));
+
+		JenkinsMaster.RunningBuild flyweightRunningBuild = _getRunningBuild(
+			_BUILD_URL_FLYWEIGHT, runningBuilds);
+
+		Assert.assertEquals(
+			"Built-In Node", flyweightRunningBuild.getJenkinsSlaveName());
+		Assert.assertFalse(flyweightRunningBuild.isLikelyStuck());
+		Assert.assertFalse(flyweightRunningBuild.isJenkinsSlaveOffline());
+
+		JenkinsMaster.RunningBuild likelyStuckRunningBuild = _getRunningBuild(
+			_BUILD_URL_LIKELY_STUCK, runningBuilds);
+
+		Assert.assertTrue(likelyStuckRunningBuild.isLikelyStuck());
+		Assert.assertFalse(likelyStuckRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertEquals(
+			_likelyStuckEstimatedDuration,
+			likelyStuckRunningBuild.getEstimatedDuration());
+
+		JenkinsMaster.RunningBuild offlineRunningBuild = _getRunningBuild(
+			_BUILD_URL_OFFLINE_NODE, runningBuilds);
+
+		Assert.assertTrue(offlineRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertEquals(
+			"Node is being removed",
+			offlineRunningBuild.getOfflineCauseReason());
+	}
+
+	@Test
 	public void testUpdate() {
 		_jenkinsMaster.update();
 
@@ -170,6 +240,88 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		Assert.assertFalse(labelBatchSizes.isEmpty());
 	}
 
+	@Test
+	public void testUpdateFullAfterMinimal() {
+		JenkinsMaster jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
+			"test-9-2", "http://test-9-2");
+
+		jenkinsMaster.update(true);
+
+		List<JenkinsMaster.RunningBuild> runningBuilds =
+			jenkinsMaster.getRunningBuilds();
+
+		Assert.assertTrue(runningBuilds.toString(), runningBuilds.isEmpty());
+
+		// The full update lands well inside the fifteen second window, but a
+		// minimal snapshot leaves out the executor detail it needs, so the
+		// cached entry must not satisfy it.
+
+		jenkinsMaster.update(false);
+
+		runningBuilds = jenkinsMaster.getRunningBuilds();
+
+		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
+
+		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
+
+		// The reverse does not hold. A full snapshot is a superset, so a
+		// later minimal request keeps it.
+
+		jenkinsMaster.update(true);
+
+		runningBuilds = jenkinsMaster.getRunningBuilds();
+
+		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
+	}
+
+	private JenkinsMaster.RunningBuild _getRunningBuild(
+		String buildURL, List<JenkinsMaster.RunningBuild> runningBuilds) {
+
+		for (JenkinsMaster.RunningBuild runningBuild : runningBuilds) {
+			String runningBuildURL = runningBuild.getURL();
+
+			if (runningBuildURL.equals(buildURL)) {
+				return runningBuild;
+			}
+		}
+
+		throw new AssertionError(
+			"Unable to find " + buildURL + " in " + runningBuilds);
+	}
+
+	private JSONObject _getRunningBuildsComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			7,
+			JenkinsMasterTestUtil.getBuiltInComputerJSONObject(
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_FLYWEIGHT, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					RandomTestUtil.randomLong())),
+			JenkinsMasterTestUtil.getComputerJSONObject(
+				"test-9-2-1",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_LIKELY_STUCK, _likelyStuckEstimatedDuration,
+					RandomTestUtil.randomString(), true,
+					RandomTestUtil.randomLong())),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-2", RandomTestUtil.randomLong(),
+				"Node is being removed", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_OFFLINE_NODE, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					RandomTestUtil.randomLong())));
+	}
+
+	private static final String _BUILD_URL_FLYWEIGHT =
+		"http://test-9-2/job/publish-testray-report/7/";
+
+	private static final String _BUILD_URL_LIKELY_STUCK =
+		"http://test-9-2/job/test-portal-acceptance-pullrequest(master)/1580/";
+
+	private static final String _BUILD_URL_OFFLINE_NODE =
+		"http://test-9-2/job/test-portal-release-downstream/22649/";
+
 	private JenkinsMaster _jenkinsMaster;
+	private long _likelyStuckEstimatedDuration;
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -10,10 +10,66 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 /**
  * @author Calum Ragan
  */
 public class JenkinsMasterTestUtil {
+
+	public static JSONObject getBuiltInComputerJSONObject(
+		JSONObject... oneOffExecutorJSONObjects) {
+
+		return _getComputerJSONObject(
+			"hudson.model.Hudson$MasterComputer", "Built-In Node",
+			new JSONArray(), false, "",
+			new JSONArray(oneOffExecutorJSONObjects));
+	}
+
+	public static JSONObject getComputerAPIJSONObject(
+		int busyExecutorCount, JSONObject... computerJSONObjects) {
+
+		return new JSONObject(
+		).put(
+			"busyExecutors", busyExecutorCount
+		).put(
+			"computer", new JSONArray(computerJSONObjects)
+		);
+	}
+
+	public static JSONObject getComputerJSONObject(
+		String displayName, JSONObject... executorJSONObjects) {
+
+		return _getComputerJSONObject(
+			"hudson.slaves.SlaveComputer", displayName,
+			new JSONArray(executorJSONObjects), false, "", new JSONArray());
+	}
+
+	public static JSONObject getExecutorJSONObject(
+		String buildURL, long estimatedDuration, String fullDisplayName,
+		boolean likelyStuck, long timestamp) {
+
+		JSONObject currentExecutableJSONObject = new JSONObject(
+		).put(
+			"building", true
+		).put(
+			"estimatedDuration", estimatedDuration
+		).put(
+			"fullDisplayName", fullDisplayName
+		).put(
+			"timestamp", timestamp
+		).put(
+			"url", buildURL
+		);
+
+		return new JSONObject(
+		).put(
+			"currentExecutable", currentExecutableJSONObject
+		).put(
+			"likelyStuck", likelyStuck
+		);
+	}
 
 	public static Properties getJenkinsCohortProperties(
 		String cohortName, int masterCount) {
@@ -76,7 +132,33 @@ public class JenkinsMasterTestUtil {
 			jenkinsMaster, "_labelBatchSizes");
 	}
 
+	public static JSONObject getOfflineComputerJSONObject(
+		String displayName, long offlineCauseTimestamp,
+		String offlineCauseReason, boolean temporarilyOffline,
+		JSONObject... executorJSONObjects) {
+
+		JSONObject computerJSONObject = _getComputerJSONObject(
+			"hudson.slaves.EC2FleetNodeComputer", displayName,
+			new JSONArray(executorJSONObjects), true, offlineCauseReason,
+			new JSONArray());
+
+		return computerJSONObject.put(
+			"offlineCause",
+			new JSONObject(
+			).put(
+				"timestamp", offlineCauseTimestamp
+			)
+		).put(
+			"temporarilyOffline", temporarilyOffline
+		);
+	}
+
 	public static void resetCaches() {
+		Map<String, ?> jenkinsCohorts = ReflectionTestUtil.getFieldValue(
+			JenkinsCohort.class, "_jenkinsCohorts");
+
+		jenkinsCohorts.clear();
+
 		Map<String, ?> jenkinsMasters = ReflectionTestUtil.getFieldValue(
 			JenkinsMaster.class, "_jenkinsMasters");
 
@@ -96,6 +178,39 @@ public class JenkinsMasterTestUtil {
 			LoadBalancerUtil.class, "_roundRobinCounters");
 
 		roundRobinCounters.clear();
+	}
+
+	private static JSONObject _getComputerJSONObject(
+		String className, String displayName, JSONArray executorsJSONArray,
+		boolean offline, String offlineCauseReason,
+		JSONArray oneOffExecutorsJSONArray) {
+
+		JSONArray assignedLabelsJSONArray = new JSONArray();
+
+		assignedLabelsJSONArray.put(
+			new JSONObject(
+			).put(
+				"name", displayName
+			));
+
+		return new JSONObject(
+		).put(
+			"_class", className
+		).put(
+			"assignedLabels", assignedLabelsJSONArray
+		).put(
+			"displayName", displayName
+		).put(
+			"executors", executorsJSONArray
+		).put(
+			"idle", executorsJSONArray.isEmpty()
+		).put(
+			"offline", offline
+		).put(
+			"offlineCauseReason", offlineCauseReason
+		).put(
+			"oneOffExecutors", oneOffExecutorsJSONArray
+		);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
@@ -1,0 +1,328 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Calum Ragan
+ */
+public class StaleBuildReaperTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Environment.setInstance(Mockito.mock(Environment.class));
+
+		_urlReader = mockUrlReader();
+
+		JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 2);
+
+		_setUpJenkinsMasterUrlReaderOutputs(
+			_getStaleBuildsComputerAPIJSONObject(), "test-9-1");
+		_setUpJenkinsMasterUrlReaderOutputs(
+			_getJenkinsSlaveOfflineComputerAPIJSONObject(), "test-9-2");
+
+		_jenkinsCohort = JenkinsCohort.getInstance("test-9");
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+
+		JenkinsResultsParserUtil.setBuildProperties(new Properties());
+	}
+
+	@Test
+	public void testGetSummary() {
+		StaleBuildReaper staleBuildReaper = _reap(
+			true, null, new ArrayList<String>());
+
+		String summary = staleBuildReaper.getSummary();
+
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+
+		Assert.assertTrue(summary, summary.contains(_BUILD_URL_LIKELY_STUCK));
+		Assert.assertTrue(summary, summary.contains(_BUILD_URL_NODE_REMOVED));
+		Assert.assertTrue(summary, summary.contains(_BUILD_URL_OFFLINE));
+
+		Assert.assertFalse(summary, summary.contains(_BUILD_URL_HEALTHY));
+		Assert.assertFalse(summary, summary.contains(_BUILD_URL_RECONNECTING));
+		Assert.assertFalse(
+			summary, summary.contains(_BUILD_URL_TEMPORARILY_OFFLINE));
+
+		// A flyweight build reports likelyStuck only minutes in, because
+		// Jenkins scales the flag to the job's own average.
+
+		Assert.assertFalse(
+			summary, summary.contains(_BUILD_URL_FLYWEIGHT_STUCK));
+
+		Assert.assertTrue(
+			summary, summary.contains("its executor reports likelyStuck"));
+		Assert.assertTrue(
+			summary, summary.contains("its node is being removed"));
+		Assert.assertTrue(
+			summary, summary.contains("its node has been offline"));
+	}
+
+	@Test
+	public void testReap() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(
+			false, null, stoppedBuildURLs);
+
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+
+		List<String> expectedBuildURLs = new ArrayList<>();
+
+		expectedBuildURLs.add(_BUILD_URL_LIKELY_STUCK);
+		expectedBuildURLs.add(_BUILD_URL_NODE_REMOVED);
+		expectedBuildURLs.add(_BUILD_URL_OFFLINE);
+
+		Collections.sort(expectedBuildURLs);
+
+		Collections.sort(stoppedBuildURLs);
+
+		Assert.assertEquals(expectedBuildURLs, stoppedBuildURLs);
+	}
+
+	@Test
+	public void testReapAbortFailed() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(
+			false, _BUILD_URL_LIKELY_STUCK, stoppedBuildURLs);
+
+		// A build that takes the interrupt and keeps running must not be
+		// counted or reported as reaped.
+
+		Assert.assertEquals(2, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+
+		Assert.assertFalse(
+			stoppedBuildURLs.toString(),
+			stoppedBuildURLs.contains(_BUILD_URL_LIKELY_STUCK));
+
+		String summary = staleBuildReaper.getSummary();
+
+		Assert.assertTrue(summary, summary.contains("Reaped 2 of 3"));
+
+		Assert.assertTrue(summary, summary.contains("Abort failed."));
+	}
+
+	@Test
+	public void testReapBlacklistedJenkinsMaster() {
+		ReflectionTestUtil.setFieldValue(
+			JenkinsMaster.getInstance("test-9-2"), "_blacklisted", true);
+
+		List<JenkinsMaster> availableJenkinsMasters =
+			_jenkinsCohort.getAvailableJenkinsMasters();
+
+		Assert.assertEquals(
+			availableJenkinsMasters.toString(), 1,
+			availableJenkinsMasters.size());
+
+		List<JenkinsMaster> blacklistedJenkinsMasters =
+			_jenkinsCohort.getBlacklistedJenkinsMasters();
+
+		Assert.assertEquals(
+			blacklistedJenkinsMasters.toString(), 1,
+			blacklistedJenkinsMasters.size());
+
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(
+			false, null, stoppedBuildURLs);
+
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertTrue(
+			stoppedBuildURLs.toString(),
+			stoppedBuildURLs.contains(_BUILD_URL_OFFLINE));
+	}
+
+	@Test
+	public void testReapDryRun() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(true, null, stoppedBuildURLs);
+
+		Assert.assertEquals(0, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertTrue(
+			stoppedBuildURLs.toString(), stoppedBuildURLs.isEmpty());
+	}
+
+	private JSONObject _getJenkinsSlaveOfflineComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			2,
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-1", _getStartTime(30 * _MINUTE),
+				"Connection was broken", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_OFFLINE, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(46 * _HOUR))),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-2", _getStartTime(2 * _MINUTE),
+				"Connection was broken", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_RECONNECTING, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(46 * _HOUR))),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-3", _getStartTime(30 * _HOUR), "Disk is full", true,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_TEMPORARILY_OFFLINE, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(46 * _HOUR))));
+	}
+
+	private JSONObject _getStaleBuildsComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			7,
+			JenkinsMasterTestUtil.getBuiltInComputerJSONObject(
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_HEALTHY, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(20 * _HOUR)),
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_FLYWEIGHT_STUCK, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), true,
+					_getStartTime(10 * _MINUTE))),
+			JenkinsMasterTestUtil.getComputerJSONObject(
+				"test-9-1-1",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_LIKELY_STUCK, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), true,
+					_getStartTime(20 * _HOUR))),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-1-2", _getStartTime(12 * 24 * _HOUR),
+				"Node is being removed", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_NODE_REMOVED, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(12 * 24 * _HOUR))));
+	}
+
+	private long _getStartTime(long duration) {
+		return JenkinsResultsParserUtil.getCurrentTimeMillis() - duration;
+	}
+
+	private StaleBuildReaper _reap(
+		boolean dryRun, String failingBuildURL, List<String> stoppedBuildURLs) {
+
+		try (MockedStatic<JenkinsStopBuildUtil> stopBuildMockedStatic =
+				Mockito.mockStatic(JenkinsStopBuildUtil.class);
+			MockedStatic<NotificationUtil> notificationMockedStatic =
+				Mockito.mockStatic(NotificationUtil.class)) {
+
+			stopBuildMockedStatic.when(
+				() -> JenkinsStopBuildUtil.abortBuild(Mockito.anyString())
+			).thenAnswer(
+				invocation -> {
+					String buildURL = invocation.getArgument(0);
+
+					if (buildURL.equals(failingBuildURL)) {
+						throw new RuntimeException(
+							"Unable to stop " + buildURL);
+					}
+
+					stoppedBuildURLs.add(buildURL);
+
+					return null;
+				}
+			);
+
+			StaleBuildReaper staleBuildReaper = new StaleBuildReaper(
+				dryRun, _jenkinsCohort);
+
+			staleBuildReaper.reap();
+
+			return staleBuildReaper;
+		}
+	}
+
+	private void _setUpJenkinsMasterUrlReaderOutputs(
+			JSONObject computerAPIJSONObject, String masterName)
+		throws Exception {
+
+		String masterURL = "http://" + masterName;
+
+		JSONObject queueJSONObject = new JSONObject();
+
+		queueJSONObject.put("items", new JSONArray());
+
+		setUrlReaderOutput(
+			queueJSONObject.toString(), masterURL + "/queue/api/json",
+			_urlReader);
+
+		JSONObject modeJSONObject = new JSONObject();
+
+		modeJSONObject.put("mode", "NORMAL");
+
+		setUrlReaderOutput(
+			modeJSONObject.toString(), masterURL + "/api/json?tree=mode",
+			_urlReader);
+
+		setUrlReaderOutput(
+			computerAPIJSONObject.toString(), masterURL + "/computer/api/json",
+			_urlReader);
+	}
+
+	private static final String _BUILD_URL_FLYWEIGHT_STUCK =
+		"http://test-9-1/job/publish-testray-report/7/";
+
+	private static final String _BUILD_URL_HEALTHY =
+		"http://test-9-1/job/test-portal-release-downstream/1/";
+
+	private static final String _BUILD_URL_LIKELY_STUCK =
+		"http://test-9-1/job/test-portal-acceptance-pullrequest(master)/1580/";
+
+	private static final String _BUILD_URL_NODE_REMOVED =
+		"http://test-9-1/job/test-portal-release-downstream/22649/";
+
+	private static final String _BUILD_URL_OFFLINE =
+		"http://test-9-2/job/test-portal-testsuite-downstream/166636/";
+
+	private static final String _BUILD_URL_RECONNECTING =
+		"http://test-9-2/job/test-portal-source-format(master)/99/";
+
+	private static final String _BUILD_URL_TEMPORARILY_OFFLINE =
+		"http://test-9-2/job/test-portal-acceptance-pullrequest(master)/42/";
+
+	private static final long _HOUR = 60 * 60 * 1000L;
+
+	private static final long _MINUTE = 60 * 1000L;
+
+	private JenkinsCohort _jenkinsCohort;
+	private UrlReader _urlReader;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7904

Supersedes https://github.com/pyoo47/liferay-portal/pull/4513.

## What Is Being Fixed

A build can wedge while still holding a Jenkins executor — its slave loses its channel, its node is decommissioned mid-run, or the build simply stops making progress. Jenkins keeps the executor allocated indefinitely, so the master's usable capacity quietly shrinks until someone notices and aborts the build by hand. Nothing in CI detects this today.

## How It Is Being Fixed

`StaleBuildReaper` walks every master in a cohort, including blacklisted ones — a draining master is exactly where a wedged build strands capacity — and enumerates the builds currently occupying executors. A build is flagged when its executor reports `likelyStuck` and has been running at least an hour, when its node is being removed, or when its node has been genuinely offline for at least fifteen minutes.

The signals are deliberately narrow. `likelyStuck` is Jenkins' own ten-times-the-estimate rule, so recomputing it here would count one signal twice; the one hour floor is there because that rule scales to the job, and the flyweight builds on `oneOffExecutors` finish in under a minute, which would otherwise put a slow report minutes away from being reaped. The offline grace period is measured from the node's `offlineCause` timestamp rather than the build's start time, so a slave that briefly drops while reconnecting gets the whole window however long its build has been running. Nodes marked `temporarilyOffline` are excluded, because jrp drains healthy slaves itself — `SlaveOfflineRule` takes the sibling slave offline when `slavesPerHost` is two — and those builds run to completion normally.

`JenkinsMaster.update` gains the wider `computer/api/json` tree query this needs, gated behind the existing `minimal` flag so no current caller pays for fields it does not read. That flag previously had no effect, so the update cache now records which mode produced a snapshot: a minimal entry can satisfy a later minimal request but never a full one, and `_runningBuilds` is only populated on a full pass, so a partial snapshot can never be mistaken for a complete one. Where a field can be absent the default is the one that does not reap.

Aborting goes through a new `JenkinsStopBuildUtil.abortBuild`. Jenkins answers `/stop` as soon as it has interrupted the executor thread, whether or not that thread reacts, so the method re-checks the build afterwards and only reports success once the build actually stopped. The pre-existing `stopBuild` path is left behaviourally identical, so the five `liferay-jenkins-ee` call sites are unaffected.

A `DRY_RUN` mode reports what would be reaped without aborting anything, and each run posts its summary to Slack.

### Note On Scope

`JenkinsMaster.isAvailable()` no longer treats a blacklisted master as unavailable. The reaper needs this — `update` bails early when `isAvailable()` is false, so without it the reaper would see nothing on a draining master, which is the incident that motivated the ticket. Because `JenkinsCohort` caches its master map and evaluates `isBlacklisted()` per call, a master blacklisted after that map is populated now contributes to the CI System Status Report's node counts during a rolling blacklist, where previously it contributed zero. This is intentional and recorded on LRCI-7904.

## PR Check

**pr-check: PASS** — tested on `3021ebc739dac8cf70330f46e7ffd31a39eeff71`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3021ebc739dac8cf70330f46e7ffd31a39eeff71"} -->
