### PR TITLE
LRCI-8035 Generate Jenkins user config.xml with OP Connect API tokens

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRepositoryFactory.java
@@ -121,7 +121,11 @@ public class GitRepositoryFactory {
 					"Unable to find git directory name " + gitDirectoryName);
 			}
 
-			if (gitRepositoryName.matches("liferay-plugins(-ee)?")) {
+			if (gitRepositoryName.equals("liferay-jenkins-ee")) {
+				workspaceGitRepository = new JenkinsWorkspaceGitRepository(
+					pullRequest, gitUpstreamBranchName);
+			}
+			else if (gitRepositoryName.matches("liferay-plugins(-ee)?")) {
 				workspaceGitRepository = new PluginsWorkspaceGitRepository(
 					pullRequest, gitUpstreamBranchName);
 			}
@@ -211,7 +215,11 @@ public class GitRepositoryFactory {
 					repositoryName, upstreamBranchName),
 				"/", gitRepositoryName, "/tree/", upstreamBranchName));
 
-		if (gitRepositoryName.matches("liferay-plugins(-ee)?")) {
+		if (gitRepositoryName.equals("liferay-jenkins-ee")) {
+			workspaceGitRepository = new JenkinsWorkspaceGitRepository(
+				remoteGitRef, upstreamBranchName);
+		}
+		else if (gitRepositoryName.matches("liferay-plugins(-ee)?")) {
 			workspaceGitRepository = new PluginsWorkspaceGitRepository(
 				remoteGitRef, upstreamBranchName);
 		}
@@ -262,6 +270,10 @@ public class GitRepositoryFactory {
 
 			if (repositoryName == null) {
 				throw new RuntimeException("Invalid JSONObject " + jsonObject);
+			}
+			else if (repositoryName.equals("liferay-jenkins-ee")) {
+				workspaceGitRepository = new JenkinsWorkspaceGitRepository(
+					jsonObject);
 			}
 			else if (repositoryName.matches("liferay-plugins(-ee)?")) {
 				workspaceGitRepository = new PluginsWorkspaceGitRepository(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -177,6 +177,65 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return Objects.equals(jenkinsMaster.getName(), getName());
 	}
 
+	public synchronized List<APIToken> getAPITokens(String jenkinsUserID) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(jenkinsUserID)) {
+			return null;
+		}
+
+		if (_apiTokens.containsKey(jenkinsUserID)) {
+			return _apiTokens.get(jenkinsUserID);
+		}
+
+		String propertyName = JenkinsResultsParserUtil.combine(
+			"jenkins.user.op.item[", jenkinsUserID, "]");
+
+		String itemReference = null;
+
+		try {
+			itemReference = JenkinsResultsParserUtil.getBuildProperty(
+				propertyName);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to get property " + propertyName, ioException);
+		}
+
+		List<APIToken> apiTokens = new ArrayList<>();
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(itemReference)) {
+			return apiTokens;
+		}
+
+		SecretsUtil.Item item = SecretsUtil.getItem(itemReference);
+
+		if (item == null) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to find item ", itemReference, " from property ",
+					propertyName));
+		}
+
+		apiTokens.add(new APIToken(itemReference));
+
+		Set<String> apiTokenItemFieldLabels = new HashSet<>();
+
+		for (SecretsUtil.ItemField itemField : item.getItemFields()) {
+			String label = itemField.getLabel();
+
+			if ((label == null) || !label.startsWith("api.token.json.") ||
+				!apiTokenItemFieldLabels.add(label)) {
+
+				continue;
+			}
+
+			apiTokens.add(new APIToken(new JSONObject(itemField.getValue())));
+		}
+
+		_apiTokens.put(jenkinsUserID, apiTokens);
+
+		return apiTokens;
+	}
+
 	@Override
 	public List<String> getAssignedLabels() {
 		return _assignedLabels;
@@ -1238,6 +1297,66 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 	protected static long maxRecentBatchAge = 120 * 1000;
 
+	protected static class APIToken {
+
+		public String getCreationDate() {
+			return _creationDate;
+		}
+
+		public String getHash() {
+			return _hash;
+		}
+
+		public String getName() {
+			return _name;
+		}
+
+		public String getToken() {
+			return _token;
+		}
+
+		public String getUUID() {
+			return _uuid;
+		}
+
+		public String getVersion() {
+			return _version;
+		}
+
+		private APIToken(JSONObject jsonObject) {
+			_creationDate = jsonObject.getString("api.token.creation.date");
+			_hash = jsonObject.getString("api.token.hash");
+			_name = jsonObject.getString("api.token.name");
+			_token = jsonObject.getString("api.token");
+			_uuid = jsonObject.getString("api.token.uuid");
+			_version = jsonObject.getString("api.token.version");
+		}
+
+		private APIToken(String itemReference) {
+			_creationDate = _getSecret(
+				itemReference, "api.token.creation.date");
+			_hash = _getSecret(itemReference, "api.token.hash");
+			_name = _getSecret(itemReference, "api.token.name");
+			_token = _getSecret(itemReference, "api.token");
+			_uuid = _getSecret(itemReference, "api.token.uuid");
+			_version = _getSecret(itemReference, "api.token.version");
+		}
+
+		private String _getSecret(String itemReference, String itemFieldLabel) {
+			return SecretsUtil.getSecret(
+				JenkinsResultsParserUtil.combine(
+					itemReference, "/", itemFieldLabel));
+		}
+
+		private final String _creationDate;
+		private final String _hash;
+		private final String _name;
+		private final String _token;
+		private final String _uuid;
+		private final String _version;
+
+	}
+
 	private static Map<String, String> _getParameters(JSONObject jsonObject) {
 		Map<String, String> parameters = new HashMap<>();
 
@@ -1706,6 +1825,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 	}
 
+	private final Map<String, List<APIToken>> _apiTokens = new HashMap<>();
 	private final List<String> _assignedLabels = new ArrayList<>();
 	private boolean _available;
 	private long _availableTimestamp = -1;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
@@ -64,7 +64,8 @@ public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 			return null;
 		}
 
-		String userConfigContent = getFileContent(userConfigFilePath);
+		String userConfigContent = SecretsUtil.replaceSecrets(
+			getFileContent(userConfigFilePath));
 
 		Document document = null;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.Properties;
+
+import org.json.JSONObject;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
+
+	public Properties getBuildProperties() {
+		if (_environmentBuildProperties != null) {
+			return _environmentBuildProperties;
+		}
+
+		File buildPropertiesFile = new File(
+			getDirectory(), "commands/build.properties");
+
+		String buildPropertiesFilePath =
+			JenkinsResultsParserUtil.getCanonicalPath(buildPropertiesFile);
+
+		EnvironmentBuildProperties environmentBuildProperties = null;
+
+		try {
+			environmentBuildProperties = new EnvironmentBuildProperties(
+				buildPropertiesFile);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to load " + buildPropertiesFilePath, ioException);
+		}
+
+		if (environmentBuildProperties.isEmpty()) {
+			throw new RuntimeException(
+				"Unable to find build properties for " +
+					buildPropertiesFilePath);
+		}
+
+		_environmentBuildProperties = environmentBuildProperties;
+
+		return _environmentBuildProperties;
+	}
+
+	public File getTemplateUsersDirectory() {
+		return new File(getDirectory(), "template/users");
+	}
+
+	protected JenkinsWorkspaceGitRepository(JSONObject jsonObject) {
+		super(jsonObject);
+	}
+
+	protected JenkinsWorkspaceGitRepository(
+		PullRequest pullRequest, String upstreamBranchName) {
+
+		super(pullRequest, upstreamBranchName);
+	}
+
+	protected JenkinsWorkspaceGitRepository(
+		RemoteGitRef remoteGitRef, String upstreamBranchName) {
+
+		super(remoteGitRef, upstreamBranchName);
+	}
+
+	private EnvironmentBuildProperties _environmentBuildProperties;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
@@ -8,11 +8,13 @@ package com.liferay.jenkins.results.parser;
 import java.io.File;
 import java.io.IOException;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
+import org.dom4j.Node;
 
 import org.json.JSONObject;
 
@@ -77,6 +79,15 @@ public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 				"Unable to parse " + userConfigFilePath, documentException);
 		}
 
+		try {
+			_setAPITokenElements(document, jenkinsMaster, jenkinsUserID);
+		}
+		catch (RuntimeException runtimeException) {
+			throw new RuntimeException(
+				"Unable to set API tokens in " + userConfigFilePath,
+				runtimeException);
+		}
+
 		return document.getRootElement();
 	}
 
@@ -114,9 +125,55 @@ public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		return null;
 	}
 
+	private void _setAPITokenElements(
+		Document document, JenkinsMaster jenkinsMaster, String jenkinsUserID) {
+
+		List<JenkinsMaster.APIToken> apiTokens = jenkinsMaster.getAPITokens(
+			jenkinsUserID);
+
+		if ((apiTokens == null) || apiTokens.isEmpty()) {
+			return;
+		}
+
+		Node tokenListNode = Dom4JUtil.getNodeByXPath(
+			document, _TOKEN_LIST_XPATH);
+
+		if (!(tokenListNode instanceof Element)) {
+			throw new RuntimeException("Unable to find " + _TOKEN_LIST_XPATH);
+		}
+
+		Element tokenListElement = (Element)tokenListNode;
+
+		tokenListElement.clearContent();
+
+		for (JenkinsMaster.APIToken apiToken : apiTokens) {
+			Element hashedTokenElement = Dom4JUtil.getNewElement(
+				"jenkins.security.apitoken.ApiTokenStore_-HashedToken",
+				tokenListElement);
+
+			Dom4JUtil.getNewElement(
+				"creationDate", hashedTokenElement, apiToken.getCreationDate());
+			Dom4JUtil.getNewElement(
+				"name", hashedTokenElement, apiToken.getName());
+			Dom4JUtil.getNewElement(
+				"uuid", hashedTokenElement, apiToken.getUUID());
+
+			Element valueElement = Dom4JUtil.getNewElement(
+				"value", hashedTokenElement);
+
+			Dom4JUtil.getNewElement("hash", valueElement, apiToken.getHash());
+			Dom4JUtil.getNewElement(
+				"version", valueElement, apiToken.getVersion());
+		}
+	}
+
 	private static final String[] _MASTERS_DIR_NAMES = {
 		"masters/generated", "masters/static"
 	};
+
+	private static final String _TOKEN_LIST_XPATH =
+		"/user/properties/jenkins.security.ApiTokenProperty/tokenStore" +
+			"/tokenList";
 
 	private Properties _commandsBuildProperties;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsWorkspaceGitRepository.java
@@ -10,6 +10,10 @@ import java.io.IOException;
 
 import java.util.Properties;
 
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+
 import org.json.JSONObject;
 
 /**
@@ -17,9 +21,9 @@ import org.json.JSONObject;
  */
 public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 
-	public Properties getBuildProperties() {
-		if (_environmentBuildProperties != null) {
-			return _environmentBuildProperties;
+	public Properties getCommandsBuildProperties() {
+		if (_commandsBuildProperties != null) {
+			return _commandsBuildProperties;
 		}
 
 		File buildPropertiesFile = new File(
@@ -28,10 +32,10 @@ public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		String buildPropertiesFilePath =
 			JenkinsResultsParserUtil.getCanonicalPath(buildPropertiesFile);
 
-		EnvironmentBuildProperties environmentBuildProperties = null;
+		Properties commandsBuildProperties = null;
 
 		try {
-			environmentBuildProperties = new EnvironmentBuildProperties(
+			commandsBuildProperties = new EnvironmentBuildProperties(
 				buildPropertiesFile);
 		}
 		catch (IOException ioException) {
@@ -39,19 +43,40 @@ public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 				"Unable to load " + buildPropertiesFilePath, ioException);
 		}
 
-		if (environmentBuildProperties.isEmpty()) {
+		if (commandsBuildProperties.isEmpty()) {
 			throw new RuntimeException(
 				"Unable to find build properties for " +
 					buildPropertiesFilePath);
 		}
 
-		_environmentBuildProperties = environmentBuildProperties;
+		_commandsBuildProperties = commandsBuildProperties;
 
-		return _environmentBuildProperties;
+		return _commandsBuildProperties;
 	}
 
-	public File getTemplateUsersDirectory() {
-		return new File(getDirectory(), "template/users");
+	public Element getUserConfigElement(
+		JenkinsMaster jenkinsMaster, String jenkinsUserID) {
+
+		String userConfigFilePath = _getUserConfigFilePath(
+			jenkinsMaster.getName(), jenkinsUserID);
+
+		if (userConfigFilePath == null) {
+			return null;
+		}
+
+		String userConfigContent = getFileContent(userConfigFilePath);
+
+		Document document = null;
+
+		try {
+			document = Dom4JUtil.parse(userConfigContent);
+		}
+		catch (DocumentException documentException) {
+			throw new RuntimeException(
+				"Unable to parse " + userConfigFilePath, documentException);
+		}
+
+		return document.getRootElement();
 	}
 
 	protected JenkinsWorkspaceGitRepository(JSONObject jsonObject) {
@@ -70,6 +95,28 @@ public class JenkinsWorkspaceGitRepository extends BaseWorkspaceGitRepository {
 		super(remoteGitRef, upstreamBranchName);
 	}
 
-	private EnvironmentBuildProperties _environmentBuildProperties;
+	private String _getUserConfigFilePath(
+		String masterName, String jenkinsUserID) {
+
+		for (String mastersDirName : _MASTERS_DIR_NAMES) {
+			String userConfigFilePath = JenkinsResultsParserUtil.combine(
+				mastersDirName, "/", masterName, "/users/", jenkinsUserID,
+				"/config.xml");
+
+			File userConfigFile = new File(getDirectory(), userConfigFilePath);
+
+			if (userConfigFile.exists()) {
+				return userConfigFilePath;
+			}
+		}
+
+		return null;
+	}
+
+	private static final String[] _MASTERS_DIR_NAMES = {
+		"masters/generated", "masters/static"
+	};
+
+	private Properties _commandsBuildProperties;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -119,6 +119,225 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
+	protected static class Item {
+
+		public void addItemField(ItemField itemField) {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_itemFields = new ArrayList<>();
+				}
+
+				_itemFields.add(itemField);
+			}
+		}
+
+		public String getId() {
+			return _id;
+		}
+
+		public ItemField getItemField(String label) {
+			List<ItemField> itemFields;
+
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+
+				itemFields = _itemFields;
+			}
+
+			for (ItemField itemField : itemFields) {
+				if (Objects.equals(itemField.getId(), label) ||
+					Objects.equals(itemField.getLabel(), label)) {
+
+					return itemField;
+				}
+			}
+
+			if (_linkedItem != null) {
+				return _linkedItem.getItemField(label);
+			}
+
+			return null;
+		}
+
+		public List<ItemField> getItemFields() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+
+				return _itemFields;
+			}
+		}
+
+		public ItemFile getItemFile(String fileName) {
+			List<ItemFile> itemFiles;
+
+			synchronized (_vault) {
+				if (_itemFiles == null) {
+					_init();
+				}
+
+				itemFiles = _itemFiles;
+			}
+
+			for (ItemFile itemFile : itemFiles) {
+				if (Objects.equals(itemFile.getName(), fileName)) {
+					return itemFile;
+				}
+			}
+
+			if (_linkedItem != null) {
+				return _linkedItem.getItemFile(fileName);
+			}
+
+			return null;
+		}
+
+		public List<ItemFile> getItemFiles() {
+			synchronized (_vault) {
+				if (_itemFiles == null) {
+					_init();
+				}
+
+				return _itemFiles;
+			}
+		}
+
+		public String getTitle() {
+			return _title;
+		}
+
+		public void load() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+			}
+		}
+
+		public void refresh() {
+			synchronized (_vault) {
+				_itemFields = null;
+				_itemFiles = null;
+				_linkedItem = null;
+			}
+		}
+
+		private Item(String id, String title, Vault vault) {
+			_id = id;
+			_title = title;
+			_vault = vault;
+		}
+
+		private void _init() {
+			JSONObject itemJSONObject = _toJSONObject(
+				JenkinsResultsParserUtil.combine(
+					"/v1/vaults/", _vault.getId(), "/items/", getId()));
+
+			JSONArray fieldsJSONArray = itemJSONObject.getJSONArray("fields");
+
+			_itemFields = new ArrayList<>(fieldsJSONArray.length());
+
+			for (int i = 0; i < fieldsJSONArray.length(); i++) {
+				JSONObject fieldJSONObject = fieldsJSONArray.getJSONObject(i);
+
+				try {
+					JSONObject sectionJSONObject =
+						fieldJSONObject.optJSONObject("section");
+
+					if (sectionJSONObject != null) {
+						if (Objects.equals(
+								sectionJSONObject.optString("label"),
+								"Related Items")) {
+
+							_linkedItem = _vault.getItem(
+								fieldJSONObject.getString("label"));
+						}
+
+						if (_linkedItem != null) {
+							continue;
+						}
+					}
+
+					if (!fieldJSONObject.has("value")) {
+						continue;
+					}
+
+					_itemFields.add(
+						new ItemField(
+							fieldJSONObject.getString("id"),
+							fieldJSONObject.getString("label"),
+							fieldJSONObject.getString("value")));
+				}
+				catch (JSONException jsonException) {
+					System.err.println(jsonException.toString());
+					System.out.println(fieldJSONObject.toString(2));
+				}
+			}
+
+			JSONArray filesJSONArray = itemJSONObject.optJSONArray(
+				"files", new JSONArray());
+
+			_itemFiles = new ArrayList<>(filesJSONArray.length());
+
+			for (int i = 0; i < filesJSONArray.length(); i++) {
+				JSONObject fileJSONObject = filesJSONArray.getJSONObject(i);
+
+				try {
+					JSONObject sectionJSONObject = fileJSONObject.optJSONObject(
+						"section");
+
+					if (sectionJSONObject != null) {
+						if (Objects.equals(
+								sectionJSONObject.optString("label"),
+								"Related Items")) {
+
+							_linkedItem = _vault.getItem(
+								fileJSONObject.getString("label"));
+						}
+
+						if (_linkedItem != null) {
+							continue;
+						}
+					}
+
+					if (!fileJSONObject.has("content_path")) {
+						continue;
+					}
+
+					_itemFiles.add(
+						new ItemFile(
+							fileJSONObject.getString("content_path"),
+							fileJSONObject.getString("name")));
+				}
+				catch (JSONException jsonException) {
+					System.err.println(jsonException.toString());
+					System.out.println(fileJSONObject.toString(2));
+				}
+			}
+		}
+
+		private final String _id;
+		private List<ItemField> _itemFields;
+		private List<ItemFile> _itemFiles;
+		private Item _linkedItem;
+		private final String _title;
+		private final Vault _vault;
+
+		private static enum Category {
+
+			API_CREDENTIAL, BANK_ACCOUNT, CREDIT_CARD, CUSTOM, DATABASE,
+			DOCUMENT, DRIVER_LICENSE, EMAIL_ACCOUNT, IDENTITY, LOGIN,
+			MEDICAL_RECORD, MEMBERSHIP, OUTDOOR_LICENSE, PASSPORT, PASSWORD,
+			REWARD_PROGRAM, SECURE_NOTE, SERVER, SOCIAL_SECURITY_NUMBER,
+			SOFTWARE_LICENSE, SSH_KEY, WIRELESS_ROUTER
+
+		}
+
+	}
+
 	private static void _createItem(
 		Map<String, String> itemFieldsMap, String itemTitle, Vault vault) {
 
@@ -553,225 +772,6 @@ public abstract class SecretsUtil {
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)");
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
-
-	private static class Item {
-
-		public void addItemField(ItemField itemField) {
-			synchronized (_vault) {
-				if (_itemFields == null) {
-					_itemFields = new ArrayList<>();
-				}
-
-				_itemFields.add(itemField);
-			}
-		}
-
-		public String getId() {
-			return _id;
-		}
-
-		public ItemField getItemField(String label) {
-			List<ItemField> itemFields;
-
-			synchronized (_vault) {
-				if (_itemFields == null) {
-					_init();
-				}
-
-				itemFields = _itemFields;
-			}
-
-			for (ItemField itemField : itemFields) {
-				if (Objects.equals(itemField.getId(), label) ||
-					Objects.equals(itemField.getLabel(), label)) {
-
-					return itemField;
-				}
-			}
-
-			if (_linkedItem != null) {
-				return _linkedItem.getItemField(label);
-			}
-
-			return null;
-		}
-
-		public List<ItemField> getItemFields() {
-			synchronized (_vault) {
-				if (_itemFields == null) {
-					_init();
-				}
-
-				return _itemFields;
-			}
-		}
-
-		public ItemFile getItemFile(String fileName) {
-			List<ItemFile> itemFiles;
-
-			synchronized (_vault) {
-				if (_itemFiles == null) {
-					_init();
-				}
-
-				itemFiles = _itemFiles;
-			}
-
-			for (ItemFile itemFile : itemFiles) {
-				if (Objects.equals(itemFile.getName(), fileName)) {
-					return itemFile;
-				}
-			}
-
-			if (_linkedItem != null) {
-				return _linkedItem.getItemFile(fileName);
-			}
-
-			return null;
-		}
-
-		public List<ItemFile> getItemFiles() {
-			synchronized (_vault) {
-				if (_itemFiles == null) {
-					_init();
-				}
-
-				return _itemFiles;
-			}
-		}
-
-		public String getTitle() {
-			return _title;
-		}
-
-		public void load() {
-			synchronized (_vault) {
-				if (_itemFields == null) {
-					_init();
-				}
-			}
-		}
-
-		public void refresh() {
-			synchronized (_vault) {
-				_itemFields = null;
-				_itemFiles = null;
-				_linkedItem = null;
-			}
-		}
-
-		private Item(String id, String title, Vault vault) {
-			_id = id;
-			_title = title;
-			_vault = vault;
-		}
-
-		private void _init() {
-			JSONObject itemJSONObject = _toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					"/v1/vaults/", _vault.getId(), "/items/", getId()));
-
-			JSONArray fieldsJSONArray = itemJSONObject.getJSONArray("fields");
-
-			_itemFields = new ArrayList<>(fieldsJSONArray.length());
-
-			for (int i = 0; i < fieldsJSONArray.length(); i++) {
-				JSONObject fieldJSONObject = fieldsJSONArray.getJSONObject(i);
-
-				try {
-					JSONObject sectionJSONObject =
-						fieldJSONObject.optJSONObject("section");
-
-					if (sectionJSONObject != null) {
-						if (Objects.equals(
-								sectionJSONObject.optString("label"),
-								"Related Items")) {
-
-							_linkedItem = _vault.getItem(
-								fieldJSONObject.getString("label"));
-						}
-
-						if (_linkedItem != null) {
-							continue;
-						}
-					}
-
-					if (!fieldJSONObject.has("value")) {
-						continue;
-					}
-
-					_itemFields.add(
-						new ItemField(
-							fieldJSONObject.getString("id"),
-							fieldJSONObject.getString("label"),
-							fieldJSONObject.getString("value")));
-				}
-				catch (JSONException jsonException) {
-					System.err.println(jsonException.toString());
-					System.out.println(fieldJSONObject.toString(2));
-				}
-			}
-
-			JSONArray filesJSONArray = itemJSONObject.optJSONArray(
-				"files", new JSONArray());
-
-			_itemFiles = new ArrayList<>(filesJSONArray.length());
-
-			for (int i = 0; i < filesJSONArray.length(); i++) {
-				JSONObject fileJSONObject = filesJSONArray.getJSONObject(i);
-
-				try {
-					JSONObject sectionJSONObject = fileJSONObject.optJSONObject(
-						"section");
-
-					if (sectionJSONObject != null) {
-						if (Objects.equals(
-								sectionJSONObject.optString("label"),
-								"Related Items")) {
-
-							_linkedItem = _vault.getItem(
-								fileJSONObject.getString("label"));
-						}
-
-						if (_linkedItem != null) {
-							continue;
-						}
-					}
-
-					if (!fileJSONObject.has("content_path")) {
-						continue;
-					}
-
-					_itemFiles.add(
-						new ItemFile(
-							fileJSONObject.getString("content_path"),
-							fileJSONObject.getString("name")));
-				}
-				catch (JSONException jsonException) {
-					System.err.println(jsonException.toString());
-					System.out.println(fileJSONObject.toString(2));
-				}
-			}
-		}
-
-		private final String _id;
-		private List<ItemField> _itemFields;
-		private List<ItemFile> _itemFiles;
-		private Item _linkedItem;
-		private final String _title;
-		private final Vault _vault;
-
-		private static enum Category {
-
-			API_CREDENTIAL, BANK_ACCOUNT, CREDIT_CARD, CUSTOM, DATABASE,
-			DOCUMENT, DRIVER_LICENSE, EMAIL_ACCOUNT, IDENTITY, LOGIN,
-			MEDICAL_RECORD, MEMBERSHIP, OUTDOOR_LICENSE, PASSPORT, PASSWORD,
-			REWARD_PROGRAM, SECURE_NOTE, SERVER, SOCIAL_SECURITY_NUMBER,
-			SOFTWARE_LICENSE, SSH_KEY, WIRELESS_ROUTER
-
-		}
-
-	}
 
 	private static class ItemField {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -119,6 +119,26 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
+	protected static Item getItem(String itemReference) {
+		Matcher matcher = _itemReferencePattern.matcher(
+			itemReference.replaceAll("/+$", ""));
+
+		if (!matcher.matches()) {
+			throw new RuntimeException(
+				"Invalid item reference " + itemReference);
+		}
+
+		String vaultName = matcher.group("vaultName");
+
+		Vault vault = Vault.getInstance(vaultName);
+
+		if (vault == null) {
+			throw new RuntimeException("Unable to find vault " + vaultName);
+		}
+
+		return vault.getItem(matcher.group("itemTitle"));
+	}
+
 	protected static class Item {
 
 		public void addItemField(ItemField itemField) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -338,6 +338,43 @@ public abstract class SecretsUtil {
 
 	}
 
+	protected static class ItemField {
+
+		public String getId() {
+			return _id;
+		}
+
+		public String getLabel() {
+			return _label;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		private ItemField(String id, String label, String value) {
+			_id = id;
+			_label = label;
+			_value = value;
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+				JenkinsResultsParserUtil.addRedactToken(value);
+			}
+		}
+
+		private final String _id;
+		private final String _label;
+		private final String _value;
+
+		private static enum Type {
+
+			ADDRESS, CONCEALED, CREDIT_CARD_NUMBER, CREDIT_CARD_TYPE, DATE,
+			EMAIL, GENDER, MENU, MONTH_YEAR, OTP, PHONE, REFERENCE, STRING, URL
+
+		}
+
+	}
+
 	private static void _createItem(
 		Map<String, String> itemFieldsMap, String itemTitle, Vault vault) {
 
@@ -772,43 +809,6 @@ public abstract class SecretsUtil {
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)");
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
-
-	private static class ItemField {
-
-		public String getId() {
-			return _id;
-		}
-
-		public String getLabel() {
-			return _label;
-		}
-
-		public String getValue() {
-			return _value;
-		}
-
-		private ItemField(String id, String label, String value) {
-			_id = id;
-			_label = label;
-			_value = value;
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-				JenkinsResultsParserUtil.addRedactToken(value);
-			}
-		}
-
-		private final String _id;
-		private final String _label;
-		private final String _value;
-
-		private static enum Type {
-
-			ADDRESS, CONCEALED, CREDIT_CARD_NUMBER, CREDIT_CARD_TYPE, DATE,
-			EMAIL, GENDER, MENU, MONTH_YEAR, OTP, PHONE, REFERENCE, STRING, URL
-
-		}
-
-	}
 
 	private static class ItemFile {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -375,6 +375,41 @@ public abstract class SecretsUtil {
 
 	}
 
+	protected static class ItemFile {
+
+		public ItemFile(String contentPath, String name) {
+			_contentPath = contentPath;
+			_name = name;
+		}
+
+		public String getName() {
+			return _name;
+		}
+
+		public String getValue() {
+			if (_value != null) {
+				return _value;
+			}
+
+			String value = _toString(_contentPath);
+
+			value = value.trim();
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
+				JenkinsResultsParserUtil.addRedactToken(value);
+			}
+
+			_value = value;
+
+			return _value;
+		}
+
+		private final String _contentPath;
+		private final String _name;
+		private String _value;
+
+	}
+
 	private static void _createItem(
 		Map<String, String> itemFieldsMap, String itemTitle, Vault vault) {
 
@@ -809,41 +844,6 @@ public abstract class SecretsUtil {
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)");
 	private static final Pattern _secretReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)/(?<fieldLabel>.*)");
-
-	private static class ItemFile {
-
-		public ItemFile(String contentPath, String name) {
-			_contentPath = contentPath;
-			_name = name;
-		}
-
-		public String getName() {
-			return _name;
-		}
-
-		public String getValue() {
-			if (_value != null) {
-				return _value;
-			}
-
-			String value = _toString(_contentPath);
-
-			value = value.trim();
-
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-				JenkinsResultsParserUtil.addRedactToken(value);
-			}
-
-			_value = value;
-
-			return _value;
-		}
-
-		private final String _contentPath;
-		private final String _name;
-		private String _value;
-
-	}
 
 	private static class Vault {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -119,6 +119,34 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
+	public static String replaceSecrets(String content) {
+		if (content == null) {
+			return content;
+		}
+
+		Matcher matcher = _inlineSecretReferencePattern.matcher(content);
+
+		StringBuffer sb = new StringBuffer();
+
+		while (matcher.find()) {
+			String secretReference = matcher.group();
+
+			String secret = getSecret(
+				matcher.group("vaultName"), matcher.group("itemTitle"),
+				matcher.group("fieldLabel"));
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
+				secret = secretReference;
+			}
+
+			matcher.appendReplacement(sb, Matcher.quoteReplacement(secret));
+		}
+
+		matcher.appendTail(sb);
+
+		return sb.toString();
+	}
+
 	protected static Item getItem(String itemReference) {
 		Matcher matcher = _itemReferencePattern.matcher(
 			itemReference.replaceAll("/+$", ""));
@@ -860,6 +888,10 @@ public abstract class SecretsUtil {
 	private static boolean _connectSecretsLoaded;
 	private static String _connectURL;
 	private static BearerHTTPAuthorization _httpAuthorization;
+	private static final Pattern _inlineSecretReferencePattern =
+		Pattern.compile(
+			"op://(?<vaultName>[^/<\\n]*)/(?<itemTitle>[^/<\\n]*)/" +
+				"(?<fieldLabel>[^<\\n]*[^<\\s])");
 	private static final Pattern _itemReferencePattern = Pattern.compile(
 		"op://(?<vaultName>[^/]*)/(?<itemTitle>[^/]*)");
 	private static final Pattern _secretReferencePattern = Pattern.compile(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8035

**What is being fixed:** Jenkins user configurations in
liferay-jenkins-ee store their API token uuid and hash as 1Password
Connect secret references, and there was no way to read one of those
configurations from Java with the references resolved. There was also
no way to represent the API tokens a Jenkins user owns, so rotating or
adding a token meant hand-editing every affected config.xml.

**How it is being fixed:** SecretsUtil gains a getItem method that
resolves an op://vault/item reference, a replaceSecrets method that
substitutes every reference embedded in a block of text, and its Item,
ItemField, and ItemFile classes become protected so callers in the
package can read an item's fields. JenkinsMaster gains an APIToken
class and a getAPITokens method that reads the item named by the
jenkins.user.op.item property for a given user, building one token
from the item's api.token fields and one for each api.token.json
field, caching the result per user. A new JenkinsWorkspaceGitRepository
represents liferay-jenkins-ee and is wired into GitRepositoryFactory;
its getUserConfigElement method locates a user's config.xml under
masters/generated or masters/static, resolves the secret references in
it, and rewrites the token list from the master's API tokens.