### PR TITLE
LRCI-8035 Add ability to apply a Jenkins master user config

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -113,7 +113,7 @@ public class JenkinsConfigUtil {
 
 		String output = jenkinsMaster.executeSSHCommand(
 			JenkinsResultsParserUtil.combine(
-				"grep -l '<id>", emailAddress, "</id>' ",
+				"grep --files-with-matches '<id>", emailAddress, "</id>' ",
 				_JENKINS_USERS_DIR_PATH, "/*/config.xml || true"));
 
 		for (String line : output.split("\n")) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -96,7 +96,7 @@ public class JenkinsConfigUtil {
 		String output = jenkinsMaster.executeSSHCommand(
 			JenkinsResultsParserUtil.combine(
 				"grep -l '<id>", emailAddress, "</id>' ",
-				_JENKINS_USERS_DIR_PATH, "/*/config.xml"));
+				_JENKINS_USERS_DIR_PATH, "/*/config.xml || true"));
 
 		for (String line : output.split("\n")) {
 			line = line.trim();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -55,11 +55,18 @@ public class JenkinsConfigUtil {
 
 			_validateAPITokens(jenkinsMaster, jenkinsUserID);
 		}
-		catch (Exception exception) {
-			_restoreJenkinsMasterUserConfigFile(
-				jenkinsMaster, jenkinsMasterUserConfigFilePath);
+		catch (Exception exception1) {
+			try {
+				_restoreJenkinsMasterUserConfigFile(
+					jenkinsMaster, jenkinsMasterUserConfigFilePath);
 
-			throw exception;
+				jenkinsMaster.reload();
+			}
+			catch (Exception exception2) {
+				exception1.addSuppressed(exception2);
+			}
+
+			throw exception1;
 		}
 		finally {
 			userConfigFile.delete();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.List;
+
+import org.dom4j.Element;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class JenkinsConfigUtil {
+
+	public static void updateJenkinsMasterUserConfig(
+		JenkinsMaster jenkinsMaster, String jenkinsUserID,
+		JenkinsWorkspaceGitRepository jenkinsWorkspaceGitRepository) {
+
+		Element userConfigElement =
+			jenkinsWorkspaceGitRepository.getUserConfigElement(
+				jenkinsMaster, jenkinsUserID);
+
+		if (userConfigElement == null) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to find user config for ", jenkinsUserID, " in ",
+					jenkinsWorkspaceGitRepository.getName()));
+		}
+
+		String emailAddress = userConfigElement.elementText("id");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(emailAddress)) {
+			throw new RuntimeException(
+				"Unable to find email address for " + jenkinsUserID);
+		}
+
+		File userConfigFile = _writeUserConfigFile(userConfigElement);
+
+		String jenkinsMasterUserConfigFilePath =
+			_getJenkinsMasterUserConfigFilePath(jenkinsMaster, emailAddress);
+
+		try {
+			_backupJenkinsMasterUserConfigFile(
+				jenkinsMaster, jenkinsMasterUserConfigFilePath);
+
+			_copyUserConfigFileToJenkinsMaster(
+				jenkinsMaster, userConfigFile, jenkinsMasterUserConfigFilePath);
+
+			jenkinsMaster.reload();
+
+			_validateAPITokens(jenkinsMaster, jenkinsUserID);
+		}
+		catch (Exception exception) {
+			_restoreJenkinsMasterUserConfigFile(
+				jenkinsMaster, jenkinsMasterUserConfigFilePath);
+
+			throw exception;
+		}
+		finally {
+			userConfigFile.delete();
+		}
+	}
+
+	private static void _backupJenkinsMasterUserConfigFile(
+		JenkinsMaster jenkinsMaster, String userConfigFilePath) {
+
+		String backupUserConfigFilePath = userConfigFilePath + ".bak";
+
+		jenkinsMaster.executeSSHCommand(
+			JenkinsResultsParserUtil.combine(
+				"cp ", userConfigFilePath, " ", backupUserConfigFilePath));
+	}
+
+	private static void _copyUserConfigFileToJenkinsMaster(
+		JenkinsMaster jenkinsMaster, File userConfigFile,
+		String userConfigFilePath) {
+
+		jenkinsMaster.copyFile(userConfigFile, userConfigFilePath);
+	}
+
+	private static String _getJenkinsMasterUserConfigFilePath(
+		JenkinsMaster jenkinsMaster, String emailAddress) {
+
+		String output = jenkinsMaster.executeSSHCommand(
+			JenkinsResultsParserUtil.combine(
+				"grep -l '<id>", emailAddress, "</id>' ",
+				_JENKINS_USERS_DIR_PATH, "/*/config.xml"));
+
+		for (String line : output.split("\n")) {
+			line = line.trim();
+
+			if (!line.isEmpty()) {
+				return line;
+			}
+		}
+
+		throw new RuntimeException(
+			JenkinsResultsParserUtil.combine(
+				"Unable to find user config for ", emailAddress, " in ",
+				jenkinsMaster.getName(), ":", _JENKINS_USERS_DIR_PATH));
+	}
+
+	private static void _restoreJenkinsMasterUserConfigFile(
+		JenkinsMaster jenkinsMaster, String userConfigFilePath) {
+
+		String backupUserConfigFilePath = userConfigFilePath + ".bak";
+
+		jenkinsMaster.executeSSHCommand(
+			JenkinsResultsParserUtil.combine(
+				"cp ", backupUserConfigFilePath, " ", userConfigFilePath));
+	}
+
+	private static void _validateAPITokens(
+		JenkinsMaster jenkinsMaster, String jenkinsUserID) {
+
+		List<JenkinsMaster.APIToken> apiTokens = jenkinsMaster.getAPITokens(
+			jenkinsUserID);
+
+		if ((apiTokens == null) || apiTokens.isEmpty()) {
+			throw new RuntimeException(
+				"Unable to find API tokens for " + jenkinsUserID);
+		}
+
+		String nodeNameURL = JenkinsResultsParserUtil.getLocalURL(
+			jenkinsMaster.getURL() + "/api/json?tree=nodeName");
+
+		for (JenkinsMaster.APIToken apiToken : apiTokens) {
+			try {
+				JenkinsResultsParserUtil.toJSONObject(
+					nodeNameURL, false, apiToken.getHTTPAuthorization());
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(
+					JenkinsResultsParserUtil.combine(
+						"Unable to validate API token ", apiToken.getName(),
+						" for ", jenkinsUserID, " against ", nodeNameURL),
+					ioException);
+			}
+		}
+	}
+
+	private static File _writeUserConfigFile(Element userConfigElement) {
+		File userConfigFile = null;
+
+		try {
+			userConfigFile = File.createTempFile("user-config-", ".xml");
+
+			JenkinsResultsParserUtil.write(
+				userConfigFile,
+				JenkinsResultsParserUtil.combine(
+					_XML_DECLARATION, "\n\n",
+					Dom4JUtil.format(userConfigElement)));
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to write user config file", ioException);
+		}
+
+		return userConfigFile;
+	}
+
+	private static final String _JENKINS_USERS_DIR_PATH =
+		"/opt/java/jenkins/users";
+
+	private static final String _XML_DECLARATION = "<?xml version=\"1.0\"?>";
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -44,26 +44,34 @@ public class JenkinsConfigUtil {
 		String jenkinsMasterUserConfigFilePath =
 			_getJenkinsMasterUserConfigFilePath(jenkinsMaster, emailAddress);
 
+		File backupUserConfigFile = null;
+
 		try {
-			_backupJenkinsMasterUserConfigFile(
+			backupUserConfigFile = _backupJenkinsMasterUserConfigFile(
 				jenkinsMaster, jenkinsMasterUserConfigFilePath);
 
-			_copyUserConfigFileToJenkinsMaster(
-				jenkinsMaster, userConfigFile, jenkinsMasterUserConfigFilePath);
+			jenkinsMaster.copyFile(
+				userConfigFile, jenkinsMasterUserConfigFilePath);
 
 			jenkinsMaster.reload();
 
 			_validateAPITokens(jenkinsMaster, jenkinsUserID);
+
+			backupUserConfigFile.delete();
 		}
 		catch (Exception exception1) {
-			try {
-				_restoreJenkinsMasterUserConfigFile(
-					jenkinsMaster, jenkinsMasterUserConfigFilePath);
+			if (backupUserConfigFile != null) {
+				try {
+					jenkinsMaster.copyFile(
+						backupUserConfigFile, jenkinsMasterUserConfigFilePath);
 
-				jenkinsMaster.reload();
-			}
-			catch (Exception exception2) {
-				exception1.addSuppressed(exception2);
+					jenkinsMaster.reload();
+
+					backupUserConfigFile.delete();
+				}
+				catch (Exception exception2) {
+					exception1.addSuppressed(exception2);
+				}
 			}
 
 			throw exception1;
@@ -73,21 +81,31 @@ public class JenkinsConfigUtil {
 		}
 	}
 
-	private static void _backupJenkinsMasterUserConfigFile(
+	private static File _backupJenkinsMasterUserConfigFile(
 		JenkinsMaster jenkinsMaster, String userConfigFilePath) {
 
-		String backupUserConfigFilePath = userConfigFilePath + ".bak";
+		File backupUserConfigFile = null;
 
-		jenkinsMaster.executeSSHCommand(
-			JenkinsResultsParserUtil.combine(
-				"cp ", userConfigFilePath, " ", backupUserConfigFilePath));
-	}
+		try {
+			backupUserConfigFile = File.createTempFile(
+				"user-config-backup-", ".xml");
 
-	private static void _copyUserConfigFileToJenkinsMaster(
-		JenkinsMaster jenkinsMaster, File userConfigFile,
-		String userConfigFilePath) {
+			jenkinsMaster.copyRemoteFile(
+				userConfigFilePath, backupUserConfigFile);
 
-		jenkinsMaster.copyFile(userConfigFile, userConfigFilePath);
+			return backupUserConfigFile;
+		}
+		catch (Exception exception) {
+			if (backupUserConfigFile != null) {
+				backupUserConfigFile.delete();
+			}
+
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to back up ", jenkinsMaster.getName(), ":",
+					userConfigFilePath),
+				exception);
+		}
 	}
 
 	private static String _getJenkinsMasterUserConfigFilePath(
@@ -110,16 +128,6 @@ public class JenkinsConfigUtil {
 			JenkinsResultsParserUtil.combine(
 				"Unable to find user config for ", emailAddress, " in ",
 				jenkinsMaster.getName(), ":", _JENKINS_USERS_DIR_PATH));
-	}
-
-	private static void _restoreJenkinsMasterUserConfigFile(
-		JenkinsMaster jenkinsMaster, String userConfigFilePath) {
-
-		String backupUserConfigFilePath = userConfigFilePath + ".bak";
-
-		jenkinsMaster.executeSSHCommand(
-			JenkinsResultsParserUtil.combine(
-				"cp ", backupUserConfigFilePath, " ", userConfigFilePath));
 	}
 
 	private static void _validateAPITokens(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -168,7 +168,7 @@ public class JenkinsConfigUtil {
 			JenkinsResultsParserUtil.write(
 				userConfigFile,
 				JenkinsResultsParserUtil.combine(
-					_XML_DECLARATION, "\n\n",
+					"<?xml version=\"1.0\"?>\n\n",
 					Dom4JUtil.format(userConfigElement)));
 		}
 		catch (IOException ioException) {
@@ -181,7 +181,5 @@ public class JenkinsConfigUtil {
 
 	private static final String _JENKINS_USERS_DIR_PATH =
 		"/opt/java/jenkins/users";
-
-	private static final String _XML_DECLARATION = "<?xml version=\"1.0\"?>";
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -50,24 +50,24 @@ public class JenkinsConfigUtil {
 			backupUserConfigFile = _backupJenkinsMasterUserConfigFile(
 				jenkinsMaster, jenkinsMasterUserConfigFilePath);
 
-			jenkinsMaster.copyFile(
+			jenkinsMaster.copyFileToJenkinsMaster(
 				userConfigFile, jenkinsMasterUserConfigFilePath);
 
 			jenkinsMaster.reload();
 
 			_validateAPITokens(jenkinsMaster, jenkinsUserID);
 
-			backupUserConfigFile.delete();
+			JenkinsResultsParserUtil.delete(backupUserConfigFile);
 		}
 		catch (Exception exception1) {
 			if (backupUserConfigFile != null) {
 				try {
-					jenkinsMaster.copyFile(
+					jenkinsMaster.copyFileToJenkinsMaster(
 						backupUserConfigFile, jenkinsMasterUserConfigFilePath);
 
 					jenkinsMaster.reload();
 
-					backupUserConfigFile.delete();
+					JenkinsResultsParserUtil.delete(backupUserConfigFile);
 				}
 				catch (Exception exception2) {
 					exception1.addSuppressed(exception2);
@@ -90,7 +90,7 @@ public class JenkinsConfigUtil {
 			backupUserConfigFile = File.createTempFile(
 				"user-config-backup-", ".xml");
 
-			jenkinsMaster.copyRemoteFile(
+			jenkinsMaster.copyFileFromJenkinsMaster(
 				userConfigFilePath, backupUserConfigFile);
 
 			return backupUserConfigFile;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -172,27 +172,20 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		String sourceFilePath = JenkinsResultsParserUtil.getCanonicalPath(
 			sourceFile);
 
-		String scpCommand = JenkinsResultsParserUtil.combine(
-			"scp ", _SSH_OPTIONS, " ", sourceFilePath, " ", _SSH_USER_NAME, "@",
-			getName(), ":", targetFilePath);
+		_executeSCPCommand(
+			JenkinsResultsParserUtil.combine(
+				sourceFilePath, " ", _SSH_USER_NAME, "@", getName(), ":",
+				targetFilePath));
+	}
 
-		Process process = null;
+	public void copyRemoteFile(String sourceFilePath, File targetFile) {
+		String targetFilePath = JenkinsResultsParserUtil.getCanonicalPath(
+			targetFile);
 
-		try {
-			process = JenkinsResultsParserUtil.executeBashCommands(
-				true, new File("."), _SSH_COMMAND_TIMEOUT, scpCommand);
-		}
-		catch (IOException | TimeoutException exception) {
-			throw new RuntimeException(
-				"Unable to execute command " + scpCommand, exception);
-		}
-
-		if (process.exitValue() != 0) {
-			throw new RuntimeException(
-				JenkinsResultsParserUtil.combine(
-					"Unable to copy ", sourceFilePath, " to ", getName(), ":",
-					targetFilePath));
-		}
+		_executeSCPCommand(
+			JenkinsResultsParserUtil.combine(
+				_SSH_USER_NAME, "@", getName(), ":", sourceFilePath, " ",
+				targetFilePath));
 	}
 
 	@Override
@@ -1572,6 +1565,27 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		catch (Exception exception) {
 			throw new RuntimeException(
 				"Unable to determine URL for master " + _masterName, exception);
+		}
+	}
+
+	private void _executeSCPCommand(String scpArguments) {
+		String scpCommand = JenkinsResultsParserUtil.combine(
+			"scp ", _SSH_OPTIONS, " ", scpArguments);
+
+		Process process = null;
+
+		try {
+			process = JenkinsResultsParserUtil.executeBashCommands(
+				true, new File("."), _SSH_COMMAND_TIMEOUT, scpCommand);
+		}
+		catch (IOException | TimeoutException exception) {
+			throw new RuntimeException(
+				"Unable to execute command " + scpCommand, exception);
+		}
+
+		if (process.exitValue() != 0) {
+			throw new RuntimeException(
+				"Unable to execute command " + scpCommand);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -1062,6 +1062,21 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return false;
 	}
 
+	public void reload() {
+		String reloadURL = JenkinsResultsParserUtil.getLocalURL(
+			getURL() + "/reload");
+
+		try {
+			JenkinsResultsParserUtil.toString(
+				reloadURL, JenkinsResultsParserUtil.HttpRequestMethod.POST,
+				false);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to reload " + getName(), ioException);
+		}
+	}
+
 	@Override
 	public String toString() {
 		return JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -180,7 +180,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 		try {
 			process = JenkinsResultsParserUtil.executeBashCommands(
-				false, new File("."), _SSH_COMMAND_TIMEOUT, scpCommand);
+				true, new File("."), _SSH_COMMAND_TIMEOUT, scpCommand);
 		}
 		catch (IOException | TimeoutException exception) {
 			throw new RuntimeException(
@@ -215,7 +215,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 		try {
 			process = JenkinsResultsParserUtil.executeBashCommands(
-				false, new File("."), _SSH_COMMAND_TIMEOUT, sshCommand);
+				true, new File("."), _SSH_COMMAND_TIMEOUT, sshCommand);
 		}
 		catch (IOException | TimeoutException exception) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -8,6 +8,7 @@ package com.liferay.jenkins.results.parser;
 import com.liferay.jenkins.results.parser.aws.AWSFactory;
 import com.liferay.jenkins.results.parser.aws.AWSFleetCloud;
 
+import java.io.File;
 import java.io.IOException;
 
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -166,6 +168,33 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 	}
 
+	public void copyFile(File sourceFile, String targetFilePath) {
+		String sourceFilePath = JenkinsResultsParserUtil.getCanonicalPath(
+			sourceFile);
+
+		String scpCommand = JenkinsResultsParserUtil.combine(
+			"scp ", _SSH_OPTIONS, " ", sourceFilePath, " ", _SSH_USER_NAME, "@",
+			getName(), ":", targetFilePath);
+
+		Process process = null;
+
+		try {
+			process = JenkinsResultsParserUtil.executeBashCommands(
+				false, new File("."), _SSH_COMMAND_TIMEOUT, scpCommand);
+		}
+		catch (IOException | TimeoutException exception) {
+			throw new RuntimeException(
+				"Unable to execute command " + scpCommand, exception);
+		}
+
+		if (process.exitValue() != 0) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to copy ", sourceFilePath, " to ", getName(), ":",
+					targetFilePath));
+		}
+	}
+
 	@Override
 	public boolean equals(Object object) {
 		if (!(object instanceof JenkinsMaster)) {
@@ -175,6 +204,38 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		JenkinsMaster jenkinsMaster = (JenkinsMaster)object;
 
 		return Objects.equals(jenkinsMaster.getName(), getName());
+	}
+
+	public String executeSSHCommand(String command) {
+		String sshCommand = JenkinsResultsParserUtil.combine(
+			"ssh ", _SSH_OPTIONS, " ", _SSH_USER_NAME, "@", getName(), " \"",
+			command, "\"");
+
+		Process process = null;
+
+		try {
+			process = JenkinsResultsParserUtil.executeBashCommands(
+				false, new File("."), _SSH_COMMAND_TIMEOUT, sshCommand);
+		}
+		catch (IOException | TimeoutException exception) {
+			throw new RuntimeException(
+				"Unable to execute command " + sshCommand, exception);
+		}
+
+		if (process.exitValue() != 0) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to execute command ", command, " on ", getName()));
+		}
+
+		try {
+			return JenkinsResultsParserUtil.readInputStream(
+				process.getInputStream());
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to read output of command " + sshCommand, ioException);
+		}
 	}
 
 	public synchronized List<APIToken> getAPITokens(String jenkinsUserID) {
@@ -1799,6 +1860,13 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	private static final long _MAXIMUM_QUEUE_UPDATE_DURATION = 15 * 1000;
 
 	private static final long _MAXIMUM_UPDATE_DURATION = 1000 * 15;
+
+	private static final long _SSH_COMMAND_TIMEOUT = 1000 * 60 * 5;
+
+	private static final String _SSH_OPTIONS =
+		"-o ConnectTimeout=60 -o NumberOfPasswordPrompts=0";
+
+	private static final String _SSH_USER_NAME = "root";
 
 	private static final Pattern _globalEnvironmentVariablesPattern =
 		Pattern.compile("[^\\{]+(?<json>\\{.*\\})\\s+");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -278,7 +278,17 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 					propertyName));
 		}
 
-		apiTokens.add(new APIToken(itemReference));
+		SecretsUtil.ItemField userIDItemField = item.getItemField("user.id");
+
+		if (userIDItemField == null) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to find item field ", itemReference, "/user.id"));
+		}
+
+		String userID = userIDItemField.getValue();
+
+		apiTokens.add(new APIToken(itemReference, userID));
 
 		Set<String> apiTokenItemFieldLabels = new HashSet<>();
 
@@ -291,7 +301,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				continue;
 			}
 
-			apiTokens.add(new APIToken(new JSONObject(itemField.getValue())));
+			apiTokens.add(
+				new APIToken(new JSONObject(itemField.getValue()), userID));
 		}
 
 		_apiTokens.put(jenkinsUserID, apiTokens);
@@ -1385,12 +1396,23 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			return _hash;
 		}
 
+		public JenkinsResultsParserUtil.HTTPAuthorization
+			getHTTPAuthorization() {
+
+			return new JenkinsResultsParserUtil.BasicHTTPAuthorization(
+				getToken(), getUserID());
+		}
+
 		public String getName() {
 			return _name;
 		}
 
 		public String getToken() {
 			return _token;
+		}
+
+		public String getUserID() {
+			return _userID;
 		}
 
 		public String getUUID() {
@@ -1401,7 +1423,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			return _version;
 		}
 
-		private APIToken(JSONObject jsonObject) {
+		private APIToken(JSONObject jsonObject, String userID) {
 			_creationDateString = jsonObject.getString(
 				"api.token.creation.date");
 			_hash = jsonObject.getString("api.token.hash");
@@ -1409,9 +1431,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			_token = jsonObject.getString("api.token");
 			_uuid = jsonObject.getString("api.token.uuid");
 			_version = jsonObject.getString("api.token.version");
+
+			_userID = userID;
 		}
 
-		private APIToken(String itemReference) {
+		private APIToken(String itemReference, String userID) {
 			_creationDateString = _getSecret(
 				itemReference, "api.token.creation.date");
 			_hash = _getSecret(itemReference, "api.token.hash");
@@ -1419,6 +1443,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			_token = _getSecret(itemReference, "api.token");
 			_uuid = _getSecret(itemReference, "api.token.uuid");
 			_version = _getSecret(itemReference, "api.token.version");
+
+			_userID = userID;
 		}
 
 		private String _getSecret(String itemReference, String itemFieldLabel) {
@@ -1431,6 +1457,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		private final String _hash;
 		private final String _name;
 		private final String _token;
+		private final String _userID;
 		private final String _uuid;
 		private final String _version;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -229,8 +229,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		try {
-			return JenkinsResultsParserUtil.readInputStream(
+			String output = JenkinsResultsParserUtil.readInputStream(
 				process.getInputStream());
+
+			return output.replace("Finished executing Bash commands.", "");
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -168,24 +168,28 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 	}
 
-	public void copyFile(File sourceFile, String targetFilePath) {
-		String sourceFilePath = JenkinsResultsParserUtil.getCanonicalPath(
-			sourceFile);
+	public void copyFileFromJenkinsMaster(
+		String sourceFilePath, File targetFile) {
 
-		_executeSCPCommand(
-			JenkinsResultsParserUtil.combine(
-				sourceFilePath, " ", _SSH_USER_NAME, "@", getName(), ":",
-				targetFilePath));
-	}
-
-	public void copyRemoteFile(String sourceFilePath, File targetFile) {
 		String targetFilePath = JenkinsResultsParserUtil.getCanonicalPath(
 			targetFile);
 
 		_executeSCPCommand(
 			JenkinsResultsParserUtil.combine(
-				_SSH_USER_NAME, "@", getName(), ":", sourceFilePath, " ",
-				targetFilePath));
+				_SSH_USER_NAME, "@", getName(), ":", sourceFilePath),
+			targetFilePath);
+	}
+
+	public void copyFileToJenkinsMaster(
+		File sourceFile, String targetFilePath) {
+
+		String sourceFilePath = JenkinsResultsParserUtil.getCanonicalPath(
+			sourceFile);
+
+		_executeSCPCommand(
+			sourceFilePath,
+			JenkinsResultsParserUtil.combine(
+				_SSH_USER_NAME, "@", getName(), ":", targetFilePath));
 	}
 
 	@Override
@@ -1568,9 +1572,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 	}
 
-	private void _executeSCPCommand(String scpArguments) {
+	private void _executeSCPCommand(
+		String sourceFilePath, String targetFilePath) {
+
 		String scpCommand = JenkinsResultsParserUtil.combine(
-			"scp ", _SSH_OPTIONS, " ", scpArguments);
+			"scp ", _SSH_OPTIONS, " ", sourceFilePath, " ", targetFilePath);
 
 		Process process = null;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5513,8 +5513,15 @@ public class JenkinsResultsParserUtil {
 			String url, HttpRequestMethod httpRequestMethod)
 		throws IOException {
 
+		return toString(url, httpRequestMethod, true);
+	}
+
+	public static String toString(
+			String url, HttpRequestMethod httpRequestMethod, boolean checkCache)
+		throws IOException {
+
 		return toString(
-			url, true, _RETRIES_SIZE_MAX_DEFAULT, httpRequestMethod, null,
+			url, checkCache, _RETRIES_SIZE_MAX_DEFAULT, httpRequestMethod, null,
 			_SECONDS_RETRY_PERIOD_DEFAULT, _MILLIS_TIMEOUT_DEFAULT, null,
 			false);
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8035

## What Is Being Fixed

Applying a Jenkins user's configuration to a Jenkins master was a manual operation. The canonical user config lives in the Jenkins workspace Git repository, but nothing could push it onto a master and confirm the master accepted it. There was also no supported way to read a user's API tokens off a master, so nothing could verify that a newly applied config left the user's tokens intact.

## How It Is Being Fixed

JenkinsMaster gains the primitives the operation needs. executeSSHCommand and copyFile reach the master's filesystem, reload makes the master re-read its configuration from disk, and getAPITokens reads a user's tokens. Each APIToken now carries an HTTPAuthorization, so a caller can authenticate as that user without re-deriving credentials.

JenkinsConfigUtil ties these together. It resolves the user config element from the Jenkins workspace Git repository, writes it to a file, backs up the existing config on the master, copies the new one into place, reloads the master, and validates the user's API tokens. Any failure restores the backup, so a bad config never leaves the master in a broken state.

JenkinsResultsParserUtil.toString gains a checkCache overload. Validating tokens immediately after a reload has to bypass the response cache, or it reads back the pre-reload state and the check is meaningless.

## Why Are There No Tests?

These changes are CI infrastructure exercised by the CI build itself; there is no automated test harness covering Jenkins master and 1Password interaction.

## PR Check

**pr-check: PASS** — tested on `b68360247c09b292fb11a5ddc21babb204d665c5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b68360247c09b292fb11a5ddc21babb204d665c5"} -->
