### PR TITLE
LRCI-7996 Consolidate three HTTP retry mechanisms into one

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBodyUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBodyUrlReader.java
@@ -1,0 +1,93 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import java.net.URLConnection;
+
+/**
+ * Reads the whole body inside the attempt, so a response that arrives but is
+ * unusable fails the same way a connection reset does and the retry loop in
+ * {@link UrlReader} can act on it.
+ *
+ * @author Kenji Heigel
+ */
+public abstract class BaseBodyUrlReader<T> extends UrlReader<T> {
+
+	@Override
+	protected T handleCachedFile(File cachedFile) throws IOException {
+		try (BufferedReader bufferedReader = new BufferedReader(
+				new FileReader(cachedFile))) {
+
+			return parse(_read(bufferedReader));
+		}
+	}
+
+	@Override
+	protected T handleResponse(
+			String cacheFileKey, boolean expectResponse,
+			URLConnection urlConnection)
+		throws IOException {
+
+		String content = null;
+
+		try (InputStream inputStream = urlConnection.getInputStream();
+
+			BufferedReader bufferedReader = new BufferedReader(
+				new InputStreamReader(inputStream))) {
+
+			content = _read(bufferedReader);
+		}
+
+		if (expectResponse && JenkinsResultsParserUtil.isNullOrEmpty(content)) {
+			throw new IOException(
+				"Unable to read a response body from " +
+					urlConnection.getURL());
+		}
+
+		if (cacheFileKey != null) {
+			JenkinsResultsParserUtil.saveToCacheFile(cacheFileKey, content);
+		}
+
+		return parse(content);
+	}
+
+	/**
+	 * Turns a body that has already been read and accepted into the value the
+	 * caller asked for. Anything thrown here fails the attempt, which is what
+	 * puts a malformed response under the same retry policy as a transport
+	 * failure.
+	 */
+	protected abstract T parse(String content) throws IOException;
+
+	/**
+	 * Appends a newline per line rather than copying the stream verbatim. The
+	 * trailing newline and the normalized line endings are what every caller
+	 * has always been handed, so reading the bytes straight through would
+	 * change the returned content fleet wide.
+	 */
+	private String _read(BufferedReader bufferedReader) throws IOException {
+		StringBuilder sb = new StringBuilder();
+
+		String line = bufferedReader.readLine();
+
+		while (line != null) {
+			sb.append(line);
+			sb.append("\n");
+
+			line = bufferedReader.readLine();
+		}
+
+		return sb.toString();
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBodyUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBodyUrlReader.java
@@ -28,7 +28,7 @@ public abstract class BaseBodyUrlReader<T> extends UrlReader<T> {
 		try (BufferedReader bufferedReader = new BufferedReader(
 				new FileReader(cachedFile))) {
 
-			return parse(_read(bufferedReader));
+			return parse(_readBody(bufferedReader));
 		}
 	}
 
@@ -45,7 +45,7 @@ public abstract class BaseBodyUrlReader<T> extends UrlReader<T> {
 			BufferedReader bufferedReader = new BufferedReader(
 				new InputStreamReader(inputStream))) {
 
-			content = _read(bufferedReader);
+			content = _readBody(bufferedReader);
 		}
 
 		if (expectResponse && JenkinsResultsParserUtil.isNullOrEmpty(content)) {
@@ -62,6 +62,15 @@ public abstract class BaseBodyUrlReader<T> extends UrlReader<T> {
 	}
 
 	/**
+	 * A body the server cut short is not a failed attempt, because another
+	 * attempt returns the same truncation. Readers that cannot represent one
+	 * answer null rather than parsing it.
+	 */
+	protected boolean isTruncated(String content) {
+		return content.endsWith(_SUFFIX_TRUNCATED);
+	}
+
+	/**
 	 * Turns a body that has already been read and accepted into the value the
 	 * caller asked for. Anything thrown here fails the attempt, which is what
 	 * puts a malformed response under the same retry policy as a transport
@@ -75,7 +84,7 @@ public abstract class BaseBodyUrlReader<T> extends UrlReader<T> {
 	 * has always been handed, so reading the bytes straight through would
 	 * change the returned content fleet wide.
 	 */
-	private String _read(BufferedReader bufferedReader) throws IOException {
+	private String _readBody(BufferedReader bufferedReader) throws IOException {
 		StringBuilder sb = new StringBuilder();
 
 		String line = bufferedReader.readLine();
@@ -89,5 +98,8 @@ public abstract class BaseBodyUrlReader<T> extends UrlReader<T> {
 
 		return sb.toString();
 	}
+
+	private static final String _SUFFIX_TRUNCATED =
+		"was truncated due to its size.";
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONArrayUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONArrayUrlReader.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthorization;
+
+import java.io.IOException;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+/**
+ * @author Kenji Heigel
+ */
+public class JSONArrayUrlReader extends BaseBodyUrlReader<JSONArray> {
+
+	public static JSONArrayUrlReader getInstance() {
+		return _jsonArrayUrlReader;
+	}
+
+	public static JSONArray read(
+			boolean checkCache, HTTPAuthorization httpAuthorization,
+			int maxRetries, String postContent, int retryPeriod, int timeout,
+			String url)
+		throws IOException {
+
+		return _jsonArrayUrlReader.doRead(
+			checkCache, true, httpAuthorization, null, maxRetries, postContent,
+			retryPeriod, timeout, url);
+	}
+
+	public static void setInstance(JSONArrayUrlReader jsonArrayUrlReader) {
+		_jsonArrayUrlReader = jsonArrayUrlReader;
+	}
+
+	/**
+	 * Parsing inside the attempt gives the array reader the retry on a
+	 * malformed body that it never had, matching what LRCI-5564 established for
+	 * the object reader.
+	 */
+	@Override
+	protected JSONArray parse(String content) throws IOException {
+		if (content.endsWith(_SUFFIX_TRUNCATED)) {
+			return null;
+		}
+
+		try {
+			return new JSONArray(content);
+		}
+		catch (JSONException jsonException) {
+			throw new IOException(
+				"Unable to create a JSON array from the response body",
+				jsonException);
+		}
+	}
+
+	private static final String _SUFFIX_TRUNCATED =
+		"was truncated due to its size.";
+
+	private static volatile JSONArrayUrlReader _jsonArrayUrlReader =
+		new JSONArrayUrlReader();
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONArrayUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONArrayUrlReader.java
@@ -43,7 +43,7 @@ public class JSONArrayUrlReader extends BaseBodyUrlReader<JSONArray> {
 	 */
 	@Override
 	protected JSONArray parse(String content) throws IOException {
-		if (content.endsWith(_SUFFIX_TRUNCATED)) {
+		if (isTruncated(content)) {
 			return null;
 		}
 
@@ -56,9 +56,6 @@ public class JSONArrayUrlReader extends BaseBodyUrlReader<JSONArray> {
 				jsonException);
 		}
 	}
-
-	private static final String _SUFFIX_TRUNCATED =
-		"was truncated due to its size.";
 
 	private static volatile JSONArrayUrlReader _jsonArrayUrlReader =
 		new JSONArrayUrlReader();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONObjectUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONObjectUrlReader.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthorization;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
+
+import java.io.IOException;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * @author Kenji Heigel
+ */
+public class JSONObjectUrlReader extends BaseBodyUrlReader<JSONObject> {
+
+	public static JSONObjectUrlReader getInstance() {
+		return _jsonObjectUrlReader;
+	}
+
+	public static JSONObject read(
+			boolean checkCache, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, int maxRetries,
+			String postContent, int retryPeriod, int timeout, String url)
+		throws IOException {
+
+		return _jsonObjectUrlReader.doRead(
+			checkCache, true, httpAuthorization, httpRequestMethod, maxRetries,
+			postContent, retryPeriod, timeout, url);
+	}
+
+	public static void setInstance(JSONObjectUrlReader jsonObjectUrlReader) {
+		_jsonObjectUrlReader = jsonObjectUrlReader;
+	}
+
+	/**
+	 * Parsing inside the attempt is deliberate and load bearing, per LRCI-5564.
+	 * A malformed body is a failed attempt the retry loop can act on, which is
+	 * the whole reason the parse lives here rather than around the read.
+	 */
+	@Override
+	protected JSONObject parse(String content) throws IOException {
+		if (content.endsWith(_SUFFIX_TRUNCATED)) {
+			return null;
+		}
+
+		try {
+			return JenkinsResultsParserUtil.createJSONObject(content);
+		}
+		catch (JSONException jsonException) {
+			throw new IOException(
+				"Unable to create a JSON object from the response body",
+				jsonException);
+		}
+	}
+
+	private static final String _SUFFIX_TRUNCATED =
+		"was truncated due to its size.";
+
+	private static volatile JSONObjectUrlReader _jsonObjectUrlReader =
+		new JSONObjectUrlReader();
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONObjectUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JSONObjectUrlReader.java
@@ -44,7 +44,7 @@ public class JSONObjectUrlReader extends BaseBodyUrlReader<JSONObject> {
 	 */
 	@Override
 	protected JSONObject parse(String content) throws IOException {
-		if (content.endsWith(_SUFFIX_TRUNCATED)) {
+		if (isTruncated(content)) {
 			return null;
 		}
 
@@ -57,9 +57,6 @@ public class JSONObjectUrlReader extends BaseBodyUrlReader<JSONObject> {
 				jsonException);
 		}
 	}
-
-	private static final String _SUFFIX_TRUNCATED =
-		"was truncated due to its size.";
 
 	private static volatile JSONObjectUrlReader _jsonObjectUrlReader =
 		new JSONObjectUrlReader();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -718,23 +718,18 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public QueueItem getQueueItem(long queueId) {
-		String queueItemAPIURL = JenkinsResultsParserUtil.combine(
-			getURL(), "/queue/item/", String.valueOf(queueId),
-			"/api/json?tree=actions[parameters[name,value]],",
-			"id,inQueueSince,task[name,url],url,why");
-
 		try {
-			String response = JenkinsResultsParserUtil.toString(
-				queueItemAPIURL, false, 0, 0, 5000);
-
-			if (JenkinsResultsParserUtil.isNullOrEmpty(response)) {
-				return null;
-			}
-
 			JSONObject queueItemJSONObject =
-				JenkinsResultsParserUtil.createJSONObject(response);
+				JenkinsResultsParserUtil.toJSONObject(
+					JenkinsResultsParserUtil.combine(
+						getURL(), "/queue/item/", String.valueOf(queueId),
+						"/api/json?tree=actions[parameters[name,value]],",
+						"id,inQueueSince,task[name,url],url,why"),
+					false, 5000);
 
-			if (!queueItemJSONObject.has("id")) {
+			if ((queueItemJSONObject == null) ||
+				!queueItemJSONObject.has("id")) {
+
 				return null;
 			}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5431,41 +5431,10 @@ public class JenkinsResultsParserUtil {
 		long start = System.currentTimeMillis();
 
 		try {
-			for (int i = 0; i < 2; i++) {
-				try (BufferedReader bufferedReader = toBufferedReader(
-						url, checkCache, maxRetries, httpRequestMethod,
-						postContent, retryPeriod, timeout, httpAuthorization)) {
-
-					StringBuilder sb = new StringBuilder();
-
-					String line = bufferedReader.readLine();
-
-					while (line != null) {
-						sb.append(line);
-						sb.append("\n");
-
-						line = bufferedReader.readLine();
-					}
-
-					String content = sb.toString();
-
-					if (expectResponse && isNullOrEmpty(content) && (i < 1)) {
-						System.out.println(
-							"Unable to get response, retrying request");
-
-						continue;
-					}
-
-					if (checkCache && !url.startsWith("file:")) {
-						saveToCacheFile(
-							getCacheFileKey(url, postContent), content);
-					}
-
-					return content;
-				}
-			}
-
-			return "";
+			return TextUrlReader.read(
+				checkCache, expectResponse, httpAuthorization,
+				httpRequestMethod, maxRetries, postContent, retryPeriod,
+				timeout, url);
 		}
 		finally {
 			long duration = System.currentTimeMillis() - start;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5106,17 +5106,9 @@ public class JenkinsResultsParserUtil {
 			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
 		throws IOException {
 
-		String response = toString(
-			url, checkCache, maxRetries, null, postContent, retryPeriod,
-			timeout, httpAuthorization, true);
-
-		if ((response == null) ||
-			response.endsWith("was truncated due to its size.")) {
-
-			return null;
-		}
-
-		return new JSONArray(response);
+		return JSONArrayUrlReader.read(
+			checkCache, httpAuthorization, maxRetries, postContent, retryPeriod,
+			timeout, url);
 	}
 
 	public static JSONArray toJSONArray(String url, String postContent)
@@ -5194,44 +5186,9 @@ public class JenkinsResultsParserUtil {
 			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
 		throws IOException {
 
-		Retryable<JSONObject> retryable = new Retryable<JSONObject>(
-			true, maxRetries, retryPeriod, true) {
-
-			@Override
-			public JSONObject execute() {
-				try {
-					String response = JenkinsResultsParserUtil.toString(
-						url, checkCache, 0, httpRequestMethod, postContent,
-						retryPeriod, timeout, httpAuthorization, true);
-
-					if ((response == null) ||
-						response.endsWith("was truncated due to its size.")) {
-
-						return null;
-					}
-
-					return createJSONObject(response);
-				}
-				catch (IOException ioException) {
-					throw new RuntimeException(ioException);
-				}
-			}
-
-			@Override
-			protected String getRetryMessage(int retryCount) {
-				return combine(
-					"Unable to create JSONObject: ",
-					super.getRetryMessage(retryCount));
-			}
-
-		};
-
-		try {
-			return retryable.executeWithRetries();
-		}
-		catch (Exception exception) {
-			throw new RuntimeException("Unable to create JSON object");
-		}
+		return JSONObjectUrlReader.read(
+			checkCache, httpAuthorization, httpRequestMethod, maxRetries,
+			postContent, retryPeriod, timeout, url);
 	}
 
 	public static JSONObject toJSONObject(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -5072,7 +5072,7 @@ public class JenkinsResultsParserUtil {
 			int retryPeriod, int timeout, HTTPAuthorization httpAuthorization)
 		throws IOException {
 
-		return UrlReader.read(
+		return StreamUrlReader.read(
 			checkCache, httpAuthorization, httpRequestMethod, maxRetries,
 			postContent, retryPeriod, timeout, url);
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StreamUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StreamUrlReader.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthorization;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.net.URLConnection;
+
+/**
+ * @author Kenji Heigel
+ */
+public class StreamUrlReader extends UrlReader<InputStream> {
+
+	public static StreamUrlReader getInstance() {
+		return _streamUrlReader;
+	}
+
+	public static InputStream read(
+			boolean checkCache, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, int maxRetries,
+			String postContent, int retryPeriod, int timeout, String url)
+		throws IOException {
+
+		return _streamUrlReader.doRead(
+			checkCache, httpAuthorization, httpRequestMethod, maxRetries,
+			postContent, retryPeriod, timeout, url);
+	}
+
+	public static void setInstance(StreamUrlReader streamUrlReader) {
+		_streamUrlReader = streamUrlReader;
+	}
+
+	@Override
+	protected InputStream handleCachedFile(File cachedFile) throws IOException {
+		return new FileInputStream(cachedFile);
+	}
+
+	/**
+	 * The stream reader cannot validate the body without buffering it, so it
+	 * retries transport failures only. Writing the cache would require the same
+	 * buffering, which is why <code>cacheFileKey</code> is ignored here.
+	 */
+	@Override
+	protected InputStream handleResponse(
+			String cacheFileKey, URLConnection urlConnection)
+		throws IOException {
+
+		return urlConnection.getInputStream();
+	}
+
+	private static volatile StreamUrlReader _streamUrlReader =
+		new StreamUrlReader();
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StreamUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StreamUrlReader.java
@@ -47,11 +47,13 @@ public class StreamUrlReader extends UrlReader<InputStream> {
 	/**
 	 * The stream reader cannot validate the body without buffering it, so it
 	 * retries transport failures only. Writing the cache would require the same
-	 * buffering, which is why <code>cacheFileKey</code> is ignored here.
+	 * buffering, which is why <code>cacheFileKey</code> and
+	 * <code>expectResponse</code> are both ignored here.
 	 */
 	@Override
 	protected InputStream handleResponse(
-			String cacheFileKey, URLConnection urlConnection)
+			String cacheFileKey, boolean expectResponse,
+			URLConnection urlConnection)
 		throws IOException {
 
 		return urlConnection.getInputStream();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TextUrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TextUrlReader.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthorization;
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMethod;
+
+import java.io.IOException;
+
+/**
+ * @author Kenji Heigel
+ */
+public class TextUrlReader extends BaseBodyUrlReader<String> {
+
+	public static TextUrlReader getInstance() {
+		return _textUrlReader;
+	}
+
+	public static String read(
+			boolean checkCache, boolean expectResponse,
+			HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, int maxRetries,
+			String postContent, int retryPeriod, int timeout, String url)
+		throws IOException {
+
+		return _textUrlReader.doRead(
+			checkCache, expectResponse, httpAuthorization, httpRequestMethod,
+			maxRetries, postContent, retryPeriod, timeout, url);
+	}
+
+	public static void setInstance(TextUrlReader textUrlReader) {
+		_textUrlReader = textUrlReader;
+	}
+
+	@Override
+	protected String parse(String content) {
+		return content;
+	}
+
+	private static volatile TextUrlReader _textUrlReader = new TextUrlReader();
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -331,11 +331,9 @@ public abstract class UrlReader<T> {
 				}
 
 				String exceptionMessage = ioException1.getMessage();
+				int responseCode = _getResponseCode(urlConnection);
 
-				if (exceptionMessage.matches(
-						".*HTTP response code\\: 422 .*") &&
-					(urlConnection != null)) {
-
+				if (responseCode == 422) {
 					StringBuilder sb = new StringBuilder();
 
 					sb.append(exceptionMessage);
@@ -353,9 +351,7 @@ public abstract class UrlReader<T> {
 
 				Matcher testray2URLMatcher = _testray2URLPattern.matcher(url);
 
-				if (exceptionMessage.matches(
-						".*HTTP response code\\: 403 .*") &&
-					testray2URLMatcher.find() &&
+				if ((responseCode == 403) && testray2URLMatcher.find() &&
 					(urlConnection instanceof HttpURLConnection)) {
 
 					HttpURLConnection httpURLConnection =
@@ -404,11 +400,7 @@ public abstract class UrlReader<T> {
 
 				Integer retryPeriodOverride = null;
 
-				if (gitHubAPICall &&
-					exceptionMessage.matches(
-						".*HTTP response code\\: 403 .*") &&
-					(urlConnection != null)) {
-
+				if (gitHubAPICall && (responseCode == 403)) {
 					try {
 						retryPeriodOverride = Integer.parseInt(
 							urlConnection.getHeaderField("retry-after"));
@@ -433,6 +425,12 @@ public abstract class UrlReader<T> {
 						throw new GitHubSecondaryRateLimitRuntimeException(
 							url, retryPeriodOverride, ioException1);
 					}
+				}
+
+				if ((responseCode >= 400) && (responseCode < 500) &&
+					!_retryableResponseCodes.contains(responseCode)) {
+
+					throw ioException1;
 				}
 
 				long retryPeriodMillis = 1000 * retryPeriod;
@@ -573,10 +571,41 @@ public abstract class UrlReader<T> {
 		JenkinsResultsParserUtil.sleep(duration);
 	}
 
+	/**
+	 * Returns the response code, or <code>-1</code> when the connection never
+	 * produced one. A connection that failed before the response line arrived,
+	 * or that is not HTTP at all, is not a 4xx and must stay retryable.
+	 */
+	private int _getResponseCode(URLConnection urlConnection) {
+		if (!(urlConnection instanceof HttpURLConnection)) {
+			return -1;
+		}
+
+		HttpURLConnection httpURLConnection = (HttpURLConnection)urlConnection;
+
+		try {
+			return httpURLConnection.getResponseCode();
+		}
+		catch (IOException ioException) {
+			return -1;
+		}
+	}
+
 	private static final int _SECONDS_RETRY_PERIOD_MAX = 60 * 30;
 
 	private static final Pattern _gitHubAPIURLPattern = Pattern.compile(
 		"https\\:\\/\\/api\\.github\\.com(.*)");
+
+	/**
+	 * A 4xx means the request will fail the same way every time, so it is
+	 * terminal. These three are the exceptions: 403 carries both the GitHub
+	 * secondary rate limit and the Testray 2 expired token, where a further
+	 * attempt is the entire remedy, and 408 and 429 are retryable by
+	 * definition.
+	 */
+	private static final List<Integer> _retryableResponseCodes = Arrays.asList(
+		403, 408, 429);
+
 	private static final Pattern _testray2URLPattern = Pattern.compile(
 		"(?<baseURL>https://webserver-testray2(-(?<lxcEnvironment>.+))?" +
 			"\\.lfr\\.cloud|https://testray\\.liferay\\.com).*");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -12,7 +12,6 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HttpRequestMe
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.TokenHTTPAuthorization;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,7 +39,7 @@ import javax.net.ssl.SSLContext;
 /**
  * @author Kenji Heigel
  */
-public class UrlReader {
+public abstract class UrlReader<T> {
 
 	public static String getResponseHeader(
 			String headerName, HTTPAuthorization httpAuthorization,
@@ -59,24 +58,11 @@ public class UrlReader {
 			Map<String, String> requestHeaders, int timeout, String url)
 		throws IOException {
 
-		return _urlReader.doGetResponseHeader(
+		StreamUrlReader streamUrlReader = StreamUrlReader.getInstance();
+
+		return streamUrlReader.doGetResponseHeader(
 			headerName, httpAuthorization, httpRequestMethod, postContent,
 			requestHeaders, timeout, url);
-	}
-
-	public static InputStream read(
-			boolean checkCache, HTTPAuthorization httpAuthorization,
-			HttpRequestMethod httpRequestMethod, int maxRetries,
-			String postContent, int retryPeriod, int timeout, String url)
-		throws IOException {
-
-		return _urlReader.doRead(
-			checkCache, httpAuthorization, httpRequestMethod, maxRetries,
-			postContent, retryPeriod, timeout, url);
-	}
-
-	public static void setInstance(UrlReader urlReader) {
-		_urlReader = urlReader;
 	}
 
 	protected String doGetResponseHeader(
@@ -141,7 +127,7 @@ public class UrlReader {
 		return httpURLConnection.getHeaderField(headerName);
 	}
 
-	protected InputStream doRead(
+	protected T doRead(
 			boolean checkCache, HTTPAuthorization httpAuthorization,
 			HttpRequestMethod httpRequestMethod, int maxRetries,
 			String postContent, int retryPeriod, int timeout, String url)
@@ -162,21 +148,24 @@ public class UrlReader {
 
 		url = JenkinsResultsParserUtil.fixURL(url);
 
+		String cacheFileKey = null;
+
 		if (url.startsWith("file:")) {
 			url = JenkinsResultsParserUtil.fixFileURL(url);
 		}
-		else {
-			if (checkCache) {
-				if (JenkinsResultsParserUtil.debug) {
-					System.out.println("Loading " + url);
-				}
+		else if (checkCache) {
+			cacheFileKey = JenkinsResultsParserUtil.getCacheFileKey(
+				url, postContent);
 
-				File cachedFile = JenkinsResultsParserUtil.getCacheFile(
-					JenkinsResultsParserUtil.getCacheFileKey(url, postContent));
+			if (JenkinsResultsParserUtil.debug) {
+				System.out.println("Loading " + url);
+			}
 
-				if ((cachedFile != null) && cachedFile.exists()) {
-					return new FileInputStream(cachedFile);
-				}
+			File cachedFile = JenkinsResultsParserUtil.getCacheFile(
+				cacheFileKey);
+
+			if ((cachedFile != null) && cachedFile.exists()) {
+				return handleCachedFile(cachedFile);
 			}
 		}
 
@@ -290,104 +279,13 @@ public class UrlReader {
 									clientId, clientSecret, tokenURL));
 				}
 
-				URL urlObject = new URL(url);
-
-				urlConnection = urlObject.openConnection();
-
-				if (urlConnection instanceof HttpURLConnection) {
-					HttpURLConnection httpURLConnection =
-						(HttpURLConnection)urlConnection;
-
-					if (httpRequestMethod == HttpRequestMethod.PATCH) {
-						httpURLConnection.setRequestMethod("POST");
-
-						httpURLConnection.setRequestProperty(
-							"X-HTTP-Method-Override", "PATCH");
-					}
-					else {
-						httpURLConnection.setRequestMethod(
-							httpRequestMethod.name());
-					}
-
-					if (gitHubAPICall &&
-						(httpURLConnection instanceof HttpsURLConnection)) {
-
-						SSLContext sslContext = null;
-
-						float javaVersionNumber =
-							JenkinsResultsParserUtil.getJavaVersionNumber();
-
-						try {
-							if (javaVersionNumber < 1.8F) {
-								sslContext = SSLContext.getInstance("TLSv1.2");
-
-								sslContext.init(null, null, null);
-
-								HttpsURLConnection httpsURLConnection =
-									(HttpsURLConnection)httpURLConnection;
-
-								httpsURLConnection.setSSLSocketFactory(
-									sslContext.getSocketFactory());
-							}
-						}
-						catch (KeyManagementException | NoSuchAlgorithmException
-									exception) {
-
-							throw new RuntimeException(
-								"Unable to set SSL context to TLS v1.2",
-								exception);
-						}
-					}
-
-					if (httpAuthorization != null) {
-						authorization = httpAuthorization.toString();
-
-						httpURLConnection.setRequestProperty(
-							"accept", "application/json");
-						httpURLConnection.setRequestProperty(
-							"Authorization", authorization);
-
-						if (!testray1Request) {
-							httpURLConnection.setRequestProperty(
-								"Content-Type", "application/json");
-						}
-					}
-
-					if (url.contains("/oauth2/")) {
-						httpURLConnection.setRequestProperty(
-							"accept", "application/json");
-						httpURLConnection.setRequestProperty(
-							"Content-Type",
-							"application/x-www-form-urlencoded");
-					}
-
-					if (url.startsWith("https://releases-cdn.liferay.com")) {
-						httpURLConnection.setRequestProperty("User-Agent", "");
-					}
-
-					if (postContent != null) {
-						if (httpRequestMethod == null) {
-							httpURLConnection.setRequestMethod("POST");
-						}
-
-						httpURLConnection.setDoOutput(true);
-
-						try (OutputStream outputStream =
-								httpURLConnection.getOutputStream()) {
-
-							outputStream.write(postContent.getBytes("UTF-8"));
-
-							outputStream.flush();
-						}
-					}
+				if (httpAuthorization != null) {
+					authorization = httpAuthorization.toString();
 				}
 
-				if (timeout != 0) {
-					urlConnection.setConnectTimeout(timeout);
-					urlConnection.setReadTimeout(timeout);
-				}
-
-				urlConnection.connect();
+				urlConnection = openURLConnection(
+					authorization, gitHubAPICall, httpRequestMethod,
+					postContent, testray1Request, timeout, url);
 
 				if (gitHubAPICall) {
 					try {
@@ -416,7 +314,7 @@ public class UrlReader {
 					}
 				}
 
-				return urlConnection.getInputStream();
+				return handleResponse(cacheFileKey, urlConnection);
 			}
 			catch (IOException ioException1) {
 				if (ioException1 instanceof FileNotFoundException) {
@@ -557,9 +455,122 @@ public class UrlReader {
 
 				retryCount++;
 
-				JenkinsResultsParserUtil.sleep(retryPeriodMillis);
+				sleep(retryPeriodMillis);
 			}
 		}
+	}
+
+	protected abstract T handleCachedFile(File cachedFile) throws IOException;
+
+	protected abstract T handleResponse(
+			String cacheFileKey, URLConnection urlConnection)
+		throws IOException;
+
+	protected URLConnection openURLConnection(
+			String authorization, boolean gitHubAPICall,
+			HttpRequestMethod httpRequestMethod, String postContent,
+			boolean testray1Request, int timeout, String url)
+		throws IOException {
+
+		URL urlObject = new URL(url);
+
+		URLConnection urlConnection = urlObject.openConnection();
+
+		if (urlConnection instanceof HttpURLConnection) {
+			HttpURLConnection httpURLConnection =
+				(HttpURLConnection)urlConnection;
+
+			if (httpRequestMethod == HttpRequestMethod.PATCH) {
+				httpURLConnection.setRequestMethod("POST");
+
+				httpURLConnection.setRequestProperty(
+					"X-HTTP-Method-Override", "PATCH");
+			}
+			else {
+				httpURLConnection.setRequestMethod(httpRequestMethod.name());
+			}
+
+			if (gitHubAPICall &&
+				(httpURLConnection instanceof HttpsURLConnection)) {
+
+				SSLContext sslContext = null;
+
+				float javaVersionNumber =
+					JenkinsResultsParserUtil.getJavaVersionNumber();
+
+				try {
+					if (javaVersionNumber < 1.8F) {
+						sslContext = SSLContext.getInstance("TLSv1.2");
+
+						sslContext.init(null, null, null);
+
+						HttpsURLConnection httpsURLConnection =
+							(HttpsURLConnection)httpURLConnection;
+
+						httpsURLConnection.setSSLSocketFactory(
+							sslContext.getSocketFactory());
+					}
+				}
+				catch (KeyManagementException | NoSuchAlgorithmException
+							exception) {
+
+					throw new RuntimeException(
+						"Unable to set SSL context to TLS v1.2", exception);
+				}
+			}
+
+			if (authorization != null) {
+				httpURLConnection.setRequestProperty(
+					"accept", "application/json");
+				httpURLConnection.setRequestProperty(
+					"Authorization", authorization);
+
+				if (!testray1Request) {
+					httpURLConnection.setRequestProperty(
+						"Content-Type", "application/json");
+				}
+			}
+
+			if (url.contains("/oauth2/")) {
+				httpURLConnection.setRequestProperty(
+					"accept", "application/json");
+				httpURLConnection.setRequestProperty(
+					"Content-Type", "application/x-www-form-urlencoded");
+			}
+
+			if (url.startsWith("https://releases-cdn.liferay.com")) {
+				httpURLConnection.setRequestProperty("User-Agent", "");
+			}
+
+			if (postContent != null) {
+				if (httpRequestMethod == null) {
+					httpURLConnection.setRequestMethod("POST");
+				}
+
+				httpURLConnection.setDoOutput(true);
+
+				try (OutputStream outputStream =
+						httpURLConnection.getOutputStream()) {
+
+					outputStream.write(postContent.getBytes("UTF-8"));
+
+					outputStream.flush();
+				}
+			}
+		}
+
+		if (timeout != 0) {
+			urlConnection.setConnectTimeout(timeout);
+			urlConnection.setReadTimeout(timeout);
+		}
+
+		urlConnection.connect();
+
+		return urlConnection;
+	}
+
+	protected void sleep(long duration) {
+		JenkinsResultsParserUtil.sleep(duration);
 	}
 
 	private static final int _SECONDS_RETRY_PERIOD_MAX = 60 * 30;
@@ -575,6 +586,5 @@ public class UrlReader {
 		Arrays.asList(
 			HttpRequestMethod.POST, HttpRequestMethod.PATCH,
 			HttpRequestMethod.PUT, HttpRequestMethod.DELETE);
-	private static volatile UrlReader _urlReader = new UrlReader();
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -286,7 +286,11 @@ public abstract class UrlReader<T> {
 									clientId, clientSecret, tokenURL));
 				}
 
-				if (httpAuthorization != null) {
+				// Resolving a client credentials authorization performs a
+				// token request, so skip it for a URL that cannot carry the
+				// header.
+
+				if ((httpAuthorization != null) && !url.startsWith("file:")) {
 					authorization = httpAuthorization.toString();
 				}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -127,8 +127,15 @@ public abstract class UrlReader<T> {
 		return httpURLConnection.getHeaderField(headerName);
 	}
 
+	/**
+	 * The <code>expectResponse</code> flag travels down to
+	 * <code>handleResponse</code> so a reader that validates the body knows
+	 * whether an empty one is a failed attempt or an acceptable answer. Readers
+	 * that never look at the body ignore it.
+	 */
 	protected T doRead(
-			boolean checkCache, HTTPAuthorization httpAuthorization,
+			boolean checkCache, boolean expectResponse,
+			HTTPAuthorization httpAuthorization,
 			HttpRequestMethod httpRequestMethod, int maxRetries,
 			String postContent, int retryPeriod, int timeout, String url)
 		throws IOException {
@@ -314,7 +321,8 @@ public abstract class UrlReader<T> {
 					}
 				}
 
-				return handleResponse(cacheFileKey, urlConnection);
+				return handleResponse(
+					cacheFileKey, expectResponse, urlConnection);
 			}
 			catch (IOException ioException1) {
 				if (ioException1 instanceof FileNotFoundException) {
@@ -325,9 +333,9 @@ public abstract class UrlReader<T> {
 					url.matches("http://test-\\d+-\\d+/.*")) {
 
 					return doRead(
-						checkCache, httpAuthorization, httpRequestMethod,
-						maxRetries, postContent, retryPeriod, timeout,
-						JenkinsResultsParserUtil.getRemoteURL(url));
+						checkCache, expectResponse, httpAuthorization,
+						httpRequestMethod, maxRetries, postContent, retryPeriod,
+						timeout, JenkinsResultsParserUtil.getRemoteURL(url));
 				}
 
 				String exceptionMessage = ioException1.getMessage();
@@ -458,10 +466,22 @@ public abstract class UrlReader<T> {
 		}
 	}
 
+	protected T doRead(
+			boolean checkCache, HTTPAuthorization httpAuthorization,
+			HttpRequestMethod httpRequestMethod, int maxRetries,
+			String postContent, int retryPeriod, int timeout, String url)
+		throws IOException {
+
+		return doRead(
+			checkCache, true, httpAuthorization, httpRequestMethod, maxRetries,
+			postContent, retryPeriod, timeout, url);
+	}
+
 	protected abstract T handleCachedFile(File cachedFile) throws IOException;
 
 	protected abstract T handleResponse(
-			String cacheFileKey, URLConnection urlConnection)
+			String cacheFileKey, boolean expectResponse,
+			URLConnection urlConnection)
 		throws IOException;
 
 	protected URLConnection openURLConnection(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -31,7 +31,7 @@ public class BasePortalControllerBuildRunnerTest
 				"upstream-controller(master_content-management)/339/";
 		String invocationJobName = "test-portal-testsuite-upstream(master)";
 
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		setUrlReaderOutput(
 			new JSONObject(
@@ -70,7 +70,7 @@ public class BasePortalControllerBuildRunnerTest
 					)
 				)
 			).toString(),
-			"queue/api/json", urlReader);
+			"queue/api/json", urlReaders);
 
 		BasePortalControllerBuildRunner<?> basePortalControllerBuildRunner =
 			Mockito.mock(BasePortalControllerBuildRunner.class);
@@ -97,13 +97,7 @@ public class BasePortalControllerBuildRunnerTest
 		Assert.assertFalse(
 			basePortalControllerBuildRunner.expirePreviousBuild());
 
-		Mockito.verify(
-			urlReader
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
-			Mockito.contains("queue/api/json")
-		);
+		verifyUrlReadCount(1, urlReaders, "queue/api/json");
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -31,7 +31,7 @@ public class BasePortalControllerBuildRunnerTest
 				"upstream-controller(master_content-management)/339/";
 		String invocationJobName = "test-portal-testsuite-upstream(master)";
 
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(
 			new JSONObject(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunnerTest.java
@@ -31,7 +31,7 @@ public class BasePortalControllerBuildRunnerTest
 				"upstream-controller(master_content-management)/339/";
 		String invocationJobName = "test-portal-testsuite-upstream(master)";
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(
 			new JSONObject(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -56,7 +56,7 @@ public class BuildQueueRebalancerTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		JSONObject queueJSONObject = new JSONObject();
 
@@ -153,7 +153,7 @@ public class BuildQueueRebalancerTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderError(
 			new IOException("Connection refused"),

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -58,7 +58,7 @@ public class BuildQueueRebalancerTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		JSONObject queueJSONObject = new JSONObject();
 
@@ -155,7 +155,7 @@ public class BuildQueueRebalancerTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		Mockito.doThrow(
 			new IOException("Connection refused")

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -18,8 +18,6 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
 /**
  * @author Calum Ragan
  */
@@ -58,7 +56,7 @@ public class BuildQueueRebalancerTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		JSONObject queueJSONObject = new JSONObject();
 
@@ -76,7 +74,7 @@ public class BuildQueueRebalancerTest
 		setUrlReaderOutput(
 			String.valueOf(queueJSONObject),
 			_BLACKLISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
-			urlReader);
+			urlReaders);
 
 		setUrlReaderOutput(
 			String.valueOf(
@@ -85,7 +83,7 @@ public class BuildQueueRebalancerTest
 					"mode", "NORMAL"
 				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/api/json?tree=mode",
-			urlReader);
+			urlReaders);
 		setUrlReaderOutput(
 			String.valueOf(
 				new JSONObject(
@@ -93,7 +91,7 @@ public class BuildQueueRebalancerTest
 					"items", new JSONArray()
 				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
-			urlReader);
+			urlReaders);
 
 		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
 		_setJenkinsMasterAWSFleetClouds(_BLACKLISTED_JENKINS_MASTER_NAME);
@@ -155,22 +153,12 @@ public class BuildQueueRebalancerTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
-		Mockito.doThrow(
-			new IOException("Connection refused")
-		).when(
-			urlReader
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
-			Mockito.argThat(
-				readURL ->
-					(readURL != null) &&
-					readURL.contains(
-						_BLACKLISTED_JENKINS_MASTER_NAME +
-							".liferay.com/queue/api/json"))
-		);
+		setUrlReaderError(
+			new IOException("Connection refused"),
+			_BLACKLISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			urlReaders);
 
 		setUrlReaderOutput(
 			String.valueOf(
@@ -179,7 +167,7 @@ public class BuildQueueRebalancerTest
 					"mode", "NORMAL"
 				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/api/json?tree=mode",
-			urlReader);
+			urlReaders);
 		setUrlReaderOutput(
 			String.valueOf(
 				new JSONObject(
@@ -187,7 +175,7 @@ public class BuildQueueRebalancerTest
 					"items", new JSONArray()
 				)),
 			_AVAILABLE_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
-			urlReader);
+			urlReaders);
 
 		_setJenkinsMasterAWSFleetClouds(_AVAILABLE_JENKINS_MASTER_NAME);
 		_setJenkinsMasterAWSFleetClouds(_BLACKLISTED_JENKINS_MASTER_NAME);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -5,8 +5,6 @@
 
 package com.liferay.jenkins.results.parser;
 
-import java.io.ByteArrayInputStream;
-
 import java.net.URL;
 
 import java.util.Date;
@@ -32,7 +30,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 
 	@Test
 	public void testInvalidateToken() throws Exception {
-		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
+		MockUrlReaders urlReaders = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -45,12 +43,12 @@ public class ClientCredentialsHTTPAuthorizationTest
 		Assert.assertNotEquals(
 			authorization, clientCredentialsHTTPAuthorization.toString());
 
-		_verifyTokenRequestCount(2, urlReader);
+		_verifyTokenRequestCount(2, urlReaders);
 	}
 
 	@Test
 	public void testInvalidateTokenWhenAuthorizationIsStale() throws Exception {
-		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
+		MockUrlReaders urlReaders = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -67,12 +65,12 @@ public class ClientCredentialsHTTPAuthorizationTest
 		Assert.assertEquals(
 			newAuthorization, clientCredentialsHTTPAuthorization.toString());
 
-		_verifyTokenRequestCount(2, urlReader);
+		_verifyTokenRequestCount(2, urlReaders);
 	}
 
 	@Test
 	public void testToStringCachesToken() throws Exception {
-		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
+		MockUrlReaders urlReaders = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -83,12 +81,12 @@ public class ClientCredentialsHTTPAuthorizationTest
 		Assert.assertEquals(
 			authorization, clientCredentialsHTTPAuthorization.toString());
 
-		_verifyTokenRequestCount(1, urlReader);
+		_verifyTokenRequestCount(1, urlReaders);
 	}
 
 	@Test
 	public void testToStringRefreshesExpiredToken() throws Exception {
-		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
+		MockUrlReaders urlReaders = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -103,34 +101,35 @@ public class ClientCredentialsHTTPAuthorizationTest
 		Assert.assertNotEquals(
 			authorization, clientCredentialsHTTPAuthorization.toString());
 
-		_verifyTokenRequestCount(2, urlReader);
+		_verifyTokenRequestCount(2, urlReaders);
 	}
 
-	private StreamUrlReader _mockTokenRequestUrlReader() throws Exception {
-		StreamUrlReader urlReader = mockUrlReader();
+	private MockUrlReaders _mockTokenRequestUrlReader() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
 
-		Mockito.doAnswer(
-			invocation -> {
-				String json = new JSONObject(
-				).put(
-					"access_token", RandomTestUtil.randomString()
-				).put(
-					"expires_in", 600
-				).put(
-					"token_type", "Bearer"
-				).toString();
+		for (UrlReader<?> urlReader : urlReaders.getUrlReaders()) {
+			Mockito.doAnswer(
+				invocation -> mockURLConnection(
+					200,
+					String.valueOf(
+						new JSONObject(
+						).put(
+							"access_token", RandomTestUtil.randomString()
+						).put(
+							"expires_in", 600
+						).put(
+							"token_type", "Bearer"
+						)))
+			).when(
+				urlReader
+			).openURLConnection(
+				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.contains("/o/oauth2/token")
+			);
+		}
 
-				return new ByteArrayInputStream(json.getBytes());
-			}
-		).when(
-			urlReader
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
-			Mockito.contains("/o/oauth2/token")
-		);
-
-		return urlReader;
+		return urlReaders;
 	}
 
 	private JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
@@ -145,16 +144,9 @@ public class ClientCredentialsHTTPAuthorizationTest
 	}
 
 	private void _verifyTokenRequestCount(
-			int expectedCount, StreamUrlReader urlReader)
-		throws Exception {
+		int expectedCount, MockUrlReaders urlReaders) {
 
-		Mockito.verify(
-			urlReader, Mockito.times(expectedCount)
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
-			Mockito.anyString()
-		);
+		verifyUrlReadCount(expectedCount, urlReaders, "/o/oauth2/token");
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -105,7 +105,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 	}
 
 	private MockUrlReaders _mockTokenRequestUrlReader() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		for (UrlReader<?> urlReader : urlReaders.getUrlReaders()) {
 			Mockito.doAnswer(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/ClientCredentialsHTTPAuthorizationTest.java
@@ -32,7 +32,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 
 	@Test
 	public void testInvalidateToken() throws Exception {
-		UrlReader urlReader = _mockTokenRequestUrlReader();
+		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -50,7 +50,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 
 	@Test
 	public void testInvalidateTokenWhenAuthorizationIsStale() throws Exception {
-		UrlReader urlReader = _mockTokenRequestUrlReader();
+		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -72,7 +72,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 
 	@Test
 	public void testToStringCachesToken() throws Exception {
-		UrlReader urlReader = _mockTokenRequestUrlReader();
+		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -88,7 +88,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 
 	@Test
 	public void testToStringRefreshesExpiredToken() throws Exception {
-		UrlReader urlReader = _mockTokenRequestUrlReader();
+		StreamUrlReader urlReader = _mockTokenRequestUrlReader();
 
 		JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization
 			clientCredentialsHTTPAuthorization =
@@ -106,8 +106,8 @@ public class ClientCredentialsHTTPAuthorizationTest
 		_verifyTokenRequestCount(2, urlReader);
 	}
 
-	private UrlReader _mockTokenRequestUrlReader() throws Exception {
-		UrlReader urlReader = mockUrlReader();
+	private StreamUrlReader _mockTokenRequestUrlReader() throws Exception {
+		StreamUrlReader urlReader = mockUrlReader();
 
 		Mockito.doAnswer(
 			invocation -> {
@@ -145,7 +145,7 @@ public class ClientCredentialsHTTPAuthorizationTest
 	}
 
 	private void _verifyTokenRequestCount(
-			int expectedCount, UrlReader urlReader)
+			int expectedCount, StreamUrlReader urlReader)
 		throws Exception {
 
 		Mockito.verify(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -34,7 +34,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Environment.setInstance(Mockito.mock(Environment.class));
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(
 			new JSONObject(
@@ -93,7 +93,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testGetQueueItem() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(
 			new JSONObject(
@@ -109,7 +109,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testGetQueueItemNotFound() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		String queueItemAPIURL = "http://test-9-1/queue/item/7800/api/json";
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -34,7 +34,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Environment.setInstance(Mockito.mock(Environment.class));
 
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(
 			new JSONObject(
@@ -93,7 +93,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testGetQueueItem() throws Exception {
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(
 			new JSONObject(
@@ -109,7 +109,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testGetQueueItemNotFound() throws Exception {
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		String queueItemAPIURL = "http://test-9-1/queue/item/7800/api/json";
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -34,23 +34,23 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Environment.setInstance(Mockito.mock(Environment.class));
 
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		setUrlReaderOutput(
 			new JSONObject(
 			).put(
 				"items", new JSONArray()
 			).toString(),
-			"http://test-9-1/queue/api/json", urlReader);
+			"http://test-9-1/queue/api/json", urlReaders);
 		setUrlReaderOutput(
 			new JSONObject(
 			).put(
 				"mode", "NORMAL"
 			).toString(),
-			"http://test-9-1/api/json?tree=mode", urlReader);
+			"http://test-9-1/api/json?tree=mode", urlReaders);
 		setUrlReaderOutput(
 			read(new File(dependenciesDirs.get(0), "computer-api.json")),
-			"http://test-9-1/computer/api/json", urlReader);
+			"http://test-9-1/computer/api/json", urlReaders);
 
 		_jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
 			"test-9-1", "http://test-9-1");
@@ -93,14 +93,14 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testGetQueueItem() throws Exception {
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		setUrlReaderOutput(
 			new JSONObject(
 			).put(
 				"id", 7800
 			).toString(),
-			"http://test-9-1/queue/item/7800/api/json", urlReader);
+			"http://test-9-1/queue/item/7800/api/json", urlReaders);
 
 		JenkinsMaster.QueueItem queueItem = _jenkinsMaster.getQueueItem(7800);
 
@@ -109,21 +109,13 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testGetQueueItemNotFound() throws Exception {
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		String queueItemAPIURL = "http://test-9-1/queue/item/7800/api/json";
 
-		Mockito.doThrow(
-			new FileNotFoundException(queueItemAPIURL)
-		).when(
-			urlReader
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
-			Mockito.argThat(
-				readURL ->
-					(readURL != null) && readURL.contains(queueItemAPIURL))
-		);
+		setUrlReaderError(
+			new FileNotFoundException(queueItemAPIURL), queueItemAPIURL,
+			urlReaders);
 
 		ByteArrayOutputStream byteArrayOutputStream =
 			new ByteArrayOutputStream();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -434,7 +434,7 @@ public class JenkinsResultsParserUtilTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		Mockito.doReturn(
 			"https://test-1-1.liferay.com/queue/item/12345"

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -434,7 +434,7 @@ public class JenkinsResultsParserUtilTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		Mockito.doReturn(
 			"https://test-1-1.liferay.com/queue/item/12345"

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -434,12 +434,12 @@ public class JenkinsResultsParserUtilTest
 
 		JenkinsResultsParserUtil.setBuildProperties(buildProperties);
 
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		Mockito.doReturn(
 			"https://test-1-1.liferay.com/queue/item/12345"
 		).when(
-			urlReader
+			urlReaders.getStreamUrlReader()
 		).doGetResponseHeader(
 			Mockito.eq("Location"), Mockito.any(), Mockito.any(), Mockito.any(),
 			Mockito.any(), Mockito.anyInt(), Mockito.anyString()

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/MockUrlReaders.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/MockUrlReaders.java
@@ -17,10 +17,22 @@ import java.util.List;
 public class MockUrlReaders {
 
 	public MockUrlReaders(
+		JSONArrayUrlReader jsonArrayUrlReader,
+		JSONObjectUrlReader jsonObjectUrlReader,
 		StreamUrlReader streamUrlReader, TextUrlReader textUrlReader) {
 
+		_jsonArrayUrlReader = jsonArrayUrlReader;
+		_jsonObjectUrlReader = jsonObjectUrlReader;
 		_streamUrlReader = streamUrlReader;
 		_textUrlReader = textUrlReader;
+	}
+
+	public JSONArrayUrlReader getJSONArrayUrlReader() {
+		return _jsonArrayUrlReader;
+	}
+
+	public JSONObjectUrlReader getJSONObjectUrlReader() {
+		return _jsonObjectUrlReader;
 	}
 
 	public StreamUrlReader getStreamUrlReader() {
@@ -32,9 +44,13 @@ public class MockUrlReaders {
 	}
 
 	public List<UrlReader<?>> getUrlReaders() {
-		return Arrays.asList(_streamUrlReader, _textUrlReader);
+		return Arrays.asList(
+			_jsonArrayUrlReader, _jsonObjectUrlReader, _streamUrlReader,
+			_textUrlReader);
 	}
 
+	private final JSONArrayUrlReader _jsonArrayUrlReader;
+	private final JSONObjectUrlReader _jsonObjectUrlReader;
 	private final StreamUrlReader _streamUrlReader;
 	private final TextUrlReader _textUrlReader;
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/MockUrlReaders.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/MockUrlReaders.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Holds one spy per reader type, so a test can stub every entry point at once
+ * and still reach for the single reader whose attempts it wants to count.
+ *
+ * @author Kenji Heigel
+ */
+public class MockUrlReaders {
+
+	public MockUrlReaders(
+		StreamUrlReader streamUrlReader, TextUrlReader textUrlReader) {
+
+		_streamUrlReader = streamUrlReader;
+		_textUrlReader = textUrlReader;
+	}
+
+	public StreamUrlReader getStreamUrlReader() {
+		return _streamUrlReader;
+	}
+
+	public TextUrlReader getTextUrlReader() {
+		return _textUrlReader;
+	}
+
+	public List<UrlReader<?>> getUrlReaders() {
+		return Arrays.asList(_streamUrlReader, _textUrlReader);
+	}
+
+	private final StreamUrlReader _streamUrlReader;
+	private final TextUrlReader _textUrlReader;
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/MockUrlReaders.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/MockUrlReaders.java
@@ -21,37 +21,22 @@ public class MockUrlReaders {
 		JSONObjectUrlReader jsonObjectUrlReader,
 		StreamUrlReader streamUrlReader, TextUrlReader textUrlReader) {
 
-		_jsonArrayUrlReader = jsonArrayUrlReader;
-		_jsonObjectUrlReader = jsonObjectUrlReader;
 		_streamUrlReader = streamUrlReader;
-		_textUrlReader = textUrlReader;
-	}
 
-	public JSONArrayUrlReader getJSONArrayUrlReader() {
-		return _jsonArrayUrlReader;
-	}
-
-	public JSONObjectUrlReader getJSONObjectUrlReader() {
-		return _jsonObjectUrlReader;
+		_urlReaders = Arrays.asList(
+			jsonArrayUrlReader, jsonObjectUrlReader, streamUrlReader,
+			textUrlReader);
 	}
 
 	public StreamUrlReader getStreamUrlReader() {
 		return _streamUrlReader;
 	}
 
-	public TextUrlReader getTextUrlReader() {
-		return _textUrlReader;
-	}
-
 	public List<UrlReader<?>> getUrlReaders() {
-		return Arrays.asList(
-			_jsonArrayUrlReader, _jsonObjectUrlReader, _streamUrlReader,
-			_textUrlReader);
+		return _urlReaders;
 	}
 
-	private final JSONArrayUrlReader _jsonArrayUrlReader;
-	private final JSONObjectUrlReader _jsonObjectUrlReader;
 	private final StreamUrlReader _streamUrlReader;
-	private final TextUrlReader _textUrlReader;
+	private final List<UrlReader<?>> _urlReaders;
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
@@ -22,7 +22,7 @@ public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
 	public void testGetCIMergeSHA() throws Exception {
 		PullRequest pullRequest = _newPullRequest();
 
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(
 			JenkinsResultsParserUtil.combine(
@@ -39,7 +39,7 @@ public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
 	public void testGetFileNames() throws Exception {
 		PullRequest pullRequest = _newPullRequest();
 
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(
 			JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
@@ -22,7 +22,7 @@ public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
 	public void testGetCIMergeSHA() throws Exception {
 		PullRequest pullRequest = _newPullRequest();
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(
 			JenkinsResultsParserUtil.combine(
@@ -39,7 +39,7 @@ public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
 	public void testGetFileNames() throws Exception {
 		PullRequest pullRequest = _newPullRequest();
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(
 			JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/PullRequestTest.java
@@ -22,13 +22,13 @@ public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
 	public void testGetCIMergeSHA() throws Exception {
 		PullRequest pullRequest = _newPullRequest();
 
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		setUrlReaderOutput(
 			JenkinsResultsParserUtil.combine(
 				"[{\"filename\": \"test/ci-merge\", ",
 				"\"patch\": \"+abcdef0123456789abcdef0123456789abcdef01\"}]"),
-			"/files", urlReader);
+			"/files", urlReaders);
 
 		Assert.assertEquals(
 			"abcdef0123456789abcdef0123456789abcdef01",
@@ -39,13 +39,13 @@ public class PullRequestTest extends com.liferay.jenkins.results.parser.Test {
 	public void testGetFileNames() throws Exception {
 		PullRequest pullRequest = _newPullRequest();
 
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		setUrlReaderOutput(
 			JenkinsResultsParserUtil.combine(
 				"[{\"filename\": \"modules/apps/foo/Foo.java\"}, ",
 				"{\"filename\": \"portal-impl/Bar.java\"}]"),
-			"/files", urlReader);
+			"/files", urlReaders);
 
 		Assert.assertEquals(
 			Arrays.asList("modules/apps/foo/Foo.java", "portal-impl/Bar.java"),

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -63,6 +63,10 @@ public class Test {
 
 		Shell.setInstance(new Shell());
 
+		JSONArrayUrlReader.setInstance(new JSONArrayUrlReader());
+
+		JSONObjectUrlReader.setInstance(new JSONObjectUrlReader());
+
 		StreamUrlReader.setInstance(new StreamUrlReader());
 
 		TextUrlReader.setInstance(new TextUrlReader());
@@ -201,14 +205,21 @@ public class Test {
 	}
 
 	protected MockUrlReaders mockUrlReader() {
+		JSONArrayUrlReader jsonArrayUrlReader = Mockito.spy(
+			new JSONArrayUrlReader());
+		JSONObjectUrlReader jsonObjectUrlReader = Mockito.spy(
+			new JSONObjectUrlReader());
 		StreamUrlReader streamUrlReader = Mockito.spy(new StreamUrlReader());
 		TextUrlReader textUrlReader = Mockito.spy(new TextUrlReader());
 
+		JSONArrayUrlReader.setInstance(jsonArrayUrlReader);
+		JSONObjectUrlReader.setInstance(jsonObjectUrlReader);
 		StreamUrlReader.setInstance(streamUrlReader);
 		TextUrlReader.setInstance(textUrlReader);
 
 		MockUrlReaders mockUrlReaders = new MockUrlReaders(
-			streamUrlReader, textUrlReader);
+			jsonArrayUrlReader, jsonObjectUrlReader, streamUrlReader,
+			textUrlReader);
 
 		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
 			try {
@@ -230,6 +241,17 @@ public class Test {
 			catch (IOException ioException) {
 				throw new RuntimeException(ioException);
 			}
+
+			// A retried read would otherwise sleep out the caller's retry
+			// period for real, which is minutes across a suite that exercises
+			// failure paths.
+
+			Mockito.doNothing(
+			).when(
+				urlReader
+			).sleep(
+				Mockito.anyLong()
+			);
 		}
 
 		return mockUrlReaders;

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -181,7 +181,34 @@ public class Test {
 	 * a stub sits below the retry loop rather than replacing it. Each
 	 * invocation must produce a new connection, because the retry loop consumes
 	 * the input stream once per attempt.
+	 *
+	 * <p>
+	 * The overload without a body is how a 4xx or a 5xx arrives: the response
+	 * code is legible while <code>getInputStream</code> throws.
+	 * </p>
 	 */
+	protected HttpURLConnection mockURLConnection(int responseCode)
+		throws IOException {
+
+		HttpURLConnection httpURLConnection = Mockito.mock(
+			HttpURLConnection.class);
+
+		Mockito.doThrow(
+			new IOException(
+				"Server returned HTTP response code: " + responseCode)
+		).when(
+			httpURLConnection
+		).getInputStream();
+
+		Mockito.doReturn(
+			responseCode
+		).when(
+			httpURLConnection
+		).getResponseCode();
+
+		return httpURLConnection;
+	}
+
 	protected HttpURLConnection mockURLConnection(
 			int responseCode, String standardOut)
 		throws IOException {
@@ -204,7 +231,7 @@ public class Test {
 		return httpURLConnection;
 	}
 
-	protected MockUrlReaders mockUrlReader() {
+	protected MockUrlReaders mockUrlReaders() {
 		JSONArrayUrlReader jsonArrayUrlReader = Mockito.spy(
 			new JSONArrayUrlReader());
 		JSONObjectUrlReader jsonObjectUrlReader = Mockito.spy(
@@ -277,6 +304,28 @@ public class Test {
 			Mockito.argThat(
 				executionRequest -> hasCommand(executionRequest, command))
 		);
+	}
+
+	/**
+	 * Fails the attempt with a response code the retry policy can classify,
+	 * rather than a bare transport failure.
+	 */
+	protected void setUrlReaderError(
+			int responseCode, String url, MockUrlReaders mockUrlReaders)
+		throws Exception {
+
+		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
+			Mockito.doAnswer(
+				invocation -> mockURLConnection(responseCode)
+			).when(
+				urlReader
+			).openURLConnection(
+				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.argThat(
+					readURL -> (readURL != null) && readURL.contains(url))
+			);
+		}
 	}
 
 	/**

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
+import java.net.HttpURLConnection;
 import java.net.URI;
 
 import java.nio.file.Files;
@@ -58,7 +59,7 @@ public class Test {
 
 		Shell.setInstance(new Shell());
 
-		UrlReader.setInstance(new UrlReader());
+		StreamUrlReader.setInstance(new StreamUrlReader());
 	}
 
 	@Rule
@@ -165,18 +166,59 @@ public class Test {
 		return shell;
 	}
 
-	protected UrlReader mockUrlReader() {
-		UrlReader urlReader = Mockito.mock(
-			UrlReader.class,
-			invocation -> {
-				String url = invocation.getArgument(7);
+	/**
+	 * Builds a connection whose body and response code the caller controls, so
+	 * a stub sits below the retry loop rather than replacing it. Each
+	 * invocation must produce a new connection, because the retry loop consumes
+	 * the input stream once per attempt.
+	 */
+	protected HttpURLConnection mockURLConnection(
+			int responseCode, String standardOut)
+		throws IOException {
 
-				throw new AssertionError("No output set for URL: " + url);
-			});
+		HttpURLConnection httpURLConnection = Mockito.mock(
+			HttpURLConnection.class);
 
-		UrlReader.setInstance(urlReader);
+		Mockito.doReturn(
+			new ByteArrayInputStream(standardOut.getBytes())
+		).when(
+			httpURLConnection
+		).getInputStream();
 
-		return urlReader;
+		Mockito.doReturn(
+			responseCode
+		).when(
+			httpURLConnection
+		).getResponseCode();
+
+		return httpURLConnection;
+	}
+
+	protected StreamUrlReader mockUrlReader() {
+		StreamUrlReader streamUrlReader = Mockito.spy(new StreamUrlReader());
+
+		try {
+			Mockito.doAnswer(
+				invocation -> {
+					String url = invocation.getArgument(6);
+
+					throw new AssertionError("No output set for URL: " + url);
+				}
+			).when(
+				streamUrlReader
+			).openURLConnection(
+				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.any()
+			);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+
+		StreamUrlReader.setInstance(streamUrlReader);
+
+		return streamUrlReader;
 	}
 
 	protected String read(File file) throws IOException {
@@ -202,16 +244,16 @@ public class Test {
 	}
 
 	protected void setUrlReaderOutput(
-			String standardOut, String url, UrlReader urlReader)
+			String standardOut, String url, StreamUrlReader streamUrlReader)
 		throws Exception {
 
 		Mockito.doAnswer(
-			invocation -> new ByteArrayInputStream(standardOut.getBytes())
+			invocation -> mockURLConnection(200, standardOut)
 		).when(
-			urlReader
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			streamUrlReader
+		).openURLConnection(
+			Mockito.any(), Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyBoolean(), Mockito.anyInt(),
 			Mockito.argThat(
 				readURL -> (readURL != null) && readURL.contains(url))
 		);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -9,6 +9,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
+import java.lang.reflect.Method;
+
 import java.net.HttpURLConnection;
 import java.net.URI;
 
@@ -28,7 +30,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ErrorCollector;
 
+import org.mockito.MockingDetails;
 import org.mockito.Mockito;
+import org.mockito.invocation.Invocation;
 
 /**
  * @author Peter Yoo
@@ -60,6 +64,8 @@ public class Test {
 		Shell.setInstance(new Shell());
 
 		StreamUrlReader.setInstance(new StreamUrlReader());
+
+		TextUrlReader.setInstance(new TextUrlReader());
 	}
 
 	@Rule
@@ -194,31 +200,39 @@ public class Test {
 		return httpURLConnection;
 	}
 
-	protected StreamUrlReader mockUrlReader() {
+	protected MockUrlReaders mockUrlReader() {
 		StreamUrlReader streamUrlReader = Mockito.spy(new StreamUrlReader());
-
-		try {
-			Mockito.doAnswer(
-				invocation -> {
-					String url = invocation.getArgument(6);
-
-					throw new AssertionError("No output set for URL: " + url);
-				}
-			).when(
-				streamUrlReader
-			).openURLConnection(
-				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
-				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
-				Mockito.any()
-			);
-		}
-		catch (IOException ioException) {
-			throw new RuntimeException(ioException);
-		}
+		TextUrlReader textUrlReader = Mockito.spy(new TextUrlReader());
 
 		StreamUrlReader.setInstance(streamUrlReader);
+		TextUrlReader.setInstance(textUrlReader);
 
-		return streamUrlReader;
+		MockUrlReaders mockUrlReaders = new MockUrlReaders(
+			streamUrlReader, textUrlReader);
+
+		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
+			try {
+				Mockito.doAnswer(
+					invocation -> {
+						String url = invocation.getArgument(6);
+
+						throw new AssertionError(
+							"No output set for URL: " + url);
+					}
+				).when(
+					urlReader
+				).openURLConnection(
+					Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+					Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
+					Mockito.any()
+				);
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
+		}
+
+		return mockUrlReaders;
 	}
 
 	protected String read(File file) throws IOException {
@@ -243,20 +257,44 @@ public class Test {
 		);
 	}
 
-	protected void setUrlReaderOutput(
-			String standardOut, String url, StreamUrlReader streamUrlReader)
+	/**
+	 * Fails the attempt rather than the whole read, so the retry loop still
+	 * runs and a test can tell a terminal failure from a retried one.
+	 */
+	protected void setUrlReaderError(
+			IOException ioException, String url, MockUrlReaders mockUrlReaders)
 		throws Exception {
 
-		Mockito.doAnswer(
-			invocation -> mockURLConnection(200, standardOut)
-		).when(
-			streamUrlReader
-		).openURLConnection(
-			Mockito.any(), Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyBoolean(), Mockito.anyInt(),
-			Mockito.argThat(
-				readURL -> (readURL != null) && readURL.contains(url))
-		);
+		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
+			Mockito.doThrow(
+				ioException
+			).when(
+				urlReader
+			).openURLConnection(
+				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.argThat(
+					readURL -> (readURL != null) && readURL.contains(url))
+			);
+		}
+	}
+
+	protected void setUrlReaderOutput(
+			String standardOut, String url, MockUrlReaders mockUrlReaders)
+		throws Exception {
+
+		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
+			Mockito.doAnswer(
+				invocation -> mockURLConnection(200, standardOut)
+			).when(
+				urlReader
+			).openURLConnection(
+				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.argThat(
+					readURL -> (readURL != null) && readURL.contains(url))
+			);
+		}
 	}
 
 	protected void testEquals(Object expected, Object actual) {
@@ -286,6 +324,40 @@ public class Test {
 			"file:" +
 				JenkinsResultsParserUtil.getCanonicalPath(dependenciesDir),
 			"${dependencies.url}/" + path);
+	}
+
+	/**
+	 * Counts attempts rather than logical reads, and counts them across every
+	 * reader type, so a test stays correct when a call is rerouted from one
+	 * reader to another. A retried read counts once per attempt, which is what
+	 * makes the retry policy assertable.
+	 */
+	protected void verifyUrlReadCount(
+		int expectedCount, MockUrlReaders mockUrlReaders, String url) {
+
+		int count = 0;
+
+		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
+			MockingDetails mockingDetails = Mockito.mockingDetails(urlReader);
+
+			for (Invocation invocation : mockingDetails.getInvocations()) {
+				Method method = invocation.getMethod();
+
+				String methodName = method.getName();
+
+				if (!methodName.equals("openURLConnection")) {
+					continue;
+				}
+
+				String readURL = invocation.getArgument(6);
+
+				if ((readURL != null) && readURL.contains(url)) {
+					count++;
+				}
+			}
+		}
+
+		testEquals(expectedCount, count);
 	}
 
 	protected List<File> dependenciesDirs = getDependenciesDirs(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
@@ -17,7 +17,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToInputStream() throws Exception {
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReader);
 
@@ -32,7 +32,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToString() throws Exception {
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReader);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
@@ -15,7 +15,6 @@ import java.net.URL;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,14 +22,6 @@ import org.junit.Test;
  * @author Kenji Heigel
  */
 public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
-
-	@After
-	@Override
-	public void tearDown() {
-		super.tearDown();
-
-		JenkinsMasterTestUtil.resetCaches();
-	}
 
 	@Test
 	public void testToInputStream() throws Exception {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
@@ -9,7 +9,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
-import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 
@@ -19,8 +18,6 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-
-import org.mockito.Mockito;
 
 /**
  * @author Kenji Heigel
@@ -37,7 +34,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToInputStream() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReaders);
 
@@ -52,7 +49,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToJSONObject() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		JSONObject jsonObject = new JSONObject();
 
@@ -75,7 +72,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 	 */
 	@Test
 	public void testToJSONObjectWhenResponseCodeIs404() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderError(new FileNotFoundException(_URL), _URL, urlReaders);
 
@@ -94,7 +91,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToJSONObjectWhenResponseIsMalformed() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput("not json at all", _URL, urlReaders);
 
@@ -127,7 +124,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 		JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 1);
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		JSONObject jsonObject = new JSONObject();
 
@@ -148,7 +145,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToString() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReaders);
 
@@ -158,7 +155,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToStringWhenConnectionTimesOut() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderError(
 			new SocketTimeoutException("Read timed out"), _URL, urlReaders);
@@ -176,7 +173,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToStringWhenResponseBodyIsEmpty() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput("", _URL, urlReaders);
 
@@ -206,7 +203,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 	public void testToStringWhenResponseBodyIsEmptyAndNotExpected()
 		throws Exception {
 
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput("", _URL, urlReaders);
 
@@ -219,13 +216,8 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
-	public void testToStringWhenResponseCodeIs403() throws Exception {
-		_testResponseCodeIsRetried(403);
-	}
-
-	@Test
 	public void testToStringWhenResponseCodeIs404() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderError(new FileNotFoundException(_URL), _URL, urlReaders);
 
@@ -240,14 +232,17 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 		verifyUrlReadCount(1, urlReaders, _URL);
 	}
 
+	/**
+	 * A 403 carries the GitHub secondary rate limit and an expired Testray 2
+	 * token, and a 408 and a 429 are retryable by definition. A 5xx is not a
+	 * 4xx at all and keeps its retries.
+	 */
 	@Test
-	public void testToStringWhenResponseCodeIs429() throws Exception {
-		_testResponseCodeIsRetried(429);
-	}
-
-	@Test
-	public void testToStringWhenResponseCodeIs500() throws Exception {
-		_testResponseCodeIsRetried(500);
+	public void testToStringWhenResponseCodeIsRetryable() throws Exception {
+		_testToStringWhenResponseCodeIsRetryable(403);
+		_testToStringWhenResponseCodeIsRetryable(408);
+		_testToStringWhenResponseCodeIsRetryable(429);
+		_testToStringWhenResponseCodeIsRetryable(500);
 	}
 
 	/**
@@ -257,9 +252,9 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 	 */
 	@Test
 	public void testToStringWhenResponseCodeIsTerminal() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
-		_setResponseCodeError(400, _URL, urlReaders);
+		setUrlReaderError(400, _URL, urlReaders);
 
 		try {
 			JenkinsResultsParserUtil.toString(_URL, false, _MAX_RETRIES, 0, 0);
@@ -272,47 +267,12 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 		verifyUrlReadCount(1, urlReaders, _URL);
 	}
 
-	private void _setResponseCodeError(
-			int responseCode, String url, MockUrlReaders mockUrlReaders)
+	private void _testToStringWhenResponseCodeIsRetryable(int responseCode)
 		throws Exception {
 
-		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
-			Mockito.doAnswer(
-				invocation -> {
-					HttpURLConnection httpURLConnection = Mockito.mock(
-						HttpURLConnection.class);
+		MockUrlReaders urlReaders = mockUrlReaders();
 
-					Mockito.doThrow(
-						new IOException(
-							"Server returned HTTP response code: " +
-								responseCode)
-					).when(
-						httpURLConnection
-					).getInputStream();
-
-					Mockito.doReturn(
-						responseCode
-					).when(
-						httpURLConnection
-					).getResponseCode();
-
-					return httpURLConnection;
-				}
-			).when(
-				urlReader
-			).openURLConnection(
-				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
-				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
-				Mockito.argThat(
-					readURL -> (readURL != null) && readURL.contains(url))
-			);
-		}
-	}
-
-	private void _testResponseCodeIsRetried(int responseCode) throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
-
-		_setResponseCodeError(responseCode, _URL, urlReaders);
+		setUrlReaderError(responseCode, _URL, urlReaders);
 
 		try {
 			JenkinsResultsParserUtil.toString(_URL, false, _MAX_RETRIES, 0, 0);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
@@ -5,10 +5,20 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
+
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import org.mockito.Mockito;
 
 /**
  * @author Kenji Heigel
@@ -31,6 +41,73 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
+	public void testToJSONObject() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put("id", 7800);
+
+		setUrlReaderOutput(String.valueOf(jsonObject), _URL, urlReaders);
+
+		JSONObject readJSONObject = JenkinsResultsParserUtil.toJSONObject(
+			_URL, false, _MAX_RETRIES, 0, 0);
+
+		Assert.assertEquals(7800, readJSONObject.getInt("id"));
+
+		verifyUrlReadCount(1, urlReaders, _URL);
+	}
+
+	/**
+	 * The headline fix. Before the consolidation the outer catch replaced the
+	 * cause with RuntimeException("Unable to create JSON object"), so no caller
+	 * could tell a missing resource from a socket timeout.
+	 */
+	@Test
+	public void testToJSONObjectWhenResponseCodeIs404() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		setUrlReaderError(new FileNotFoundException(_URL), _URL, urlReaders);
+
+		try {
+			JenkinsResultsParserUtil.toJSONObject(
+				_URL, false, _MAX_RETRIES, 0, 0);
+
+			Assert.fail("Expected an IOException to reach the caller");
+		}
+		catch (FileNotFoundException fileNotFoundException) {
+			Assert.assertEquals(_URL, fileNotFoundException.getMessage());
+		}
+
+		verifyUrlReadCount(1, urlReaders, _URL);
+	}
+
+	@Test
+	public void testToJSONObjectWhenResponseIsMalformed() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		setUrlReaderOutput("not json at all", _URL, urlReaders);
+
+		try {
+			JenkinsResultsParserUtil.toJSONObject(
+				_URL, false, _MAX_RETRIES, 0, 0);
+
+			Assert.fail("Expected an IOException to reach the caller");
+		}
+		catch (IOException ioException) {
+			Assert.assertEquals(
+				"Unable to create a JSON object from the response body",
+				ioException.getMessage());
+
+			Throwable throwable = ioException.getCause();
+
+			Assert.assertTrue(throwable instanceof JSONException);
+		}
+
+		verifyUrlReadCount(_MAX_RETRIES + 1, urlReaders, _URL);
+	}
+
+	@Test
 	public void testToString() throws Exception {
 		MockUrlReaders urlReaders = mockUrlReader();
 
@@ -39,6 +116,177 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 		Assert.assertEquals(
 			_STANDARD_OUT, JenkinsResultsParserUtil.toString(_URL, false));
 	}
+
+	@Test
+	public void testToStringWhenConnectionTimesOut() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		setUrlReaderError(
+			new SocketTimeoutException("Read timed out"), _URL, urlReaders);
+
+		try {
+			JenkinsResultsParserUtil.toString(_URL, false, _MAX_RETRIES, 0, 0);
+
+			Assert.fail("Expected an IOException to reach the caller");
+		}
+		catch (SocketTimeoutException socketTimeoutException) {
+		}
+
+		verifyUrlReadCount(_MAX_RETRIES + 1, urlReaders, _URL);
+	}
+
+	@Test
+	public void testToStringWhenResponseBodyIsEmpty() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		setUrlReaderOutput("", _URL, urlReaders);
+
+		try {
+			JenkinsResultsParserUtil.toString(
+				_URL, false, _MAX_RETRIES, 0, 0, true);
+
+			Assert.fail("Expected an IOException to reach the caller");
+		}
+		catch (IOException ioException) {
+			Assert.assertTrue(
+				ioException.getMessage(),
+				ioException.getMessage(
+				).startsWith(
+					"Unable to read a response body"
+				));
+		}
+
+		verifyUrlReadCount(_MAX_RETRIES + 1, urlReaders, _URL);
+	}
+
+	/**
+	 * A caller that does not expect a body still gets the empty string, so the
+	 * empty-body rejection stays scoped to callers that asked for one.
+	 */
+	@Test
+	public void testToStringWhenResponseBodyIsEmptyAndNotExpected()
+		throws Exception {
+
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		setUrlReaderOutput("", _URL, urlReaders);
+
+		Assert.assertEquals(
+			"",
+			JenkinsResultsParserUtil.toString(
+				_URL, false, _MAX_RETRIES, 0, 0, false));
+
+		verifyUrlReadCount(1, urlReaders, _URL);
+	}
+
+	@Test
+	public void testToStringWhenResponseCodeIs403() throws Exception {
+		_testResponseCodeIsRetried(403);
+	}
+
+	@Test
+	public void testToStringWhenResponseCodeIs404() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		setUrlReaderError(new FileNotFoundException(_URL), _URL, urlReaders);
+
+		try {
+			JenkinsResultsParserUtil.toString(_URL, false, _MAX_RETRIES, 0, 0);
+
+			Assert.fail("Expected an IOException to reach the caller");
+		}
+		catch (FileNotFoundException fileNotFoundException) {
+		}
+
+		verifyUrlReadCount(1, urlReaders, _URL);
+	}
+
+	@Test
+	public void testToStringWhenResponseCodeIs429() throws Exception {
+		_testResponseCodeIsRetried(429);
+	}
+
+	@Test
+	public void testToStringWhenResponseCodeIs500() throws Exception {
+		_testResponseCodeIsRetried(500);
+	}
+
+	/**
+	 * A 4xx that carries no remedy fails the whole read on the first attempt,
+	 * rather than spending the caller's retry budget on an answer that cannot
+	 * change.
+	 */
+	@Test
+	public void testToStringWhenResponseCodeIsTerminal() throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		_setResponseCodeError(400, _URL, urlReaders);
+
+		try {
+			JenkinsResultsParserUtil.toString(_URL, false, _MAX_RETRIES, 0, 0);
+
+			Assert.fail("Expected an IOException to reach the caller");
+		}
+		catch (IOException ioException) {
+		}
+
+		verifyUrlReadCount(1, urlReaders, _URL);
+	}
+
+	private void _setResponseCodeError(
+			int responseCode, String url, MockUrlReaders mockUrlReaders)
+		throws Exception {
+
+		for (UrlReader<?> urlReader : mockUrlReaders.getUrlReaders()) {
+			Mockito.doAnswer(
+				invocation -> {
+					HttpURLConnection httpURLConnection = Mockito.mock(
+						HttpURLConnection.class);
+
+					Mockito.doThrow(
+						new IOException(
+							"Server returned HTTP response code: " +
+								responseCode)
+					).when(
+						httpURLConnection
+					).getInputStream();
+
+					Mockito.doReturn(
+						responseCode
+					).when(
+						httpURLConnection
+					).getResponseCode();
+
+					return httpURLConnection;
+				}
+			).when(
+				urlReader
+			).openURLConnection(
+				Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+				Mockito.any(), Mockito.anyBoolean(), Mockito.anyInt(),
+				Mockito.argThat(
+					readURL -> (readURL != null) && readURL.contains(url))
+			);
+		}
+	}
+
+	private void _testResponseCodeIsRetried(int responseCode) throws Exception {
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		_setResponseCodeError(responseCode, _URL, urlReaders);
+
+		try {
+			JenkinsResultsParserUtil.toString(_URL, false, _MAX_RETRIES, 0, 0);
+
+			Assert.fail("Expected an IOException to reach the caller");
+		}
+		catch (IOException ioException) {
+		}
+
+		verifyUrlReadCount(_MAX_RETRIES + 1, urlReaders, _URL);
+	}
+
+	private static final int _MAX_RETRIES = 2;
 
 	private static final String _STANDARD_OUT = "Hello, World!\n";
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
@@ -11,10 +11,12 @@ import java.io.InputStream;
 
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
+import java.net.URL;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,6 +26,14 @@ import org.mockito.Mockito;
  * @author Kenji Heigel
  */
 public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+	}
 
 	@Test
 	public void testToInputStream() throws Exception {
@@ -105,6 +115,35 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 		}
 
 		verifyUrlReadCount(_MAX_RETRIES + 1, urlReaders, _URL);
+	}
+
+	/**
+	 * Resolving a client credentials authorization performs a token request, so
+	 * a URL that cannot carry the header must not resolve one.
+	 */
+	@Test
+	public void testToJSONObjectWhenURLIsFileAndAuthorizationIsClientCredentials()
+		throws Exception {
+
+		JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 1);
+
+		MockUrlReaders urlReaders = mockUrlReader();
+
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put("id", 7800);
+
+		setUrlReaderOutput(String.valueOf(jsonObject), _URL_FILE, urlReaders);
+
+		JSONObject readJSONObject = JenkinsResultsParserUtil.toJSONObject(
+			_URL_FILE,
+			new JenkinsResultsParserUtil.ClientCredentialsHTTPAuthorization(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				new URL("https://test.liferay.com/o/oauth2/token")));
+
+		Assert.assertEquals(7800, readJSONObject.getInt("id"));
+
+		verifyUrlReadCount(0, urlReaders, "/o/oauth2/token");
 	}
 
 	@Test
@@ -291,5 +330,7 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 	private static final String _STANDARD_OUT = "Hello, World!\n";
 
 	private static final String _URL = "http://test.liferay.com";
+
+	private static final String _URL_FILE = "file:/tmp/queue-item.json";
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UrlReaderTest.java
@@ -17,9 +17,9 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToInputStream() throws Exception {
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
-		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReader);
+		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReaders);
 
 		try (InputStream inputStream = JenkinsResultsParserUtil.toInputStream(
 				_URL, false)) {
@@ -32,9 +32,9 @@ public class UrlReaderTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testToString() throws Exception {
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
-		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReader);
+		setUrlReaderOutput(_STANDARD_OUT, _URL, urlReaders);
 
 		Assert.assertEquals(
 			_STANDARD_OUT, JenkinsResultsParserUtil.toString(_URL, false));

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -8,7 +8,7 @@ package com.liferay.jenkins.results.parser.monitor;
 import com.liferay.jenkins.results.parser.JenkinsMasterTestUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.RandomTestUtil;
-import com.liferay.jenkins.results.parser.UrlReader;
+import com.liferay.jenkins.results.parser.StreamUrlReader;
 
 import java.util.List;
 import java.util.Map;
@@ -425,7 +425,7 @@ public class JobHealthMonitorTest
 
 	@Test
 	public void testExecuteUnreadableResponse() throws Exception {
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(
 			RandomTestUtil.randomString(), _JOB_API_URL, urlReader);
@@ -536,7 +536,7 @@ public class JobHealthMonitorTest
 	}
 
 	private void _setJobJSONObject(JSONObject jobJSONObject) throws Exception {
-		UrlReader urlReader = mockUrlReader();
+		StreamUrlReader urlReader = mockUrlReader();
 
 		setUrlReaderOutput(jobJSONObject.toString(), _JOB_API_URL, urlReader);
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -425,7 +425,7 @@ public class JobHealthMonitorTest
 
 	@Test
 	public void testExecuteUnreadableResponse() throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(
 			RandomTestUtil.randomString(), _JOB_API_URL, urlReaders);
@@ -536,7 +536,7 @@ public class JobHealthMonitorTest
 	}
 
 	private void _setJobJSONObject(JSONObject jobJSONObject) throws Exception {
-		MockUrlReaders urlReaders = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReaders();
 
 		setUrlReaderOutput(jobJSONObject.toString(), _JOB_API_URL, urlReaders);
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -7,8 +7,8 @@ package com.liferay.jenkins.results.parser.monitor;
 
 import com.liferay.jenkins.results.parser.JenkinsMasterTestUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.MockUrlReaders;
 import com.liferay.jenkins.results.parser.RandomTestUtil;
-import com.liferay.jenkins.results.parser.StreamUrlReader;
 
 import java.util.List;
 import java.util.Map;
@@ -425,10 +425,10 @@ public class JobHealthMonitorTest
 
 	@Test
 	public void testExecuteUnreadableResponse() throws Exception {
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
 		setUrlReaderOutput(
-			RandomTestUtil.randomString(), _JOB_API_URL, urlReader);
+			RandomTestUtil.randomString(), _JOB_API_URL, urlReaders);
 
 		MonitorResult monitorResult = _execute(_newMonitorProperties());
 
@@ -536,9 +536,9 @@ public class JobHealthMonitorTest
 	}
 
 	private void _setJobJSONObject(JSONObject jobJSONObject) throws Exception {
-		StreamUrlReader urlReader = mockUrlReader();
+		MockUrlReaders urlReaders = mockUrlReader();
 
-		setUrlReaderOutput(jobJSONObject.toString(), _JOB_API_URL, urlReader);
+		setUrlReaderOutput(jobJSONObject.toString(), _JOB_API_URL, urlReaders);
 	}
 
 	private void _testJobHealthMonitorExpectedIllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/JobHealthMonitorTest.java
@@ -435,7 +435,7 @@ public class JobHealthMonitorTest
 		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
 		testEquals(
 			"Unable to read http://test-9-1/job/generate-reports-controller: " +
-				"Unable to create JSON object",
+				"Unable to create a JSON object from the response body",
 			monitorResult.getMessage());
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7996

## What Is Being Fixed

CI Infrastructure retried an HTTP call in three separate places, each added because the one below it could not see the failure that mattered. The root cause was the reader's contract: `UrlReader.doRead` returned an `InputStream`, so its retry loop opened the connection, handed back the stream, and exited before the body was ever read. Nothing about the content of a response was visible to the loop doing the retrying, so every caller that cared about content grew a second loop around the outside — one for an empty body inside `toString`, and a `Retryable` wrapper for a malformed JSON body inside `toJSONObject`.

Three defects followed. A 4xx was retried, because `toJSONObject` caught the terminal `FileNotFoundException` and rewrapped it as a `RuntimeException` it could no longer tell apart from a socket timeout. No caller could see a 4xx at all, because the outer catch replaced the cause with `RuntimeException("Unable to create JSON object")` — despite the `throws IOException` on the signature, 29 `catch (IOException)` blocks across 17 files were unreachable. And GitHub's retry-after backoff had been bypassed since April 2025, because the wrapper consumed the caller's `maxRetries` and passed a hardcoded `0` downstream, making every `retryCount >= maxRetries` test true on the first attempt.

## How It Is Being Fixed

`UrlReader` becomes generic in what one attempt produces. An overridable `handleResponse` builds the result inside the attempt, so anything it throws is a failed attempt the existing loop already knows how to act on — a response that arrives but is unusable now fails the same way a connection reset does. `StreamUrlReader` keeps today's contract exactly and still serves `toFile`, which streams downloads to disk and must not buffer arbitrary artifacts into memory. `TextUrlReader` and the two JSON readers sit on a shared `BaseBodyUrlReader` that reads the body, rejects an empty one, writes the cache, and delegates to a `parse` step.

Retry classification moves off three regexes matched against exception messages and onto `HttpURLConnection.getResponseCode()`, which also removes a latent NPE when an `IOException` carried no message. The resulting policy is that a 4xx is terminal except 403, 408 and 429 — 403 carries both the GitHub secondary rate limit and an expired Testray 2 token, where a further attempt is the entire remedy, and 408 and 429 are retryable by definition.

The parse retry itself is preserved rather than removed, per LRCI-5564; it only moves inside the loop. `JSONException` is unchecked and would otherwise escape uncaught, so each reader converts it to an `IOException`, which also means the cause survives instead of being flattened away. `toJSONArray` gains the parse retry it never had. With a 404 finally reaching callers, the LRCI-7931 interim hunk in `JenkinsMaster.getQueueItem` is removed and the original form restored, since its `catch (IOException) { return null; }` was always correct and merely unreachable.

Every public `JenkinsResultsParserUtil` signature is unchanged, so the 43 BeanShell call sites in `liferay-jenkins-ee` that resolve these overloads through `bsh.Reflect.invokeStaticMethod` are untouched.

## PR Check

**pr-check: PASS** — tested on `1f0604a32ad6bb73d13154e507f1d608abf0123d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1f0604a32ad6bb73d13154e507f1d608abf0123d"} -->
