### PR TITLE
LRCI-7904 Detect and abort builds that hang holding an executor

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -253,7 +253,7 @@ public class JenkinsCohort {
 				continue;
 			}
 
-			buildCount += jenkinsMaster.getStartedBuildCountAfter(date, false);
+			buildCount += jenkinsMaster.getStartedBuildsCountAfter(date, false);
 		}
 
 		return buildCount;
@@ -271,7 +271,7 @@ public class JenkinsCohort {
 				continue;
 			}
 
-			buildCount += jenkinsMaster.getStartedBuildCountAfter(date, true);
+			buildCount += jenkinsMaster.getStartedBuildsCountAfter(date, true);
 		}
 
 		return buildCount;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -294,7 +294,7 @@ public class JenkinsCohort {
 
 					@Override
 					public Void call() {
-						jenkinsMaster.update(false);
+						jenkinsMaster.update(true);
 
 						buildURLs.addAll(jenkinsMaster.getBuildURLs());
 						queuedBuildURLs.putAll(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -822,8 +822,13 @@ public class JenkinsCohort {
 				JenkinsResultsParserUtil.getBuildProperty(
 					"jenkins.load.balancer.blacklist");
 
-			Collections.addAll(
-				_jenkinsMastersBlacklist, jenkinsMastersBlacklist.split(","));
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(
+					jenkinsMastersBlacklist)) {
+
+				Collections.addAll(
+					_jenkinsMastersBlacklist,
+					jenkinsMastersBlacklist.split(","));
+			}
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -242,7 +242,7 @@ public class JenkinsCohort {
 	}
 
 	public int getStartedDownstreamBuildCountAfter(Date date) {
-		int buildCount = 0;
+		int buildsCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
 			update();
@@ -253,14 +253,15 @@ public class JenkinsCohort {
 				continue;
 			}
 
-			buildCount += jenkinsMaster.getStartedBuildsCountAfter(date, false);
+			buildsCount += jenkinsMaster.getStartedBuildsCountAfter(
+				date, false);
 		}
 
-		return buildCount;
+		return buildsCount;
 	}
 
 	public int getStartedTopLevelBuildCountAfter(Date date) {
-		int buildCount = 0;
+		int buildsCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
 			update();
@@ -271,10 +272,10 @@ public class JenkinsCohort {
 				continue;
 			}
 
-			buildCount += jenkinsMaster.getStartedBuildsCountAfter(date, true);
+			buildsCount += jenkinsMaster.getStartedBuildsCountAfter(date, true);
 		}
 
-		return buildCount;
+		return buildsCount;
 	}
 
 	public void update() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsCohort.java
@@ -82,18 +82,18 @@ public class JenkinsCohort {
 		return blacklistedJenkinsMasters;
 	}
 
-	public int getIdleJenkinsSlaveCount() {
-		int idleJenkinsSlaveCount = 0;
+	public int getIdleJenkinsSlavesCount() {
+		int idleJenkinsSlavesCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
 			update();
 		}
 
 		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
-			idleJenkinsSlaveCount += jenkinsMaster.getIdleJenkinsSlavesCount();
+			idleJenkinsSlavesCount += jenkinsMaster.getIdleJenkinsSlavesCount();
 		}
 
-		return idleJenkinsSlaveCount;
+		return idleJenkinsSlavesCount;
 	}
 
 	public List<JenkinsMaster> getJenkinsMasters() {
@@ -177,38 +177,38 @@ public class JenkinsCohort {
 		return networkNames;
 	}
 
-	public int getOfflineJenkinsSlaveCount() {
-		int offlineJenkinsSlaveCount = 0;
+	public int getOfflineJenkinsSlavesCount() {
+		int offlineJenkinsSlavesCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
 			update();
 		}
 
 		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
-			offlineJenkinsSlaveCount +=
+			offlineJenkinsSlavesCount +=
 				jenkinsMaster.getOfflineJenkinsSlavesCount();
 		}
 
-		return offlineJenkinsSlaveCount;
+		return offlineJenkinsSlavesCount;
 	}
 
-	public int getOnlineJenkinsSlaveCount() {
-		int onlineJenkinsSlaveCount = 0;
+	public int getOnlineJenkinsSlavesCount() {
+		int onlineJenkinsSlavesCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
 			update();
 		}
 
 		for (JenkinsMaster jenkinsMaster : _jenkinsMastersMap.values()) {
-			onlineJenkinsSlaveCount +=
+			onlineJenkinsSlavesCount +=
 				jenkinsMaster.getOnlineJenkinsSlavesCount();
 		}
 
-		return onlineJenkinsSlaveCount;
+		return onlineJenkinsSlavesCount;
 	}
 
-	public int getQueuedBuildCount() {
-		int queuedBuildCount = 0;
+	public int getQueuedBuildsCount() {
+		int queuedBuildsCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
 			update();
@@ -217,15 +217,15 @@ public class JenkinsCohort {
 		for (JenkinsCohortJob jenkinsCohortJob :
 				_jenkinsCohortJobsMap.values()) {
 
-			queuedBuildCount =
-				queuedBuildCount + jenkinsCohortJob.getQueuedBuildCount();
+			queuedBuildsCount =
+				queuedBuildsCount + jenkinsCohortJob.getQueuedBuildsCount();
 		}
 
-		return queuedBuildCount;
+		return queuedBuildsCount;
 	}
 
-	public int getRunningBuildCount() {
-		int runningBuildCount = 0;
+	public int getRunningBuildsCount() {
+		int runningBuildsCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
 			update();
@@ -234,14 +234,14 @@ public class JenkinsCohort {
 		for (JenkinsCohortJob jenkinsCohortJob :
 				_jenkinsCohortJobsMap.values()) {
 
-			runningBuildCount =
-				runningBuildCount + jenkinsCohortJob.getRunningBuildCount();
+			runningBuildsCount =
+				runningBuildsCount + jenkinsCohortJob.getRunningBuildsCount();
 		}
 
-		return runningBuildCount;
+		return runningBuildsCount;
 	}
 
-	public int getStartedDownstreamBuildCountAfter(Date date) {
+	public int getStartedDownstreamBuildsCountAfter(Date date) {
 		int buildsCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
@@ -260,7 +260,7 @@ public class JenkinsCohort {
 		return buildsCount;
 	}
 
-	public int getStartedTopLevelBuildCountAfter(Date date) {
+	public int getStartedTopLevelBuildsCountAfter(Date date) {
 		int buildsCount = 0;
 
 		if (_jenkinsCohortJobsMap.isEmpty()) {
@@ -358,9 +358,9 @@ public class JenkinsCohort {
 
 		nodeDataTableJSONArray.put(
 			Arrays.asList(
-				getRunningBuildCount(), getOnlineJenkinsSlaveCount(),
-				getQueuedBuildCount(), getOfflineJenkinsSlaveCount(),
-				getIdleJenkinsSlaveCount()));
+				getRunningBuildsCount(), getOnlineJenkinsSlavesCount(),
+				getQueuedBuildsCount(), getOfflineJenkinsSlavesCount(),
+				getIdleJenkinsSlavesCount()));
 
 		sb.append(nodeDataTableJSONArray.toString());
 
@@ -380,21 +380,21 @@ public class JenkinsCohort {
 				Arrays.asList(
 					jenkinsCohortJob.getJobName(),
 					_createJSONArray(
-						jenkinsCohortJob.getTotalBuildCount(),
-						_formatBuildCountText(
-							jenkinsCohortJob.getTotalBuildCount(),
+						jenkinsCohortJob.getTotalBuildsCount(),
+						_formatBuildsCountText(
+							jenkinsCohortJob.getTotalBuildsCount(),
 							jenkinsCohortJob.getTotalBuildPercentage())),
 					_createJSONArray(
-						jenkinsCohortJob.getRunningBuildCount(),
-						_formatBuildCountText(
-							jenkinsCohortJob.getRunningBuildCount(),
+						jenkinsCohortJob.getRunningBuildsCount(),
+						_formatBuildsCountText(
+							jenkinsCohortJob.getRunningBuildsCount(),
 							jenkinsCohortJob.getRunningBuildPercentage())),
 					_createJSONArray(
-						jenkinsCohortJob.getQueuedBuildCount(),
-						_formatBuildCountText(
-							jenkinsCohortJob.getQueuedBuildCount(),
+						jenkinsCohortJob.getQueuedBuildsCount(),
+						_formatBuildsCountText(
+							jenkinsCohortJob.getQueuedBuildsCount(),
 							jenkinsCohortJob.getQueuedBuildPercentage())),
-					jenkinsCohortJob.getTopLevelBuildCount()));
+					jenkinsCohortJob.getTopLevelBuildsCount()));
 		}
 
 		sb.append(buildLoadDataTableJSONArray.toString());
@@ -515,11 +515,11 @@ public class JenkinsCohort {
 		JSONArray timestampsJSONArray = jsonObject.optJSONArray(
 			"timestamps", new JSONArray());
 
-		int timestampCount = timestampsJSONArray.length();
+		int timestampsCount = timestampsJSONArray.length();
 
 		long previousTimestamp = currentTimestamp;
 
-		if (timestampCount > 0) {
+		if (timestampsCount > 0) {
 			previousTimestamp = timestampsJSONArray.getLong(
 				timestampsJSONArray.length() - 1);
 		}
@@ -527,28 +527,29 @@ public class JenkinsCohort {
 		Date previousDate = new Date(previousTimestamp);
 
 		_addNodeData(
-			jsonObject, timestampCount, "downstream_started_builds",
-			getStartedDownstreamBuildCountAfter(previousDate));
+			jsonObject, timestampsCount, "downstream_started_builds",
+			getStartedDownstreamBuildsCountAfter(previousDate));
 
 		_addNodeData(
-			jsonObject, timestampCount, "idle_nodes",
-			getIdleJenkinsSlaveCount());
+			jsonObject, timestampsCount, "idle_nodes",
+			getIdleJenkinsSlavesCount());
 		_addNodeData(
-			jsonObject, timestampCount, "occupied_nodes",
-			getRunningBuildCount());
+			jsonObject, timestampsCount, "occupied_nodes",
+			getRunningBuildsCount());
 		_addNodeData(
-			jsonObject, timestampCount, "offline_nodes",
-			getOfflineJenkinsSlaveCount());
+			jsonObject, timestampsCount, "offline_nodes",
+			getOfflineJenkinsSlavesCount());
 		_addNodeData(
-			jsonObject, timestampCount, "online_nodes",
-			getOnlineJenkinsSlaveCount());
+			jsonObject, timestampsCount, "online_nodes",
+			getOnlineJenkinsSlavesCount());
 		_addNodeData(
-			jsonObject, timestampCount, "queued_builds", getQueuedBuildCount());
+			jsonObject, timestampsCount, "queued_builds",
+			getQueuedBuildsCount());
 		_addNodeData(
-			jsonObject, timestampCount, "timestamps", currentTimestamp);
+			jsonObject, timestampsCount, "timestamps", currentTimestamp);
 		_addNodeData(
-			jsonObject, timestampCount, "top_level_started_builds",
-			getStartedTopLevelBuildCountAfter(previousDate));
+			jsonObject, timestampsCount, "top_level_started_builds",
+			getStartedTopLevelBuildsCountAfter(previousDate));
 
 		if (JenkinsResultsParserUtil.isCloudCINode()) {
 			jsonObject.put("asg_primary_labels", getASGPrimaryLabels());
@@ -576,16 +577,16 @@ public class JenkinsCohort {
 				}
 
 				_addNodeData(
-					jsonObject, timestampCount,
+					jsonObject, timestampsCount,
 					"idle_nodes__" + asgPrimaryLabel, idleNodes);
 				_addNodeData(
-					jsonObject, timestampCount,
+					jsonObject, timestampsCount,
 					"occupied_nodes__" + asgPrimaryLabel, occupiedNodes);
 				_addNodeData(
-					jsonObject, timestampCount,
+					jsonObject, timestampsCount,
 					"offline_nodes__" + asgPrimaryLabel, offlineNodes);
 				_addNodeData(
-					jsonObject, timestampCount,
+					jsonObject, timestampsCount,
 					"queued_builds__" + asgPrimaryLabel, queuedBuilds);
 			}
 		}
@@ -598,11 +599,11 @@ public class JenkinsCohort {
 	}
 
 	private void _addNodeData(
-		JSONObject jsonObject, int recordCount, String key, long value) {
+		JSONObject jsonObject, int recordsCount, String key, long value) {
 
 		JSONArray jsonArray = jsonObject.optJSONArray(key, new JSONArray());
 
-		while (jsonArray.length() < recordCount) {
+		while (jsonArray.length() < recordsCount) {
 			jsonArray.put(0);
 		}
 
@@ -672,10 +673,10 @@ public class JenkinsCohort {
 				duration, JenkinsResultsParserUtil.toDurationString(duration)));
 	}
 
-	private String _formatBuildCountText(
-		int buildCount, String buildPercentage) {
+	private String _formatBuildsCountText(
+		int buildsCount, String buildPercentage) {
 
-		return buildCount + " (" + buildPercentage + ")";
+		return buildsCount + " (" + buildPercentage + ")";
 	}
 
 	private List<JenkinsMaster> _getAvailableJenkinsMasters(
@@ -877,32 +878,32 @@ public class JenkinsCohort {
 			return _jenkinsCohortJobName;
 		}
 
-		public int getQueuedBuildCount() {
-			return _queuedTopLevelBuildsJsonMap.size() +
-				_queuedOtherBuildsJsonMap.size();
-		}
-
 		public String getQueuedBuildPercentage() {
 			return CISystemStatusReportUtil.getPercentage(
-				getQueuedBuildCount(),
-				JenkinsCohort.this.getQueuedBuildCount());
+				getQueuedBuildsCount(),
+				JenkinsCohort.this.getQueuedBuildsCount());
+		}
+
+		public int getQueuedBuildsCount() {
+			return _queuedTopLevelBuildsJsonMap.size() +
+				_queuedOtherBuildsJsonMap.size();
 		}
 
 		public Map<String, JSONObject> getQueuedTopLevelBuildsJsonMap() {
 			return _queuedTopLevelBuildsJsonMap;
 		}
 
-		public int getRunningBuildCount() {
+		public String getRunningBuildPercentage() {
+			return CISystemStatusReportUtil.getPercentage(
+				getRunningBuildsCount(),
+				JenkinsCohort.this.getRunningBuildsCount());
+		}
+
+		public int getRunningBuildsCount() {
 			return _topLevelBuildURLs.size() + _otherBuildURLs.size();
 		}
 
-		public String getRunningBuildPercentage() {
-			return CISystemStatusReportUtil.getPercentage(
-				getRunningBuildCount(),
-				JenkinsCohort.this.getRunningBuildCount());
-		}
-
-		public int getTopLevelBuildCount() {
+		public int getTopLevelBuildsCount() {
 			return _topLevelBuildURLs.size() +
 				_queuedTopLevelBuildsJsonMap.size();
 		}
@@ -911,15 +912,15 @@ public class JenkinsCohort {
 			return _topLevelBuildURLs;
 		}
 
-		public int getTotalBuildCount() {
-			return getQueuedBuildCount() + getRunningBuildCount();
-		}
-
 		public String getTotalBuildPercentage() {
 			return CISystemStatusReportUtil.getPercentage(
-				getTotalBuildCount(),
-				JenkinsCohort.this.getRunningBuildCount() +
-					JenkinsCohort.this.getQueuedBuildCount());
+				getTotalBuildsCount(),
+				JenkinsCohort.this.getRunningBuildsCount() +
+					JenkinsCohort.this.getQueuedBuildsCount());
+		}
+
+		public int getTotalBuildsCount() {
+			return getQueuedBuildsCount() + getRunningBuildsCount();
 		}
 
 		private final String _jenkinsCohortJobName;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -245,20 +245,22 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 	public int getAvailableSlavesCount(String labelExpression) {
 		int idleNodesCount = _getIdleNodesCount(labelExpression);
-		int queueCount = _getQueueCount(labelExpression);
+		int queueItemsCount = _getQueueItemsCount(labelExpression);
 		int recentBatchSizesTotal = _getRecentBatchSizesTotal(labelExpression);
 
-		return idleNodesCount - queueCount - recentBatchSizesTotal;
+		return idleNodesCount - queueItemsCount - recentBatchSizesTotal;
 	}
 
 	public float getAverageQueueLength(String labelExpression) {
 		int busyNodesCount = _getBusyNodesCount(labelExpression);
-		int queueCount = _getQueueCount(labelExpression);
+		int queueItemsCount = _getQueueItemsCount(labelExpression);
 		int recentBatchSizesTotal = _getRecentBatchSizesTotal(labelExpression);
 		int usableNodesCount = _getUsableNodesCount(labelExpression);
 
-		return ((float)busyNodesCount + queueCount + recentBatchSizesTotal) /
-			usableNodesCount;
+		float queueLength =
+			(float)busyNodesCount + queueItemsCount + recentBatchSizesTotal;
+
+		return queueLength / usableNodesCount;
 	}
 
 	public List<AWSFleetCloud> getAWSFleetClouds() {
@@ -1813,8 +1815,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _labelExpressionLabels.get(labelExpression);
 	}
 
-	private int _getQueueCount(String labelExpression) {
-		int queueCount = 0;
+	private int _getQueueItemsCount(String labelExpression) {
+		int queueItemsCount = 0;
 
 		List<String> labels = _getLabels(labelExpression);
 
@@ -1824,11 +1826,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			}
 
 			if (_matchesLabels(queueItem.getLabelExpression(), labels)) {
-				queueCount++;
+				queueItemsCount++;
 			}
 		}
 
-		return queueCount;
+		return queueItemsCount;
 	}
 
 	private synchronized int _getRecentBatchSizesTotal(String labelExpression) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -244,21 +244,21 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public int getAvailableSlavesCount(String labelExpression) {
-		int idleNodeCount = _getIdleNodeCount(labelExpression);
+		int idleNodesCount = _getIdleNodesCount(labelExpression);
 		int queueCount = _getQueueCount(labelExpression);
 		int recentBatchSizesTotal = _getRecentBatchSizesTotal(labelExpression);
 
-		return idleNodeCount - queueCount - recentBatchSizesTotal;
+		return idleNodesCount - queueCount - recentBatchSizesTotal;
 	}
 
 	public float getAverageQueueLength(String labelExpression) {
-		int busyNodeCount = _getBusyNodeCount(labelExpression);
+		int busyNodesCount = _getBusyNodesCount(labelExpression);
 		int queueCount = _getQueueCount(labelExpression);
 		int recentBatchSizesTotal = _getRecentBatchSizesTotal(labelExpression);
-		int usableNodeCount = _getUsableNodeCount(labelExpression);
+		int usableNodesCount = _getUsableNodesCount(labelExpression);
 
-		return ((float)busyNodeCount + queueCount + recentBatchSizesTotal) /
-			usableNodeCount;
+		return ((float)busyNodesCount + queueCount + recentBatchSizesTotal) /
+			usableNodesCount;
 	}
 
 	public List<AWSFleetCloud> getAWSFleetClouds() {
@@ -843,7 +843,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _slavesPerHost;
 	}
 
-	public int getStartedBuildCountAfter(Date date, boolean topLevelBuilds) {
+	public int getStartedBuildsCountAfter(Date date, boolean topLevelBuilds) {
 		if (_buildCountJSONObject == null) {
 			try {
 				_buildCountJSONObject = JenkinsResultsParserUtil.toJSONObject(
@@ -860,7 +860,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			return 0;
 		}
 
-		int buildCount = 0;
+		int buildsCount = 0;
 
 		for (int i = 0; i < jobsJSONArray.length(); i++) {
 			JSONObject jobJSONObject = jobsJSONArray.optJSONObject(i);
@@ -898,12 +898,12 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				Date buildDate = new Date(buildJSONObject.getLong("timestamp"));
 
 				if (buildDate.after(date)) {
-					buildCount++;
+					buildsCount++;
 				}
 			}
 		}
 
-		return buildCount;
+		return buildsCount;
 	}
 
 	public String getURL() {
@@ -1704,8 +1704,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return retryable.executeWithRetries();
 	}
 
-	private int _getBusyNodeCount(String labelExpression) {
-		int busyNodeCount = 0;
+	private int _getBusyNodesCount(String labelExpression) {
+		int busyNodesCount = 0;
 
 		List<JenkinsNode> jenkinsNodes = new ArrayList<>();
 
@@ -1718,15 +1718,15 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 					labelExpression, jenkinsNode.getAssignedLabels()) &&
 				!jenkinsNode.isIdle() && !jenkinsNode.isOffline()) {
 
-				busyNodeCount++;
+				busyNodesCount++;
 			}
 		}
 
-		return busyNodeCount;
+		return busyNodesCount;
 	}
 
-	private int _getIdleNodeCount(String labelExpression) {
-		int idleNodeCount = 0;
+	private int _getIdleNodesCount(String labelExpression) {
+		int idleNodesCount = 0;
 
 		List<JenkinsNode> jenkinsNodes = new ArrayList<>();
 
@@ -1747,14 +1747,14 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 					labelExpression, jenkinsNode.getAssignedLabels()) &&
 				jenkinsNode.isIdle() && !jenkinsNode.isOffline()) {
 
-				idleNodeCount++;
+				idleNodesCount++;
 			}
 		}
 
 		List<AWSFleetCloud> awsFleetClouds = getAWSFleetClouds();
 
 		if (awsFleetClouds.isEmpty()) {
-			return idleNodeCount;
+			return idleNodesCount;
 		}
 
 		for (AWSFleetCloud awsFleetCloud : awsFleetClouds) {
@@ -1762,18 +1762,18 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				continue;
 			}
 
-			int idleAWSFleetCloudSlaveCount = awsFleetCloud.getMaxSize();
+			int idleAWSFleetCloudSlavesCount = awsFleetCloud.getMaxSize();
 
 			for (JenkinsSlave jenkinsSlave : awsFleetCloud.getJenkinsSlaves()) {
 				if (!jenkinsSlave.isIdle() || jenkinsSlave.isOffline()) {
-					idleAWSFleetCloudSlaveCount--;
+					idleAWSFleetCloudSlavesCount--;
 				}
 			}
 
-			idleNodeCount += idleAWSFleetCloudSlaveCount;
+			idleNodesCount += idleAWSFleetCloudSlavesCount;
 		}
 
-		return idleNodeCount;
+		return idleNodesCount;
 	}
 
 	private List<String> _getLabels(String labelExpression) {
@@ -1881,11 +1881,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return recentBatchSizesTotal;
 	}
 
-	private int _getUsableNodeCount(String labelExpression) {
-		int usableNodeCount = 0;
+	private int _getUsableNodesCount(String labelExpression) {
+		int usableNodesCount = 0;
 
 		if (_matchesLabels(labelExpression, getAssignedLabels())) {
-			usableNodeCount++;
+			usableNodesCount++;
 		}
 
 		for (JenkinsSlave jenkinsSlave : getJenkinsSlaves()) {
@@ -1894,17 +1894,17 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				_matchesLabels(
 					labelExpression, jenkinsSlave.getAssignedLabels())) {
 
-				usableNodeCount++;
+				usableNodesCount++;
 			}
 		}
 
 		for (AWSFleetCloud awsFleetCloud : getAWSFleetClouds()) {
 			if (_matchesLabels(labelExpression, awsFleetCloud.getLabels())) {
-				usableNodeCount += awsFleetCloud.getMaxSize();
+				usableNodesCount += awsFleetCloud.getMaxSize();
 			}
 		}
 
-		return usableNodeCount;
+		return usableNodesCount;
 	}
 
 	private boolean _isTopLevelJobName(String jobName) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -577,6 +577,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return new ArrayList<>(_jenkinsSlavesMap.values());
 	}
 
+	public int getMaxRunningBuildCount() {
+		return Math.max(_busyExecutorCount, _runningBuilds.size());
+	}
+
 	@Override
 	public String getName() {
 		return _masterName;
@@ -827,6 +831,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _masterRemoteURL;
 	}
 
+	public List<RunningBuild> getRunningBuilds() {
+		return new ArrayList<>(_runningBuilds);
+	}
+
 	public Integer getSlaveRAM() {
 		return _slaveRAM;
 	}
@@ -915,12 +923,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 				_AVAILABLE_TIMEOUT)) {
 
 			try {
-				if (!isBlacklisted()) {
-					JenkinsResultsParserUtil.toJSONObject(
-						getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
+				JenkinsResultsParserUtil.toJSONObject(
+					getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
 
-					_available = true;
-				}
+				_available = true;
 			}
 			catch (Exception exception) {
 				System.out.println(getName() + " is unreachable.");
@@ -1017,7 +1023,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public synchronized void update(boolean minimal) {
-		if (_isUpdated()) {
+		if (_isUpdated(minimal)) {
 			return;
 		}
 
@@ -1026,7 +1032,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		if (!isAvailable()) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
+			_busyExecutorCount = 0;
 			_jenkinsSlavesMap.clear();
+			_runningBuilds.clear();
 
 			return;
 		}
@@ -1036,19 +1044,33 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		JSONObject computerAPIJSONObject = null;
 
 		try {
+			String treeQuery = JenkinsResultsParserUtil.combine(
+				"/computer/api/json?tree=computer[assignedLabels[name],",
+				"displayName,executors[currentExecutable[url]],idle,offline,",
+				"offlineCauseReason]");
+
+			if (!minimal) {
+				treeQuery = JenkinsResultsParserUtil.combine(
+					"/computer/api/json?tree=busyExecutors,computer",
+					"[assignedLabels[name],displayName,executors",
+					"[currentExecutable[building,estimatedDuration,",
+					"fullDisplayName,timestamp,url],likelyStuck],idle,",
+					"offline,offlineCause[timestamp],offlineCauseReason,",
+					"oneOffExecutors[currentExecutable[building,",
+					"estimatedDuration,fullDisplayName,timestamp,url],",
+					"likelyStuck],temporarilyOffline]");
+			}
+
 			computerAPIJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					getURL(), "/computer/api/json?tree=computer",
-					"[assignedLabels[name],displayName,",
-					"executors[currentExecutable[url]],idle,offline,",
-					"offlineCauseReason]"),
-				false, 5000);
+				getURL() + treeQuery, false, 5000);
 		}
 		catch (Exception exception) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
+			_busyExecutorCount = 0;
 			_jenkinsSlavesMap.clear();
 			_labelExpressionLabels.clear();
+			_runningBuilds.clear();
 
 			System.out.println("Unable to read " + _masterURL);
 
@@ -1056,6 +1078,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		List<String> buildURLs = new ArrayList<>();
+		List<RunningBuild> runningBuilds = new ArrayList<>();
 
 		JSONArray computerJSONArray = computerAPIJSONObject.getJSONArray(
 			"computer");
@@ -1065,6 +1088,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 			String jenkinsSlaveName = JenkinsSlave.getDisplayName(
 				computerJSONObject);
+
+			if (!minimal) {
+				_addRunningBuilds(
+					computerJSONObject, jenkinsSlaveName, runningBuilds);
+			}
 
 			if (jenkinsSlaveName.equals("Built-In Node") ||
 				jenkinsSlaveName.equals("master")) {
@@ -1141,6 +1169,20 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		_buildURLs.clear();
 
 		_buildURLs.addAll(buildURLs);
+
+		if (minimal) {
+			_busyExecutorCount = 0;
+
+			_runningBuilds.clear();
+
+			return;
+		}
+
+		_busyExecutorCount = computerAPIJSONObject.optInt("busyExecutors", 0);
+
+		_runningBuilds.clear();
+
+		_runningBuilds.addAll(runningBuilds);
 	}
 
 	public static class QueueItem implements Comparable<QueueItem> {
@@ -1294,6 +1336,137 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		private AWSFleetCloud _awsFleetCloud;
 		private final JenkinsMaster _jenkinsMaster;
 		private final JSONObject _jsonObject;
+
+	}
+
+	public static class RunningBuild {
+
+		public long getDuration(long currentTimeMillis) {
+			long startTime = _getStartTime();
+
+			if (startTime <= 0) {
+				return 0;
+			}
+
+			return currentTimeMillis - startTime;
+		}
+
+		public long getEstimatedDuration() {
+			return _jsonObject.optLong("estimatedDuration", -1);
+		}
+
+		public String getFullDisplayName() {
+			return _jsonObject.optString("fullDisplayName");
+		}
+
+		public JenkinsMaster getJenkinsMaster() {
+			return _jenkinsMaster;
+		}
+
+		public String getJenkinsSlaveName() {
+			return _jenkinsSlaveName;
+		}
+
+		public long getJenkinsSlaveOfflineDuration(long currentTimeMillis) {
+			long jenkinsSlaveOfflineTime = _getJenkinsSlaveOfflineTime();
+
+			if (!_isJenkinsSlaveOffline() || (jenkinsSlaveOfflineTime <= 0)) {
+				return 0;
+			}
+
+			return currentTimeMillis - jenkinsSlaveOfflineTime;
+		}
+
+		public String getOfflineCauseReason() {
+			return _computerJSONObject.optString("offlineCauseReason");
+		}
+
+		public String getURL() {
+			return _jsonObject.optString("url");
+		}
+
+		public boolean isBuilding() {
+			return _jsonObject.optBoolean("building", false);
+		}
+
+		public boolean isJenkinsSlaveBeingRemoved() {
+			String offlineCauseReason = getOfflineCauseReason();
+
+			if (!_isJenkinsSlaveOffline() ||
+				JenkinsResultsParserUtil.isNullOrEmpty(offlineCauseReason)) {
+
+				return false;
+			}
+
+			return offlineCauseReason.contains("is being removed");
+		}
+
+		public boolean isJenkinsSlaveOffline() {
+			if (_isJenkinsSlaveOffline() &&
+				!_isJenkinsSlaveTemporarilyOffline()) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		public boolean isLikelyStuck() {
+			return _likelyStuck;
+		}
+
+		@Override
+		public String toString() {
+			return JenkinsResultsParserUtil.combine(
+				_jenkinsMaster.getName(), " ", getFullDisplayName(), " (",
+				getURL(), ")");
+		}
+
+		protected RunningBuild(
+			JSONObject computerJSONObject,
+			JSONObject currentExecutableJSONObject, JenkinsMaster jenkinsMaster,
+			String jenkinsSlaveName, boolean likelyStuck) {
+
+			_computerJSONObject = computerJSONObject;
+			_jenkinsMaster = jenkinsMaster;
+			_jenkinsSlaveName = jenkinsSlaveName;
+			_likelyStuck = likelyStuck;
+
+			_jsonObject = currentExecutableJSONObject;
+		}
+
+		private long _getJenkinsSlaveOfflineTime() {
+			JSONObject offlineCauseJSONObject =
+				_computerJSONObject.optJSONObject("offlineCause");
+
+			if (offlineCauseJSONObject == null) {
+				return -1;
+			}
+
+			return offlineCauseJSONObject.optLong("timestamp", -1);
+		}
+
+		private long _getStartTime() {
+			return _jsonObject.optLong("timestamp", -1);
+		}
+
+		private boolean _isJenkinsSlaveOffline() {
+			return _computerJSONObject.optBoolean("offline", false);
+		}
+
+		private boolean _isJenkinsSlaveTemporarilyOffline() {
+
+			// Absent means the payload never carried the field, so assume the
+			// node was drained deliberately rather than reaping its builds.
+
+			return _computerJSONObject.optBoolean("temporarilyOffline", true);
+		}
+
+		private final JSONObject _computerJSONObject;
+		private final JenkinsMaster _jenkinsMaster;
+		private final String _jenkinsSlaveName;
+		private final JSONObject _jsonObject;
+		private final boolean _likelyStuck;
 
 	}
 
@@ -1467,6 +1640,39 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		catch (Exception exception) {
 			throw new RuntimeException(
 				"Unable to determine URL for master " + _masterName, exception);
+		}
+	}
+
+	private void _addRunningBuilds(
+		JSONObject computerJSONObject, String jenkinsSlaveName,
+		List<RunningBuild> runningBuilds) {
+
+		for (String key : new String[] {"executors", "oneOffExecutors"}) {
+			JSONArray executorsJSONArray = computerJSONObject.optJSONArray(key);
+
+			if (executorsJSONArray == null) {
+				continue;
+			}
+
+			for (int i = 0; i < executorsJSONArray.length(); i++) {
+				JSONObject executorJSONObject =
+					executorsJSONArray.getJSONObject(i);
+
+				JSONObject currentExecutableJSONObject =
+					executorJSONObject.optJSONObject("currentExecutable");
+
+				if ((currentExecutableJSONObject == null) ||
+					!currentExecutableJSONObject.has("url")) {
+
+					continue;
+				}
+
+				runningBuilds.add(
+					new RunningBuild(
+						computerJSONObject, currentExecutableJSONObject, this,
+						jenkinsSlaveName,
+						executorJSONObject.optBoolean("likelyStuck", false)));
+			}
 		}
 	}
 
@@ -1740,11 +1946,20 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return _topLevelJobNames.contains(jobName);
 	}
 
-	private synchronized boolean _isUpdated() {
+	private synchronized boolean _isUpdated(boolean minimal) {
+
+		// A minimal update leaves out the executor detail a full update
+		// collects, so it can satisfy a later minimal request but never a
+		// full one. Without this a caller asking for the full payload can be
+		// handed a minimal snapshot and read every missing field as a
+		// default.
+
 		if ((_updateTimestamp == -1) ||
 			((System.currentTimeMillis() - _updateTimestamp) >
-				_MAXIMUM_UPDATE_DURATION)) {
+				_MAXIMUM_UPDATE_DURATION) ||
+			(_updateMinimal && !minimal)) {
 
+			_updateMinimal = minimal;
 			_updateTimestamp = System.currentTimeMillis();
 
 			return false;
@@ -1840,6 +2055,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		new HashMap<>();
 	private final Map<String, Long> _buildsUpdateTimes = new HashMap<>();
 	private final List<String> _buildURLs = new CopyOnWriteArrayList<>();
+	private int _busyExecutorCount;
 	private final List<DefaultBuild> _defaultBuilds = new ArrayList<>();
 	private Map<String, String> _globalEnvironmentVariables;
 	private boolean _idle;
@@ -1856,9 +2072,12 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	private boolean _offline;
 	private final List<QueueItem> _queueItems = new ArrayList<>();
 	private Long _queueUpdateTime;
+	private final List<RunningBuild> _runningBuilds =
+		new CopyOnWriteArrayList<>();
 	private final Integer _slaveRAM;
 	private final Integer _slavesPerHost;
 	private List<String> _topLevelJobNames;
+	private boolean _updateMinimal = true;
 	private long _updateTimestamp = -1;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -577,8 +577,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		return new ArrayList<>(_jenkinsSlavesMap.values());
 	}
 
-	public int getMaxRunningBuildCount() {
-		return Math.max(_busyExecutorCount, _runningBuilds.size());
+	public int getMaxRunningBuildsCount() {
+		return Math.max(_busyExecutorsCount, _runningBuilds.size());
 	}
 
 	@Override
@@ -1032,7 +1032,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		if (!isAvailable()) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
-			_busyExecutorCount = 0;
+			_busyExecutorsCount = 0;
 			_jenkinsSlavesMap.clear();
 			_runningBuilds.clear();
 
@@ -1067,7 +1067,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		catch (Exception exception) {
 			_assignedLabels.clear();
 			_buildURLs.clear();
-			_busyExecutorCount = 0;
+			_busyExecutorsCount = 0;
 			_jenkinsSlavesMap.clear();
 			_labelExpressionLabels.clear();
 			_runningBuilds.clear();
@@ -1171,14 +1171,14 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		_buildURLs.addAll(buildURLs);
 
 		if (minimal) {
-			_busyExecutorCount = 0;
+			_busyExecutorsCount = 0;
 
 			_runningBuilds.clear();
 
 			return;
 		}
 
-		_busyExecutorCount = computerAPIJSONObject.optInt("busyExecutors", 0);
+		_busyExecutorsCount = computerAPIJSONObject.optInt("busyExecutors", 0);
 
 		_runningBuilds.clear();
 
@@ -2044,7 +2044,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		new HashMap<>();
 	private final Map<String, Long> _buildsUpdateTimes = new HashMap<>();
 	private final List<String> _buildURLs = new CopyOnWriteArrayList<>();
-	private int _busyExecutorCount;
+	private int _busyExecutorsCount;
 	private final List<DefaultBuild> _defaultBuilds = new ArrayList<>();
 	private Map<String, String> _globalEnvironmentVariables;
 	private boolean _idle;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -1455,10 +1455,6 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		private boolean _isJenkinsSlaveTemporarilyOffline() {
-
-			// Absent means the payload never carried the field, so assume the
-			// node was drained deliberately rather than reaping its builds.
-
 			return _computerJSONObject.optBoolean("temporarilyOffline", true);
 		}
 
@@ -1947,13 +1943,6 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	private synchronized boolean _isUpdated(boolean minimal) {
-
-		// A minimal update leaves out the executor detail a full update
-		// collects, so it can satisfy a later minimal request but never a
-		// full one. Without this a caller asking for the full payload can be
-		// handed a minimal snapshot and read every missing field as a
-		// default.
-
 		if ((_updateTimestamp == -1) ||
 			((System.currentTimeMillis() - _updateTimestamp) >
 				_MAXIMUM_UPDATE_DURATION) ||

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -1377,10 +1377,6 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			return currentTimeMillis - jenkinsSlaveOfflineTime;
 		}
 
-		public String getOfflineCauseReason() {
-			return _computerJSONObject.optString("offlineCauseReason");
-		}
-
 		public String getURL() {
 			return _currentExecutableJSONObject.optString("url");
 		}
@@ -1390,7 +1386,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		public boolean isJenkinsSlaveBeingRemoved() {
-			String offlineCauseReason = getOfflineCauseReason();
+			String offlineCauseReason = _getOfflineCauseReason();
 
 			if (!_isJenkinsSlaveOffline() ||
 				JenkinsResultsParserUtil.isNullOrEmpty(offlineCauseReason)) {
@@ -1443,6 +1439,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			}
 
 			return offlineCauseJSONObject.optLong("timestamp", -1);
+		}
+
+		private String _getOfflineCauseReason() {
+			return _computerJSONObject.optString("offlineCauseReason");
 		}
 
 		private long _getStartTime() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -1352,7 +1352,8 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		public long getEstimatedDuration() {
-			return _currentExecutableJSONObject.optLong("estimatedDuration", -1);
+			return _currentExecutableJSONObject.optLong(
+				"estimatedDuration", -1);
 		}
 
 		public String getFullDisplayName() {
@@ -1397,7 +1398,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			return offlineCauseReason.contains("is being removed");
 		}
 
-		public boolean isJenkinsSlaveOffline() {
+		public boolean isJenkinsSlaveOfflineUnexpectedly() {
 			if (_isJenkinsSlaveOffline() &&
 				!_isJenkinsSlaveTemporarilyOffline()) {
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -1352,11 +1352,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		public long getEstimatedDuration() {
-			return _jsonObject.optLong("estimatedDuration", -1);
+			return _currentExecutableJSONObject.optLong("estimatedDuration", -1);
 		}
 
 		public String getFullDisplayName() {
-			return _jsonObject.optString("fullDisplayName");
+			return _currentExecutableJSONObject.optString("fullDisplayName");
 		}
 
 		public JenkinsMaster getJenkinsMaster() {
@@ -1382,11 +1382,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		public String getURL() {
-			return _jsonObject.optString("url");
+			return _currentExecutableJSONObject.optString("url");
 		}
 
 		public boolean isBuilding() {
-			return _jsonObject.optBoolean("building", false);
+			return _currentExecutableJSONObject.optBoolean("building", false);
 		}
 
 		public boolean isJenkinsSlaveBeingRemoved() {
@@ -1428,11 +1428,10 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			String jenkinsSlaveName, boolean likelyStuck) {
 
 			_computerJSONObject = computerJSONObject;
+			_currentExecutableJSONObject = currentExecutableJSONObject;
 			_jenkinsMaster = jenkinsMaster;
 			_jenkinsSlaveName = jenkinsSlaveName;
 			_likelyStuck = likelyStuck;
-
-			_jsonObject = currentExecutableJSONObject;
 		}
 
 		private long _getJenkinsSlaveOfflineTime() {
@@ -1447,7 +1446,7 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		private long _getStartTime() {
-			return _jsonObject.optLong("timestamp", -1);
+			return _currentExecutableJSONObject.optLong("timestamp", -1);
 		}
 
 		private boolean _isJenkinsSlaveOffline() {
@@ -1463,9 +1462,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		}
 
 		private final JSONObject _computerJSONObject;
+		private final JSONObject _currentExecutableJSONObject;
 		private final JenkinsMaster _jenkinsMaster;
 		private final String _jenkinsSlaveName;
-		private final JSONObject _jsonObject;
 		private final boolean _likelyStuck;
 
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -22,12 +22,12 @@ import org.json.JSONObject;
  */
 public class JenkinsStopBuildUtil {
 
-	public static void abortBuild(String buildURL) throws Exception {
+	public static AbortResult abortBuild(String buildURL) throws Exception {
 		String normalizedBuildURL = JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.getLocalURL(buildURL));
 
 		if (!_isBuilding(normalizedBuildURL)) {
-			return;
+			return AbortResult.ALREADY_FINISHED;
 		}
 
 		int responseCode = _post(normalizedBuildURL + "/stop");
@@ -49,7 +49,7 @@ public class JenkinsStopBuildUtil {
 			JenkinsResultsParserUtil.sleep(_ABORT_VERIFICATION_PERIOD);
 
 			if (!_isBuilding(normalizedBuildURL)) {
-				return;
+				return AbortResult.STOPPED;
 			}
 		}
 
@@ -96,6 +96,12 @@ public class JenkinsStopBuildUtil {
 		for (Build downstreamBuild : downstreamBuilds) {
 			_stopBuild(downstreamBuild);
 		}
+	}
+
+	public static enum AbortResult {
+
+		ALREADY_FINISHED, STOPPED
+
 	}
 
 	protected static String encodeAuthorizationFields(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -149,11 +149,18 @@ public class JenkinsStopBuildUtil {
 		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
 			normalizedBuildURL + "/api/json?tree=result", false);
 
-		if (jsonObject.has("result") && jsonObject.isNull("result")) {
-			return true;
+		// A response without the key at all means the state could not be
+		// read. Treating that as finished would silently drop a build that
+		// is still holding its executor.
+
+		if (!jsonObject.has("result")) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to determine whether ", normalizedBuildURL,
+					" is running, no result was reported"));
 		}
 
-		return false;
+		return jsonObject.isNull("result");
 	}
 
 	private static int _post(String urlString) throws Exception {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -188,8 +188,19 @@ public class JenkinsStopBuildUtil {
 
 		String username = JenkinsResultsParserUtil.getBuildProperty(
 			"jenkins.admin.user.name");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(username)) {
+			throw new RuntimeException(
+				"Unable to find property jenkins.admin.user.name");
+		}
+
 		String password = JenkinsResultsParserUtil.getBuildProperty(
 			"jenkins.admin.user.token");
+
+		if (JenkinsResultsParserUtil.isNullOrEmpty(password)) {
+			throw new RuntimeException(
+				"Unable to find property jenkins.admin.user.token");
+		}
 
 		httpConnection.setRequestProperty(
 			"Authorization",

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -53,16 +53,21 @@ public class JenkinsStopBuildUtil {
 			}
 		}
 
+		// A build that never reacts to the interrupt is expected rather than
+		// exceptional. The caller reports it and the next scheduled pass
+		// flags it again, so it must not surface as a stack trace every run.
+
 		long abortVerificationDuration =
 			_ABORT_VERIFICATION_PERIOD * _ABORT_VERIFICATION_RETRIES;
 
-		throw new RuntimeException(
+		System.out.println(
 			JenkinsResultsParserUtil.combine(
-				"Unable to stop ", normalizedBuildURL, ", it was still ",
-				"running ",
+				normalizedBuildURL, " was still running ",
 				JenkinsResultsParserUtil.toDurationString(
 					abortVerificationDuration),
 				" after being interrupted"));
+
+		return AbortResult.STILL_RUNNING;
 	}
 
 	public static void cancelQueueItem(
@@ -100,7 +105,7 @@ public class JenkinsStopBuildUtil {
 
 	public static enum AbortResult {
 
-		ALREADY_FINISHED, STOPPED
+		ALREADY_FINISHED, STILL_RUNNING, STOPPED
 
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -39,12 +39,6 @@ public class JenkinsStopBuildUtil {
 					", received response ", String.valueOf(responseCode)));
 		}
 
-		// Jenkins answers /stop as soon as it has interrupted the executor
-		// thread, whether or not that thread ever reacts. A build wedged in a
-		// native call or an unresponsive socket read takes the interrupt and
-		// keeps its executor, so the response alone does not mean the build
-		// stopped.
-
 		for (int i = 0; i < _ABORT_VERIFICATION_RETRIES; i++) {
 			JenkinsResultsParserUtil.sleep(_ABORT_VERIFICATION_PERIOD);
 
@@ -52,10 +46,6 @@ public class JenkinsStopBuildUtil {
 				return AbortResult.STOPPED;
 			}
 		}
-
-		// A build that never reacts to the interrupt is expected rather than
-		// exceptional. The caller reports it and the next scheduled pass
-		// flags it again, so it must not surface as a stack trace every run.
 
 		long abortVerificationDuration =
 			_ABORT_VERIFICATION_PERIOD * _ABORT_VERIFICATION_RETRIES;
@@ -148,10 +138,6 @@ public class JenkinsStopBuildUtil {
 
 		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
 			normalizedBuildURL + "/api/json?tree=result", false);
-
-		// A response without the key at all means the state could not be
-		// read. Treating that as finished would silently drop a build that
-		// is still holding its executor.
 
 		if (!jsonObject.has("result")) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -177,7 +177,7 @@ public class JenkinsStopBuildUtil {
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(username)) {
 			throw new RuntimeException(
-				"Unable to find property jenkins.admin.user.name");
+				"Unable to find property \"jenkins.admin.user.name\"");
 		}
 
 		String password = JenkinsResultsParserUtil.getBuildProperty(
@@ -185,7 +185,7 @@ public class JenkinsStopBuildUtil {
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(password)) {
 			throw new RuntimeException(
-				"Unable to find property jenkins.admin.user.token");
+				"Unable to find property \"jenkins.admin.user.token\"");
 		}
 
 		httpConnection.setRequestProperty(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -22,6 +22,49 @@ import org.json.JSONObject;
  */
 public class JenkinsStopBuildUtil {
 
+	public static void abortBuild(String buildURL) throws Exception {
+		String normalizedBuildURL = JenkinsResultsParserUtil.fixURL(
+			JenkinsResultsParserUtil.getLocalURL(buildURL));
+
+		if (!_isBuilding(normalizedBuildURL)) {
+			return;
+		}
+
+		int responseCode = _post(normalizedBuildURL + "/stop");
+
+		if (responseCode >= 400) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to stop ", normalizedBuildURL,
+					", received response ", String.valueOf(responseCode)));
+		}
+
+		// Jenkins answers /stop as soon as it has interrupted the executor
+		// thread, whether or not that thread ever reacts. A build wedged in a
+		// native call or an unresponsive socket read takes the interrupt and
+		// keeps its executor, so the response alone does not mean the build
+		// stopped.
+
+		for (int i = 0; i < _ABORT_VERIFICATION_RETRIES; i++) {
+			JenkinsResultsParserUtil.sleep(_ABORT_VERIFICATION_PERIOD);
+
+			if (!_isBuilding(normalizedBuildURL)) {
+				return;
+			}
+		}
+
+		long abortVerificationDuration =
+			_ABORT_VERIFICATION_PERIOD * _ABORT_VERIFICATION_RETRIES;
+
+		throw new RuntimeException(
+			JenkinsResultsParserUtil.combine(
+				"Unable to stop ", normalizedBuildURL, ", it was still ",
+				"running ",
+				JenkinsResultsParserUtil.toDurationString(
+					abortVerificationDuration),
+				" after being interrupted"));
+	}
+
 	public static void cancelQueueItem(
 			JenkinsMaster jenkinsMaster, long queueId)
 		throws Exception {
@@ -29,20 +72,7 @@ public class JenkinsStopBuildUtil {
 		String normalizedURL = JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.getLocalURL(jenkinsMaster.getURL()));
 
-		URL urlObject = new URL(
-			normalizedURL + "/queue/cancelItem?id=" + queueId);
-
-		HttpURLConnection httpConnection =
-			(HttpURLConnection)urlObject.openConnection();
-
-		httpConnection.setRequestMethod("POST");
-
-		_setAuthorization(httpConnection);
-
-		System.out.println(
-			"Response from " + urlObject.toString() + ": " +
-				httpConnection.getResponseCode() + " " +
-					httpConnection.getResponseMessage());
+		_post(normalizedURL + "/queue/cancelItem?id=" + queueId);
 	}
 
 	public static void stopBuild(String buildURL) throws Exception {
@@ -102,6 +132,39 @@ public class JenkinsStopBuildUtil {
 		return downstreamURLs;
 	}
 
+	private static boolean _isBuilding(String normalizedBuildURL)
+		throws Exception {
+
+		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
+			normalizedBuildURL + "/api/json?tree=result", false);
+
+		if (jsonObject.has("result") && jsonObject.isNull("result")) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static int _post(String urlString) throws Exception {
+		URL urlObject = new URL(urlString);
+
+		HttpURLConnection httpConnection =
+			(HttpURLConnection)urlObject.openConnection();
+
+		httpConnection.setRequestMethod("POST");
+
+		_setAuthorization(httpConnection);
+
+		int responseCode = httpConnection.getResponseCode();
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Response from ", urlString, ": ", String.valueOf(responseCode),
+				" ", httpConnection.getResponseMessage()));
+
+		return responseCode;
+	}
+
 	private static void _setAuthorization(HttpURLConnection httpConnection)
 		throws Exception {
 
@@ -123,24 +186,11 @@ public class JenkinsStopBuildUtil {
 		String normalizedBuildURL = JenkinsResultsParserUtil.fixURL(
 			JenkinsResultsParserUtil.getLocalURL(buildURL));
 
-		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-			normalizedBuildURL + "/api/json?tree=result", false);
-
-		if (jsonObject.has("result") && jsonObject.isNull("result")) {
-			URL urlObject = new URL(normalizedBuildURL + "/stop");
-
-			HttpURLConnection httpConnection =
-				(HttpURLConnection)urlObject.openConnection();
-
-			httpConnection.setRequestMethod("POST");
-
-			_setAuthorization(httpConnection);
-
-			System.out.println(
-				"Response from " + urlObject.toString() + ": " +
-					httpConnection.getResponseCode() + " " +
-						httpConnection.getResponseMessage());
+		if (!_isBuilding(normalizedBuildURL)) {
+			return;
 		}
+
+		_post(normalizedBuildURL + "/stop");
 	}
 
 	private static void _stopDownstreamBuilds(String buildURL)
@@ -152,6 +202,10 @@ public class JenkinsStopBuildUtil {
 			_stopBuild(downstreamURL);
 		}
 	}
+
+	private static final long _ABORT_VERIFICATION_PERIOD = 5 * 1000L;
+
+	private static final int _ABORT_VERIFICATION_RETRIES = 6;
 
 	private static final Pattern _buildURLPattern = Pattern.compile(
 		".+://(?<hostName>[^.]+)(.liferay.com)?/job/(?<jobName>[^/]+).*/" +

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -1,0 +1,329 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Calum Ragan
+ */
+public class StaleBuildReaper {
+
+	public StaleBuildReaper(boolean dryRun, JenkinsCohort jenkinsCohort) {
+		_dryRun = dryRun;
+		_jenkinsCohort = jenkinsCohort;
+	}
+
+	public int getReapedBuildCount() {
+		int reapedBuildCount = 0;
+
+		for (ReapAction reapAction : _reapActions) {
+			if (reapAction.isExecuted()) {
+				reapedBuildCount++;
+			}
+		}
+
+		return reapedBuildCount;
+	}
+
+	public int getStaleBuildCount() {
+		return _reapActions.size();
+	}
+
+	public String getSummary() {
+		StringBuilder sb = new StringBuilder();
+
+		int staleBuildCount = getStaleBuildCount();
+
+		String nounForm = JenkinsResultsParserUtil.getNounForm(
+			staleBuildCount, "stale builds", "stale build");
+
+		if (_dryRun) {
+			sb.append("Found ");
+			sb.append(staleBuildCount);
+			sb.append(" ");
+			sb.append(nounForm);
+			sb.append(". No build was aborted because DRY_RUN is enabled.");
+		}
+		else {
+			sb.append("Reaped ");
+			sb.append(getReapedBuildCount());
+			sb.append(" of ");
+			sb.append(staleBuildCount);
+			sb.append(" ");
+			sb.append(nounForm);
+			sb.append(".");
+		}
+
+		for (ReapAction reapAction : _reapActions) {
+			sb.append("\n");
+			sb.append(reapAction.getSummary());
+		}
+
+		return sb.toString();
+	}
+
+	public void reap() {
+		_generateReapActions();
+
+		_executeReapActions();
+
+		String summary = getSummary();
+
+		System.out.println(summary);
+
+		_sendSlackNotification(summary);
+	}
+
+	public static enum Reason {
+
+		JENKINS_SLAVE_BEING_REMOVED("its node is being removed"),
+		JENKINS_SLAVE_OFFLINE("its node has been offline"),
+		LIKELY_STUCK("its executor reports likelyStuck");
+
+		public String getDescription() {
+			return _description;
+		}
+
+		private Reason(String description) {
+			_description = description;
+		}
+
+		private final String _description;
+
+	}
+
+	private void _executeReapActions() {
+		if (_dryRun) {
+			return;
+		}
+
+		for (ReapAction reapAction : _reapActions) {
+			reapAction.execute();
+		}
+	}
+
+	private void _generateReapActions() {
+		long currentTimeMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		for (JenkinsMaster jenkinsMaster : _getJenkinsMasters()) {
+			jenkinsMaster.update(false);
+
+			List<JenkinsMaster.RunningBuild> runningBuilds =
+				jenkinsMaster.getRunningBuilds();
+
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					jenkinsMaster.getName(), " reports at most ",
+					String.valueOf(jenkinsMaster.getMaxRunningBuildCount()),
+					" running build(s). Enumerated ",
+					String.valueOf(runningBuilds.size()), "."));
+
+			for (JenkinsMaster.RunningBuild runningBuild : runningBuilds) {
+				List<Reason> reasons = _getReasons(
+					currentTimeMillis, runningBuild);
+
+				if (reasons.isEmpty()) {
+					continue;
+				}
+
+				_reapActions.add(
+					new ReapAction(
+						runningBuild.getDuration(currentTimeMillis), reasons,
+						runningBuild));
+			}
+		}
+	}
+
+	private List<JenkinsMaster> _getJenkinsMasters() {
+		List<JenkinsMaster> jenkinsMasters = new ArrayList<>(
+			_jenkinsCohort.getAvailableJenkinsMasters());
+
+		jenkinsMasters.addAll(_jenkinsCohort.getBlacklistedJenkinsMasters());
+
+		return jenkinsMasters;
+	}
+
+	private List<Reason> _getJenkinsSlaveReasons(
+		long currentTimeMillis, JenkinsMaster.RunningBuild runningBuild) {
+
+		List<Reason> reasons = new ArrayList<>();
+
+		if (runningBuild.isJenkinsSlaveBeingRemoved()) {
+			reasons.add(Reason.JENKINS_SLAVE_BEING_REMOVED);
+
+			return reasons;
+		}
+
+		if (!runningBuild.isJenkinsSlaveOffline()) {
+			return reasons;
+		}
+
+		// The grace period runs from the moment the node went offline, not
+		// from the moment the build started, so a node that is reconnecting
+		// gets the whole window however long its build has been running.
+		// Jenkins does not always report when the node went offline, and
+		// without that there is no way to tell a momentary drop from a dead
+		// channel, so the build is left for a later pass.
+
+		long jenkinsSlaveOfflineDuration =
+			runningBuild.getJenkinsSlaveOfflineDuration(currentTimeMillis);
+
+		if (jenkinsSlaveOfflineDuration >= _MINIMUM_OFFLINE_DURATION) {
+			reasons.add(Reason.JENKINS_SLAVE_OFFLINE);
+		}
+
+		return reasons;
+	}
+
+	private List<Reason> _getReasons(
+		long currentTimeMillis, JenkinsMaster.RunningBuild runningBuild) {
+
+		List<Reason> reasons = new ArrayList<>();
+
+		if (!runningBuild.isBuilding()) {
+			return reasons;
+		}
+
+		// Jenkins derives likelyStuck as ten times the estimate when an
+		// estimate exists, and a flat twenty four hours when it does not, so
+		// it already is the "far past its estimate" signal. Recomputing that
+		// here would only count one signal twice. It is scaled to the job
+		// though, and the flyweight builds occupying a one off executor
+		// finish in under a minute, which puts their likelyStuck window
+		// minutes rather than hours away. The floor keeps a slow report from
+		// being reaped as a hung batch.
+
+		long duration = runningBuild.getDuration(currentTimeMillis);
+
+		if (runningBuild.isLikelyStuck() &&
+			(duration >= _MINIMUM_LIKELY_STUCK_DURATION)) {
+
+			reasons.add(Reason.LIKELY_STUCK);
+		}
+
+		reasons.addAll(
+			_getJenkinsSlaveReasons(currentTimeMillis, runningBuild));
+
+		return reasons;
+	}
+
+	private void _sendSlackNotification(String summary) {
+		if (_reapActions.isEmpty()) {
+			return;
+		}
+
+		String subject = "Stale builds reaped";
+
+		if (_dryRun) {
+			subject = "Stale builds detected";
+		}
+
+		NotificationUtil.sendSlackNotification(
+			summary, "ci-notifications", subject);
+	}
+
+	private static final long _MINIMUM_LIKELY_STUCK_DURATION = 60 * 60 * 1000L;
+
+	private static final long _MINIMUM_OFFLINE_DURATION = 15 * 60 * 1000L;
+
+	private final boolean _dryRun;
+	private final JenkinsCohort _jenkinsCohort;
+	private final List<ReapAction> _reapActions = new ArrayList<>();
+
+	private class ReapAction {
+
+		public void execute() {
+			String buildURL = _runningBuild.getURL();
+
+			try {
+				JenkinsStopBuildUtil.abortBuild(buildURL);
+
+				_executed = true;
+			}
+			catch (Exception exception) {
+				System.out.println("Unable to reap " + buildURL);
+
+				exception.printStackTrace();
+			}
+		}
+
+		public String getSummary() {
+			StringBuilder sb = new StringBuilder();
+
+			JenkinsMaster jenkinsMaster = _runningBuild.getJenkinsMaster();
+
+			sb.append(jenkinsMaster.getName());
+
+			sb.append(" ");
+			sb.append(_runningBuild.getFullDisplayName());
+			sb.append(" on ");
+			sb.append(_runningBuild.getJenkinsSlaveName());
+			sb.append(" has been running for ");
+			sb.append(JenkinsResultsParserUtil.toDurationString(_duration));
+
+			long estimatedDuration = _runningBuild.getEstimatedDuration();
+
+			if (estimatedDuration > 0) {
+				sb.append(" against an estimate of ");
+				sb.append(
+					JenkinsResultsParserUtil.toDurationString(
+						estimatedDuration));
+			}
+
+			sb.append(". Flagged because ");
+
+			List<String> descriptions = new ArrayList<>();
+
+			for (Reason reason : _reasons) {
+				descriptions.add(reason.getDescription());
+			}
+
+			sb.append(JenkinsResultsParserUtil.join(", and ", descriptions));
+
+			sb.append(". ");
+			sb.append(_getOutcome());
+			sb.append(" ");
+			sb.append(_runningBuild.getURL());
+
+			return sb.toString();
+		}
+
+		public boolean isExecuted() {
+			return _executed;
+		}
+
+		private ReapAction(
+			long duration, List<Reason> reasons,
+			JenkinsMaster.RunningBuild runningBuild) {
+
+			_duration = duration;
+			_reasons = reasons;
+			_runningBuild = runningBuild;
+		}
+
+		private String _getOutcome() {
+			if (_dryRun) {
+				return "Not aborted (DRY_RUN).";
+			}
+
+			if (_executed) {
+				return "Aborted.";
+			}
+
+			return "Abort failed.";
+		}
+
+		private final long _duration;
+		private boolean _executed;
+		private final List<Reason> _reasons;
+		private final JenkinsMaster.RunningBuild _runningBuild;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -164,13 +164,6 @@ public class StaleBuildReaper {
 			return reasons;
 		}
 
-		// The grace period runs from the moment the node went offline, not
-		// from the moment the build started, so a node that is reconnecting
-		// gets the whole window however long its build has been running.
-		// Jenkins does not always report when the node went offline, and
-		// without that there is no way to tell a momentary drop from a dead
-		// channel, so the build is left for a later pass.
-
 		long jenkinsSlaveOfflineDuration =
 			runningBuild.getJenkinsSlaveOfflineDuration(currentTimeMillis);
 
@@ -189,15 +182,6 @@ public class StaleBuildReaper {
 		if (!runningBuild.isBuilding()) {
 			return reasons;
 		}
-
-		// Jenkins derives likelyStuck as ten times the estimate when an
-		// estimate exists, and a flat twenty four hours when it does not, so
-		// it already is the "far past its estimate" signal. Recomputing that
-		// here would only count one signal twice. It is scaled to the job
-		// though, and the flyweight builds occupying a one off executor
-		// finish in under a minute, which puts their likelyStuck window
-		// minutes rather than hours away. The floor keeps a slow report from
-		// being reaped as a hung batch.
 
 		long duration = runningBuild.getDuration(currentTimeMillis);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -160,7 +160,7 @@ public class StaleBuildReaper {
 			return reasons;
 		}
 
-		if (!runningBuild.isJenkinsSlaveOffline()) {
+		if (!runningBuild.isJenkinsSlaveOfflineUnexpectedly()) {
 			return reasons;
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -320,6 +320,12 @@ public class StaleBuildReaper {
 				return "Already finished.";
 			}
 
+			if (_abortResult ==
+					JenkinsStopBuildUtil.AbortResult.STILL_RUNNING) {
+
+				return "Ignored the abort, still holding its executor.";
+			}
+
 			if (_abortResult == JenkinsStopBuildUtil.AbortResult.STOPPED) {
 				return "Aborted.";
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -242,9 +242,7 @@ public class StaleBuildReaper {
 			String buildURL = _runningBuild.getURL();
 
 			try {
-				JenkinsStopBuildUtil.abortBuild(buildURL);
-
-				_executed = true;
+				_abortResult = JenkinsStopBuildUtil.abortBuild(buildURL);
 			}
 			catch (Exception exception) {
 				System.out.println("Unable to reap " + buildURL);
@@ -295,7 +293,11 @@ public class StaleBuildReaper {
 		}
 
 		public boolean isExecuted() {
-			return _executed;
+			if (_abortResult == JenkinsStopBuildUtil.AbortResult.STOPPED) {
+				return true;
+			}
+
+			return false;
 		}
 
 		private ReapAction(
@@ -312,15 +314,21 @@ public class StaleBuildReaper {
 				return "Not aborted (DRY_RUN).";
 			}
 
-			if (_executed) {
+			if (_abortResult ==
+					JenkinsStopBuildUtil.AbortResult.ALREADY_FINISHED) {
+
+				return "Already finished.";
+			}
+
+			if (_abortResult == JenkinsStopBuildUtil.AbortResult.STOPPED) {
 				return "Aborted.";
 			}
 
 			return "Abort failed.";
 		}
 
+		private JenkinsStopBuildUtil.AbortResult _abortResult;
 		private final long _duration;
-		private boolean _executed;
 		private final List<Reason> _reasons;
 		private final JenkinsMaster.RunningBuild _runningBuild;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/StaleBuildReaper.java
@@ -18,42 +18,42 @@ public class StaleBuildReaper {
 		_jenkinsCohort = jenkinsCohort;
 	}
 
-	public int getReapedBuildCount() {
-		int reapedBuildCount = 0;
+	public int getReapedBuildsCount() {
+		int reapedBuildsCount = 0;
 
 		for (ReapAction reapAction : _reapActions) {
 			if (reapAction.isExecuted()) {
-				reapedBuildCount++;
+				reapedBuildsCount++;
 			}
 		}
 
-		return reapedBuildCount;
+		return reapedBuildsCount;
 	}
 
-	public int getStaleBuildCount() {
+	public int getStaleBuildsCount() {
 		return _reapActions.size();
 	}
 
 	public String getSummary() {
 		StringBuilder sb = new StringBuilder();
 
-		int staleBuildCount = getStaleBuildCount();
+		int staleBuildsCount = getStaleBuildsCount();
 
 		String nounForm = JenkinsResultsParserUtil.getNounForm(
-			staleBuildCount, "stale builds", "stale build");
+			staleBuildsCount, "stale builds", "stale build");
 
 		if (_dryRun) {
 			sb.append("Found ");
-			sb.append(staleBuildCount);
+			sb.append(staleBuildsCount);
 			sb.append(" ");
 			sb.append(nounForm);
 			sb.append(". No build was aborted because DRY_RUN is enabled.");
 		}
 		else {
 			sb.append("Reaped ");
-			sb.append(getReapedBuildCount());
+			sb.append(getReapedBuildsCount());
 			sb.append(" of ");
-			sb.append(staleBuildCount);
+			sb.append(staleBuildsCount);
 			sb.append(" ");
 			sb.append(nounForm);
 			sb.append(".");
@@ -120,7 +120,7 @@ public class StaleBuildReaper {
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
 					jenkinsMaster.getName(), " reports at most ",
-					String.valueOf(jenkinsMaster.getMaxRunningBuildCount()),
+					String.valueOf(jenkinsMaster.getMaxRunningBuildsCount()),
 					" running build(s). Enumerated ",
 					String.valueOf(runningBuilds.size()), "."));
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -303,8 +303,8 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 					RandomTestUtil.randomString(), true,
 					RandomTestUtil.randomLong())),
 			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
-				"test-9-2-2", RandomTestUtil.randomLong(),
-				"Node is being removed", false,
+				"test-9-2-2", "Node is being removed",
+				RandomTestUtil.randomLong(), false,
 				JenkinsMasterTestUtil.getExecutorJSONObject(
 					_BUILD_URL_OFFLINE_NODE, RandomTestUtil.randomLong(),
 					RandomTestUtil.randomString(), false,

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -172,7 +172,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
 
-		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
+		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildsCount());
 
 		List<String> buildURLs = jenkinsMaster.getBuildURLs();
 
@@ -253,7 +253,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
 
-		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
+		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildsCount());
 
 		jenkinsMaster.update(true);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -172,10 +172,6 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
 
-		// The busyExecutors metric is 7 while only 3 builds could be
-		// enumerated, so the count must come from what Jenkins reported
-		// rather than from the list.
-
 		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
 
 		List<String> buildURLs = jenkinsMaster.getBuildURLs();
@@ -251,10 +247,6 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertTrue(runningBuilds.toString(), runningBuilds.isEmpty());
 
-		// The full update lands well inside the fifteen second window, but a
-		// minimal snapshot leaves out the executor detail it needs, so the
-		// cached entry must not satisfy it.
-
 		jenkinsMaster.update(false);
 
 		runningBuilds = jenkinsMaster.getRunningBuilds();
@@ -262,9 +254,6 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
 
 		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
-
-		// The reverse does not hold. A full snapshot is a superset, so a
-		// later minimal request keeps it.
 
 		jenkinsMaster.update(true);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -206,9 +206,7 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 			_BUILD_URL_OFFLINE_NODE, runningBuilds);
 
 		Assert.assertTrue(offlineRunningBuild.isJenkinsSlaveOffline());
-		Assert.assertEquals(
-			"Node is being removed",
-			offlineRunningBuild.getOfflineCauseReason());
+		Assert.assertTrue(offlineRunningBuild.isJenkinsSlaveBeingRemoved());
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 
+import java.util.List;
 import java.util.Map;
 
 import org.json.JSONArray;
@@ -36,6 +37,8 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		UrlReader urlReader = mockUrlReader();
 
+		_likelyStuckEstimatedDuration = RandomTestUtil.randomLong();
+
 		setUrlReaderOutput(
 			new JSONObject(
 			).put(
@@ -51,6 +54,22 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		setUrlReaderOutput(
 			read(new File(dependenciesDirs.get(0), "computer-api.json")),
 			"http://test-9-1/computer/api/json", urlReader);
+
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"items", new JSONArray()
+			).toString(),
+			"http://test-9-2/queue/api/json", urlReader);
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"mode", "NORMAL"
+			).toString(),
+			"http://test-9-2/api/json?tree=mode", urlReader);
+		setUrlReaderOutput(
+			_getRunningBuildsComputerAPIJSONObject().toString(),
+			"http://test-9-2/computer/api/json", urlReader);
 
 		_jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
 			"test-9-1", "http://test-9-1");
@@ -142,6 +161,57 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
+	public void testGetRunningBuilds() {
+		JenkinsMaster jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
+			"test-9-2", "http://test-9-2");
+
+		jenkinsMaster.update(false);
+
+		List<JenkinsMaster.RunningBuild> runningBuilds =
+			jenkinsMaster.getRunningBuilds();
+
+		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
+
+		// The busyExecutors metric is 7 while only 3 builds could be
+		// enumerated, so the count must come from what Jenkins reported
+		// rather than from the list.
+
+		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
+
+		List<String> buildURLs = jenkinsMaster.getBuildURLs();
+
+		Assert.assertEquals(buildURLs.toString(), 2, buildURLs.size());
+
+		Assert.assertFalse(
+			buildURLs.toString(), buildURLs.contains(_BUILD_URL_FLYWEIGHT));
+
+		JenkinsMaster.RunningBuild flyweightRunningBuild = _getRunningBuild(
+			_BUILD_URL_FLYWEIGHT, runningBuilds);
+
+		Assert.assertEquals(
+			"Built-In Node", flyweightRunningBuild.getJenkinsSlaveName());
+		Assert.assertFalse(flyweightRunningBuild.isLikelyStuck());
+		Assert.assertFalse(flyweightRunningBuild.isJenkinsSlaveOffline());
+
+		JenkinsMaster.RunningBuild likelyStuckRunningBuild = _getRunningBuild(
+			_BUILD_URL_LIKELY_STUCK, runningBuilds);
+
+		Assert.assertTrue(likelyStuckRunningBuild.isLikelyStuck());
+		Assert.assertFalse(likelyStuckRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertEquals(
+			_likelyStuckEstimatedDuration,
+			likelyStuckRunningBuild.getEstimatedDuration());
+
+		JenkinsMaster.RunningBuild offlineRunningBuild = _getRunningBuild(
+			_BUILD_URL_OFFLINE_NODE, runningBuilds);
+
+		Assert.assertTrue(offlineRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertEquals(
+			"Node is being removed",
+			offlineRunningBuild.getOfflineCauseReason());
+	}
+
+	@Test
 	public void testUpdate() {
 		_jenkinsMaster.update();
 
@@ -168,6 +238,88 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		Assert.assertFalse(labelBatchSizes.isEmpty());
 	}
 
+	@Test
+	public void testUpdateFullAfterMinimal() {
+		JenkinsMaster jenkinsMaster = JenkinsMasterTestUtil.getJenkinsMaster(
+			"test-9-2", "http://test-9-2");
+
+		jenkinsMaster.update(true);
+
+		List<JenkinsMaster.RunningBuild> runningBuilds =
+			jenkinsMaster.getRunningBuilds();
+
+		Assert.assertTrue(runningBuilds.toString(), runningBuilds.isEmpty());
+
+		// The full update lands well inside the fifteen second window, but a
+		// minimal snapshot leaves out the executor detail it needs, so the
+		// cached entry must not satisfy it.
+
+		jenkinsMaster.update(false);
+
+		runningBuilds = jenkinsMaster.getRunningBuilds();
+
+		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
+
+		Assert.assertEquals(7, jenkinsMaster.getMaxRunningBuildCount());
+
+		// The reverse does not hold. A full snapshot is a superset, so a
+		// later minimal request keeps it.
+
+		jenkinsMaster.update(true);
+
+		runningBuilds = jenkinsMaster.getRunningBuilds();
+
+		Assert.assertEquals(runningBuilds.toString(), 3, runningBuilds.size());
+	}
+
+	private JenkinsMaster.RunningBuild _getRunningBuild(
+		String buildURL, List<JenkinsMaster.RunningBuild> runningBuilds) {
+
+		for (JenkinsMaster.RunningBuild runningBuild : runningBuilds) {
+			String runningBuildURL = runningBuild.getURL();
+
+			if (runningBuildURL.equals(buildURL)) {
+				return runningBuild;
+			}
+		}
+
+		throw new AssertionError(
+			"Unable to find " + buildURL + " in " + runningBuilds);
+	}
+
+	private JSONObject _getRunningBuildsComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			7,
+			JenkinsMasterTestUtil.getBuiltInComputerJSONObject(
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_FLYWEIGHT, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					RandomTestUtil.randomLong())),
+			JenkinsMasterTestUtil.getComputerJSONObject(
+				"test-9-2-1",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_LIKELY_STUCK, _likelyStuckEstimatedDuration,
+					RandomTestUtil.randomString(), true,
+					RandomTestUtil.randomLong())),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-2", RandomTestUtil.randomLong(),
+				"Node is being removed", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_OFFLINE_NODE, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					RandomTestUtil.randomLong())));
+	}
+
+	private static final String _BUILD_URL_FLYWEIGHT =
+		"http://test-9-2/job/publish-testray-report/7/";
+
+	private static final String _BUILD_URL_LIKELY_STUCK =
+		"http://test-9-2/job/test-portal-acceptance-pullrequest(master)/1580/";
+
+	private static final String _BUILD_URL_OFFLINE_NODE =
+		"http://test-9-2/job/test-portal-release-downstream/22649/";
+
 	private JenkinsMaster _jenkinsMaster;
+	private long _likelyStuckEstimatedDuration;
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -285,7 +285,9 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		}
 
 		throw new AssertionError(
-			"Unable to find " + buildURL + " in " + runningBuilds);
+			JenkinsResultsParserUtil.combine(
+				"Unable to find ", buildURL, " in ",
+				String.valueOf(runningBuilds)));
 	}
 
 	private JSONObject _getRunningBuildsComputerAPIJSONObject() {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -191,13 +191,15 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		Assert.assertEquals(
 			"Built-In Node", flyweightRunningBuild.getJenkinsSlaveName());
 		Assert.assertFalse(flyweightRunningBuild.isLikelyStuck());
-		Assert.assertFalse(flyweightRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertFalse(
+			flyweightRunningBuild.isJenkinsSlaveOfflineUnexpectedly());
 
 		JenkinsMaster.RunningBuild likelyStuckRunningBuild = _getRunningBuild(
 			_BUILD_URL_LIKELY_STUCK, runningBuilds);
 
 		Assert.assertTrue(likelyStuckRunningBuild.isLikelyStuck());
-		Assert.assertFalse(likelyStuckRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertFalse(
+			likelyStuckRunningBuild.isJenkinsSlaveOfflineUnexpectedly());
 		Assert.assertEquals(
 			_likelyStuckEstimatedDuration,
 			likelyStuckRunningBuild.getEstimatedDuration());
@@ -205,7 +207,8 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 		JenkinsMaster.RunningBuild offlineRunningBuild = _getRunningBuild(
 			_BUILD_URL_OFFLINE_NODE, runningBuilds);
 
-		Assert.assertTrue(offlineRunningBuild.isJenkinsSlaveOffline());
+		Assert.assertTrue(
+			offlineRunningBuild.isJenkinsSlaveOfflineUnexpectedly());
 		Assert.assertTrue(offlineRunningBuild.isJenkinsSlaveBeingRemoved());
 	}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -28,11 +28,11 @@ public class JenkinsMasterTestUtil {
 	}
 
 	public static JSONObject getComputerAPIJSONObject(
-		int busyExecutorCount, JSONObject... computerJSONObjects) {
+		int busyExecutorsCount, JSONObject... computerJSONObjects) {
 
 		return new JSONObject(
 		).put(
-			"busyExecutors", busyExecutorCount
+			"busyExecutors", busyExecutorsCount
 		).put(
 			"computer", new JSONArray(computerJSONObjects)
 		);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -133,8 +133,8 @@ public class JenkinsMasterTestUtil {
 	}
 
 	public static JSONObject getOfflineComputerJSONObject(
-		String displayName, long offlineCauseTimestamp,
-		String offlineCauseReason, boolean temporarilyOffline,
+		String displayName, String offlineCauseReason,
+		long offlineCauseTimestamp, boolean temporarilyOffline,
 		JSONObject... executorJSONObjects) {
 
 		JSONObject computerJSONObject = _getComputerJSONObject(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTestUtil.java
@@ -10,10 +10,66 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 /**
  * @author Calum Ragan
  */
 public class JenkinsMasterTestUtil {
+
+	public static JSONObject getBuiltInComputerJSONObject(
+		JSONObject... oneOffExecutorJSONObjects) {
+
+		return _getComputerJSONObject(
+			"hudson.model.Hudson$MasterComputer", "Built-In Node",
+			new JSONArray(), false, "",
+			new JSONArray(oneOffExecutorJSONObjects));
+	}
+
+	public static JSONObject getComputerAPIJSONObject(
+		int busyExecutorCount, JSONObject... computerJSONObjects) {
+
+		return new JSONObject(
+		).put(
+			"busyExecutors", busyExecutorCount
+		).put(
+			"computer", new JSONArray(computerJSONObjects)
+		);
+	}
+
+	public static JSONObject getComputerJSONObject(
+		String displayName, JSONObject... executorJSONObjects) {
+
+		return _getComputerJSONObject(
+			"hudson.slaves.SlaveComputer", displayName,
+			new JSONArray(executorJSONObjects), false, "", new JSONArray());
+	}
+
+	public static JSONObject getExecutorJSONObject(
+		String buildURL, long estimatedDuration, String fullDisplayName,
+		boolean likelyStuck, long timestamp) {
+
+		JSONObject currentExecutableJSONObject = new JSONObject(
+		).put(
+			"building", true
+		).put(
+			"estimatedDuration", estimatedDuration
+		).put(
+			"fullDisplayName", fullDisplayName
+		).put(
+			"timestamp", timestamp
+		).put(
+			"url", buildURL
+		);
+
+		return new JSONObject(
+		).put(
+			"currentExecutable", currentExecutableJSONObject
+		).put(
+			"likelyStuck", likelyStuck
+		);
+	}
 
 	public static Properties getJenkinsCohortProperties(
 		String cohortName, int masterCount) {
@@ -76,7 +132,33 @@ public class JenkinsMasterTestUtil {
 			jenkinsMaster, "_labelBatchSizes");
 	}
 
+	public static JSONObject getOfflineComputerJSONObject(
+		String displayName, long offlineCauseTimestamp,
+		String offlineCauseReason, boolean temporarilyOffline,
+		JSONObject... executorJSONObjects) {
+
+		JSONObject computerJSONObject = _getComputerJSONObject(
+			"hudson.slaves.EC2FleetNodeComputer", displayName,
+			new JSONArray(executorJSONObjects), true, offlineCauseReason,
+			new JSONArray());
+
+		return computerJSONObject.put(
+			"offlineCause",
+			new JSONObject(
+			).put(
+				"timestamp", offlineCauseTimestamp
+			)
+		).put(
+			"temporarilyOffline", temporarilyOffline
+		);
+	}
+
 	public static void resetCaches() {
+		Map<String, ?> jenkinsCohorts = ReflectionTestUtil.getFieldValue(
+			JenkinsCohort.class, "_jenkinsCohorts");
+
+		jenkinsCohorts.clear();
+
 		Map<String, ?> jenkinsMasters = ReflectionTestUtil.getFieldValue(
 			JenkinsMaster.class, "_jenkinsMasters");
 
@@ -96,6 +178,39 @@ public class JenkinsMasterTestUtil {
 			LoadBalancerUtil.class, "_roundRobinCounters");
 
 		roundRobinCounters.clear();
+	}
+
+	private static JSONObject _getComputerJSONObject(
+		String className, String displayName, JSONArray executorsJSONArray,
+		boolean offline, String offlineCauseReason,
+		JSONArray oneOffExecutorsJSONArray) {
+
+		JSONArray assignedLabelsJSONArray = new JSONArray();
+
+		assignedLabelsJSONArray.put(
+			new JSONObject(
+			).put(
+				"name", displayName
+			));
+
+		return new JSONObject(
+		).put(
+			"_class", className
+		).put(
+			"assignedLabels", assignedLabelsJSONArray
+		).put(
+			"displayName", displayName
+		).put(
+			"executors", executorsJSONArray
+		).put(
+			"idle", executorsJSONArray.isEmpty()
+		).put(
+			"offline", offline
+		).put(
+			"offlineCauseReason", offlineCauseReason
+		).put(
+			"oneOffExecutors", oneOffExecutorsJSONArray
+		);
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
@@ -303,7 +303,7 @@ public class JenkinsStopBuildUtilTest
 
 		UrlReader urlReader = mockUrlReader();
 
-		AtomicInteger readCount = new AtomicInteger();
+		AtomicInteger readsCount = new AtomicInteger();
 
 		Mockito.doAnswer(
 			invocation -> {
@@ -311,7 +311,7 @@ public class JenkinsStopBuildUtilTest
 
 				JSONObject jsonObject = new JSONObject();
 
-				if (readCount.getAndIncrement() < buildingResultsCount) {
+				if (readsCount.getAndIncrement() < buildingResultsCount) {
 					jsonObject.put("result", JSONObject.NULL);
 				}
 				else {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
@@ -298,7 +298,9 @@ public class JenkinsStopBuildUtilTest
 		JenkinsResultsParserUtil.setBuildProperties(properties);
 	}
 
-	private void _setUpResultOutputs(int buildingResultCount) throws Exception {
+	private void _setUpResultOutputs(int buildingResultsCount)
+		throws Exception {
+
 		UrlReader urlReader = mockUrlReader();
 
 		AtomicInteger readCount = new AtomicInteger();
@@ -309,7 +311,7 @@ public class JenkinsStopBuildUtilTest
 
 				JSONObject jsonObject = new JSONObject();
 
-				if (readCount.getAndIncrement() < buildingResultCount) {
+				if (readCount.getAndIncrement() < buildingResultsCount) {
 					jsonObject.put("result", JSONObject.NULL);
 				}
 				else {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayInputStream;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,9 +52,9 @@ public class JenkinsStopBuildUtilTest
 		_httpServer.createContext(
 			"/",
 			httpExchange -> {
-				_postedPaths.add(
-					httpExchange.getRequestURI(
-					).getPath());
+				URI requestURI = httpExchange.getRequestURI();
+
+				_postedPaths.add(requestURI.getPath());
 
 				_requestMethods.add(httpExchange.getRequestMethod());
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
@@ -5,13 +5,283 @@
 
 package com.liferay.jenkins.results.parser;
 
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.ByteArrayInputStream;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.json.JSONObject;
+
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Kevin Yen
+ * @author Peter Yoo
  */
-public class JenkinsStopBuildUtilTest {
+public class JenkinsStopBuildUtilTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_username = RandomTestUtil.randomString();
+		_password = RandomTestUtil.randomString();
+
+		_setUpBuildProperties(_username, _password);
+
+		_httpServer = HttpServer.create(
+			new InetSocketAddress(InetAddress.getByName("localhost"), 0), 0);
+
+		_httpServer.createContext(
+			"/",
+			httpExchange -> {
+				_postedPaths.add(
+					httpExchange.getRequestURI(
+					).getPath());
+
+				_requestMethods.add(httpExchange.getRequestMethod());
+
+				Headers headers = httpExchange.getRequestHeaders();
+
+				_authorizations.add(headers.getFirst("Authorization"));
+
+				httpExchange.sendResponseHeaders(_responseCode, -1);
+
+				httpExchange.close();
+			});
+
+		_httpServer.start();
+
+		InetSocketAddress inetSocketAddress = _httpServer.getAddress();
+
+		_buildURL = JenkinsResultsParserUtil.combine(
+			"http://localhost:", String.valueOf(inetSocketAddress.getPort()),
+			"/job/test-job/1/");
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		_httpServer.stop(0);
+	}
+
+	@Test
+	public void testAbortBuildAlreadyFinished() throws Exception {
+		_setUpResultOutputs(0);
+
+		Assert.assertEquals(
+			JenkinsStopBuildUtil.AbortResult.ALREADY_FINISHED, _abortBuild());
+
+		// A build that finished on its own must not be reported as one this
+		// call stopped, and it must not be interrupted.
+
+		Assert.assertEquals(_postedPaths.toString(), 0, _postedPaths.size());
+	}
+
+	@Test
+	public void testAbortBuildMissingCredentials() throws Exception {
+		_setUpBuildProperties(RandomTestUtil.randomString(), null);
+
+		_setUpResultOutputs(_MAXIMUM_RESULT_READS);
+
+		try {
+			_abortBuild();
+
+			Assert.fail("Expected a RuntimeException");
+		}
+		catch (RuntimeException runtimeException) {
+			String message = runtimeException.getMessage();
+
+			Assert.assertTrue(
+				message, message.contains("jenkins.admin.user.token"));
+		}
+
+		Assert.assertEquals(_postedPaths.toString(), 0, _postedPaths.size());
+	}
+
+	@Test
+	public void testAbortBuildNormalizesRemoteURL() throws Exception {
+		_setUpResultOutputs(0);
+
+		JenkinsStopBuildUtil.abortBuild(
+			"https://test-1-41.liferay.com/job/test-job/1/");
+
+		// The call has to work from inside CI, where only the local hostname
+		// resolves.
+
+		Assert.assertEquals(_readURLs.toString(), 1, _readURLs.size());
+
+		String readURL = _readURLs.get(0);
+
+		Assert.assertTrue(readURL, readURL.startsWith("http://test-1-41/"));
+	}
+
+	@Test
+	public void testAbortBuildResultAbsent() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			String.valueOf(new JSONObject()), "tree=result", urlReader);
+
+		try {
+			_abortBuild();
+
+			Assert.fail("Expected a RuntimeException");
+		}
+		catch (RuntimeException runtimeException) {
+			String message = runtimeException.getMessage();
+
+			Assert.assertTrue(
+				message, message.contains("Unable to determine whether"));
+		}
+
+		Assert.assertEquals(_postedPaths.toString(), 0, _postedPaths.size());
+	}
+
+	@Test
+	public void testAbortBuildResultTerminal() throws Exception {
+		for (String result :
+				new String[] {
+					"ABORTED", "FAILURE", "NOT_BUILT", "SUCCESS", "UNSTABLE"
+				}) {
+
+			UrlReader urlReader = mockUrlReader();
+
+			setUrlReaderOutput(
+				String.valueOf(
+					new JSONObject(
+					).put(
+						"result", result
+					)),
+				"tree=result", urlReader);
+
+			Assert.assertEquals(
+				result, JenkinsStopBuildUtil.AbortResult.ALREADY_FINISHED,
+				_abortBuild());
+		}
+	}
+
+	@Test
+	public void testAbortBuildStillRunning() throws Exception {
+		_setUpResultOutputs(_MAXIMUM_RESULT_READS);
+
+		Assert.assertEquals(
+			JenkinsStopBuildUtil.AbortResult.STILL_RUNNING, _abortBuild());
+
+		Assert.assertEquals(_postedPaths.toString(), 1, _postedPaths.size());
+	}
+
+	@Test
+	public void testAbortBuildStopped() throws Exception {
+		_setUpResultOutputs(1);
+
+		Assert.assertEquals(
+			JenkinsStopBuildUtil.AbortResult.STOPPED, _abortBuild());
+
+		Assert.assertEquals(_postedPaths.toString(), 1, _postedPaths.size());
+
+		String postedPath = _postedPaths.get(0);
+
+		Assert.assertTrue(
+			postedPath, postedPath.startsWith("/job/test-job/1/"));
+		Assert.assertTrue(postedPath, postedPath.endsWith("/stop"));
+
+		// Jenkins only interrupts on a POST, and only for a caller it can
+		// authenticate as an administrator.
+
+		Assert.assertEquals("POST", _requestMethods.get(0));
+
+		String encodedString = JenkinsStopBuildUtil.encodeAuthorizationFields(
+			_username, _password);
+
+		Assert.assertEquals("Basic " + encodedString, _authorizations.get(0));
+	}
+
+	@Test
+	public void testAbortBuildStoppedOnFinalVerification() throws Exception {
+
+		// Stopping on the last pass is a stop, not a failure.
+
+		_setUpResultOutputs(_MAXIMUM_RESULT_READS - 1);
+
+		Assert.assertEquals(
+			JenkinsStopBuildUtil.AbortResult.STOPPED, _abortBuild());
+	}
+
+	@Test
+	public void testAbortBuildUnacceptedResponse() throws Exception {
+		_responseCode = 500;
+
+		_setUpResultOutputs(_MAXIMUM_RESULT_READS);
+
+		try {
+			_abortBuild();
+
+			Assert.fail("Expected a RuntimeException");
+		}
+		catch (RuntimeException runtimeException) {
+			String message = runtimeException.getMessage();
+
+			Assert.assertTrue(message, message.contains("500"));
+		}
+
+		// The build was never re-read, so no verification pass ran.
+
+		Assert.assertEquals(_readURLs.toString(), 1, _readURLs.size());
+	}
+
+	@Test
+	public void testAbortBuildUnacceptedResponseAtBoundary() throws Exception {
+
+		// 400 is rejected, not accepted.
+
+		_responseCode = 400;
+
+		_setUpResultOutputs(_MAXIMUM_RESULT_READS);
+
+		try {
+			_abortBuild();
+
+			Assert.fail("Expected a RuntimeException");
+		}
+		catch (RuntimeException runtimeException) {
+			String message = runtimeException.getMessage();
+
+			Assert.assertTrue(message, message.contains("400"));
+		}
+	}
+
+	@Test
+	public void testAbortBuildVerifiesAfterRedirect() throws Exception {
+
+		// Jenkins answers /stop with a redirect as soon as it has interrupted
+		// the executor thread, so anything short of an error is accepted.
+
+		_responseCode = 302;
+
+		_setUpResultOutputs(1);
+
+		Assert.assertEquals(
+			JenkinsStopBuildUtil.AbortResult.STOPPED, _abortBuild());
+	}
 
 	@Test
 	public void testEncodeAuthorizationFields() {
@@ -20,5 +290,79 @@ public class JenkinsStopBuildUtilTest {
 
 		Assert.assertEquals("dGVzdDp0ZXN0", encodedString);
 	}
+
+	private JenkinsStopBuildUtil.AbortResult _abortBuild() throws Exception {
+		try (MockedStatic<JenkinsResultsParserUtil> mockedStatic =
+				Mockito.mockStatic(
+					JenkinsResultsParserUtil.class,
+					Mockito.CALLS_REAL_METHODS)) {
+
+			mockedStatic.when(
+				() -> JenkinsResultsParserUtil.sleep(Mockito.anyLong())
+			).thenAnswer(
+				invocation -> null
+			);
+
+			return JenkinsStopBuildUtil.abortBuild(_buildURL);
+		}
+	}
+
+	private void _setUpBuildProperties(String username, String password) {
+		Properties properties = new Properties();
+
+		if (username != null) {
+			properties.setProperty("jenkins.admin.user.name", username);
+		}
+
+		if (password != null) {
+			properties.setProperty("jenkins.admin.user.token", password);
+		}
+
+		JenkinsResultsParserUtil.setBuildProperties(properties);
+	}
+
+	private void _setUpResultOutputs(int buildingResultCount) throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		AtomicInteger readCount = new AtomicInteger();
+
+		Mockito.doAnswer(
+			invocation -> {
+				_readURLs.add(invocation.getArgument(7));
+
+				JSONObject jsonObject = new JSONObject();
+
+				if (readCount.getAndIncrement() < buildingResultCount) {
+					jsonObject.put("result", JSONObject.NULL);
+				}
+				else {
+					jsonObject.put("result", "ABORTED");
+				}
+
+				String string = String.valueOf(jsonObject);
+
+				return new ByteArrayInputStream(string.getBytes());
+			}
+		).when(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.argThat(
+				readURL -> (readURL != null) && readURL.contains("tree=result"))
+		);
+	}
+
+	private static final int _MAXIMUM_RESULT_READS = 7;
+
+	private final List<String> _authorizations = new ArrayList<>();
+	private String _buildURL;
+	private HttpServer _httpServer;
+	private String _password;
+	private final List<String> _postedPaths = new ArrayList<>();
+	private final List<String> _readURLs = new ArrayList<>();
+	private final List<String> _requestMethods = new ArrayList<>();
+	private int _responseCode = 200;
+	private String _username;
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
@@ -41,10 +41,7 @@ public class JenkinsStopBuildUtilTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_username = RandomTestUtil.randomString();
-		_password = RandomTestUtil.randomString();
-
-		_setUpBuildProperties(_username, _password);
+		_setUpBuildProperties(_USERNAME, _PASSWORD);
 
 		_httpServer = HttpServer.create(
 			new InetSocketAddress(InetAddress.getByName("localhost"), 0), 0);
@@ -202,7 +199,7 @@ public class JenkinsStopBuildUtilTest
 		Assert.assertEquals("POST", _requestMethods.get(0));
 
 		String encodedString = JenkinsStopBuildUtil.encodeAuthorizationFields(
-			_username, _password);
+			_USERNAME, _PASSWORD);
 
 		Assert.assertEquals("Basic " + encodedString, _authorizations.get(0));
 	}
@@ -335,14 +332,16 @@ public class JenkinsStopBuildUtilTest
 
 	private static final int _MAXIMUM_RESULT_READS = 7;
 
+	private static final String _PASSWORD = RandomTestUtil.randomString();
+
+	private static final String _USERNAME = RandomTestUtil.randomString();
+
 	private final List<String> _authorizations = new ArrayList<>();
 	private String _buildURL;
 	private HttpServer _httpServer;
-	private String _password;
 	private final List<String> _postedPaths = new ArrayList<>();
 	private final List<String> _readURLs = new ArrayList<>();
 	private final List<String> _requestMethods = new ArrayList<>();
 	private int _responseCode = 200;
-	private String _username;
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtilTest.java
@@ -90,9 +90,6 @@ public class JenkinsStopBuildUtilTest
 		Assert.assertEquals(
 			JenkinsStopBuildUtil.AbortResult.ALREADY_FINISHED, _abortBuild());
 
-		// A build that finished on its own must not be reported as one this
-		// call stopped, and it must not be interrupted.
-
 		Assert.assertEquals(_postedPaths.toString(), 0, _postedPaths.size());
 	}
 
@@ -123,9 +120,6 @@ public class JenkinsStopBuildUtilTest
 
 		JenkinsStopBuildUtil.abortBuild(
 			"https://test-1-41.liferay.com/job/test-job/1/");
-
-		// The call has to work from inside CI, where only the local hostname
-		// resolves.
 
 		Assert.assertEquals(_readURLs.toString(), 1, _readURLs.size());
 
@@ -204,9 +198,6 @@ public class JenkinsStopBuildUtilTest
 			postedPath, postedPath.startsWith("/job/test-job/1/"));
 		Assert.assertTrue(postedPath, postedPath.endsWith("/stop"));
 
-		// Jenkins only interrupts on a POST, and only for a caller it can
-		// authenticate as an administrator.
-
 		Assert.assertEquals("POST", _requestMethods.get(0));
 
 		String encodedString = JenkinsStopBuildUtil.encodeAuthorizationFields(
@@ -217,9 +208,6 @@ public class JenkinsStopBuildUtilTest
 
 	@Test
 	public void testAbortBuildStoppedOnFinalVerification() throws Exception {
-
-		// Stopping on the last pass is a stop, not a failure.
-
 		_setUpResultOutputs(_MAXIMUM_RESULT_READS - 1);
 
 		Assert.assertEquals(
@@ -243,16 +231,11 @@ public class JenkinsStopBuildUtilTest
 			Assert.assertTrue(message, message.contains("500"));
 		}
 
-		// The build was never re-read, so no verification pass ran.
-
 		Assert.assertEquals(_readURLs.toString(), 1, _readURLs.size());
 	}
 
 	@Test
 	public void testAbortBuildUnacceptedResponseAtBoundary() throws Exception {
-
-		// 400 is rejected, not accepted.
-
 		_responseCode = 400;
 
 		_setUpResultOutputs(_MAXIMUM_RESULT_READS);
@@ -271,10 +254,6 @@ public class JenkinsStopBuildUtilTest
 
 	@Test
 	public void testAbortBuildVerifiesAfterRedirect() throws Exception {
-
-		// Jenkins answers /stop with a redirect as soon as it has interrupted
-		// the executor thread, so anything short of an error is accepted.
-
 		_responseCode = 302;
 
 		_setUpResultOutputs(1);

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
@@ -74,9 +74,6 @@ public class StaleBuildReaperTest
 		Assert.assertFalse(
 			summary, summary.contains(_BUILD_URL_TEMPORARILY_OFFLINE));
 
-		// A flyweight build reports likelyStuck only minutes in, because
-		// Jenkins scales the flag to the job's own average.
-
 		Assert.assertFalse(
 			summary, summary.contains(_BUILD_URL_FLYWEIGHT_STUCK));
 
@@ -118,9 +115,6 @@ public class StaleBuildReaperTest
 
 		StaleBuildReaper staleBuildReaper = _reap(
 			false, _BUILD_URL_LIKELY_STUCK, stoppedBuildURLs);
-
-		// A build that takes the interrupt and keeps running must not be
-		// counted or reported as reaped.
 
 		Assert.assertEquals(2, staleBuildReaper.getReapedBuildCount());
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
@@ -257,7 +257,7 @@ public class StaleBuildReaperTest
 
 					stoppedBuildURLs.add(buildURL);
 
-					return null;
+					return JenkinsStopBuildUtil.AbortResult.STOPPED;
 				}
 			);
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
@@ -63,7 +63,7 @@ public class StaleBuildReaperTest
 
 		String summary = staleBuildReaper.getSummary();
 
-		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildsCount());
 
 		Assert.assertTrue(summary, summary.contains(_BUILD_URL_LIKELY_STUCK));
 		Assert.assertTrue(summary, summary.contains(_BUILD_URL_NODE_REMOVED));
@@ -92,9 +92,9 @@ public class StaleBuildReaperTest
 		StaleBuildReaper staleBuildReaper = _reap(
 			false, null, stoppedBuildURLs);
 
-		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildsCount());
 
-		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildsCount());
 
 		List<String> expectedBuildURLs = new ArrayList<>();
 
@@ -116,9 +116,9 @@ public class StaleBuildReaperTest
 		StaleBuildReaper staleBuildReaper = _reap(
 			false, _BUILD_URL_LIKELY_STUCK, stoppedBuildURLs);
 
-		Assert.assertEquals(2, staleBuildReaper.getReapedBuildCount());
+		Assert.assertEquals(2, staleBuildReaper.getReapedBuildsCount());
 
-		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildsCount());
 
 		Assert.assertFalse(
 			stoppedBuildURLs.toString(),
@@ -155,7 +155,7 @@ public class StaleBuildReaperTest
 		StaleBuildReaper staleBuildReaper = _reap(
 			false, null, stoppedBuildURLs);
 
-		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildsCount());
 
 		Assert.assertTrue(
 			stoppedBuildURLs.toString(),
@@ -168,7 +168,7 @@ public class StaleBuildReaperTest
 
 		StaleBuildReaper staleBuildReaper = _reap(true, null, stoppedBuildURLs);
 
-		Assert.assertEquals(0, staleBuildReaper.getReapedBuildCount());
+		Assert.assertEquals(0, staleBuildReaper.getReapedBuildsCount());
 
 		Assert.assertTrue(
 			stoppedBuildURLs.toString(), stoppedBuildURLs.isEmpty());

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
@@ -1,0 +1,328 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Calum Ragan
+ */
+public class StaleBuildReaperTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		Environment.setInstance(Mockito.mock(Environment.class));
+
+		_urlReader = mockUrlReader();
+
+		JenkinsMasterTestUtil.getJenkinsCohortProperties("test-9", 2);
+
+		_setUpJenkinsMasterUrlReaderOutputs(
+			_getStaleBuildsComputerAPIJSONObject(), "test-9-1");
+		_setUpJenkinsMasterUrlReaderOutputs(
+			_getJenkinsSlaveOfflineComputerAPIJSONObject(), "test-9-2");
+
+		_jenkinsCohort = JenkinsCohort.getInstance("test-9");
+	}
+
+	@After
+	@Override
+	public void tearDown() {
+		super.tearDown();
+
+		JenkinsMasterTestUtil.resetCaches();
+
+		JenkinsResultsParserUtil.setBuildProperties(new Properties());
+	}
+
+	@Test
+	public void testGetSummary() {
+		StaleBuildReaper staleBuildReaper = _reap(
+			true, null, new ArrayList<String>());
+
+		String summary = staleBuildReaper.getSummary();
+
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+
+		Assert.assertTrue(summary, summary.contains(_BUILD_URL_LIKELY_STUCK));
+		Assert.assertTrue(summary, summary.contains(_BUILD_URL_NODE_REMOVED));
+		Assert.assertTrue(summary, summary.contains(_BUILD_URL_OFFLINE));
+
+		Assert.assertFalse(summary, summary.contains(_BUILD_URL_HEALTHY));
+		Assert.assertFalse(summary, summary.contains(_BUILD_URL_RECONNECTING));
+		Assert.assertFalse(
+			summary, summary.contains(_BUILD_URL_TEMPORARILY_OFFLINE));
+
+		// A flyweight build reports likelyStuck only minutes in, because
+		// Jenkins scales the flag to the job's own average.
+
+		Assert.assertFalse(
+			summary, summary.contains(_BUILD_URL_FLYWEIGHT_STUCK));
+
+		Assert.assertTrue(
+			summary, summary.contains("its executor reports likelyStuck"));
+		Assert.assertTrue(
+			summary, summary.contains("its node is being removed"));
+		Assert.assertTrue(
+			summary, summary.contains("its node has been offline"));
+	}
+
+	@Test
+	public void testReap() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(
+			false, null, stoppedBuildURLs);
+
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+
+		List<String> expectedBuildURLs = new ArrayList<>();
+
+		expectedBuildURLs.add(_BUILD_URL_LIKELY_STUCK);
+		expectedBuildURLs.add(_BUILD_URL_NODE_REMOVED);
+		expectedBuildURLs.add(_BUILD_URL_OFFLINE);
+
+		Collections.sort(expectedBuildURLs);
+
+		Collections.sort(stoppedBuildURLs);
+
+		Assert.assertEquals(expectedBuildURLs, stoppedBuildURLs);
+	}
+
+	@Test
+	public void testReapAbortFailed() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(
+			false, _BUILD_URL_LIKELY_STUCK, stoppedBuildURLs);
+
+		// A build that takes the interrupt and keeps running must not be
+		// counted or reported as reaped.
+
+		Assert.assertEquals(2, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertEquals(3, staleBuildReaper.getStaleBuildCount());
+
+		Assert.assertFalse(
+			stoppedBuildURLs.toString(),
+			stoppedBuildURLs.contains(_BUILD_URL_LIKELY_STUCK));
+
+		String summary = staleBuildReaper.getSummary();
+
+		Assert.assertTrue(summary, summary.contains("Reaped 2 of 3"));
+
+		Assert.assertTrue(summary, summary.contains("Abort failed."));
+	}
+
+	@Test
+	public void testReapBlacklistedJenkinsMaster() {
+		ReflectionTestUtil.setFieldValue(
+			JenkinsMaster.getInstance("test-9-2"), "_blacklisted", true);
+
+		List<JenkinsMaster> availableJenkinsMasters =
+			_jenkinsCohort.getAvailableJenkinsMasters();
+
+		Assert.assertEquals(
+			availableJenkinsMasters.toString(), 1,
+			availableJenkinsMasters.size());
+
+		List<JenkinsMaster> blacklistedJenkinsMasters =
+			_jenkinsCohort.getBlacklistedJenkinsMasters();
+
+		Assert.assertEquals(
+			blacklistedJenkinsMasters.toString(), 1,
+			blacklistedJenkinsMasters.size());
+
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(
+			false, null, stoppedBuildURLs);
+
+		Assert.assertEquals(3, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertTrue(
+			stoppedBuildURLs.toString(),
+			stoppedBuildURLs.contains(_BUILD_URL_OFFLINE));
+	}
+
+	@Test
+	public void testReapDryRun() {
+		List<String> stoppedBuildURLs = new ArrayList<>();
+
+		StaleBuildReaper staleBuildReaper = _reap(true, null, stoppedBuildURLs);
+
+		Assert.assertEquals(0, staleBuildReaper.getReapedBuildCount());
+
+		Assert.assertTrue(
+			stoppedBuildURLs.toString(), stoppedBuildURLs.isEmpty());
+	}
+
+	private JSONObject _getJenkinsSlaveOfflineComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			2,
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-1", _getStartTime(30 * _MINUTE),
+				"Connection was broken", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_OFFLINE, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(46 * _HOUR))),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-2", _getStartTime(2 * _MINUTE),
+				"Connection was broken", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_RECONNECTING, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(46 * _HOUR))),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-2-3", _getStartTime(30 * _HOUR), "Disk is full", true,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_TEMPORARILY_OFFLINE, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(46 * _HOUR))));
+	}
+
+	private JSONObject _getStaleBuildsComputerAPIJSONObject() {
+		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
+			7,
+			JenkinsMasterTestUtil.getBuiltInComputerJSONObject(
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_HEALTHY, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(20 * _HOUR)),
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_FLYWEIGHT_STUCK, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), true,
+					_getStartTime(10 * _MINUTE))),
+			JenkinsMasterTestUtil.getComputerJSONObject(
+				"test-9-1-1",
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_LIKELY_STUCK, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), true,
+					_getStartTime(20 * _HOUR))),
+			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
+				"test-9-1-2", _getStartTime(12 * 24 * _HOUR),
+				"Node is being removed", false,
+				JenkinsMasterTestUtil.getExecutorJSONObject(
+					_BUILD_URL_NODE_REMOVED, RandomTestUtil.randomLong(),
+					RandomTestUtil.randomString(), false,
+					_getStartTime(12 * 24 * _HOUR))));
+	}
+
+	private long _getStartTime(long duration) {
+		return JenkinsResultsParserUtil.getCurrentTimeMillis() - duration;
+	}
+
+	private StaleBuildReaper _reap(
+		boolean dryRun, String failingBuildURL, List<String> stoppedBuildURLs) {
+
+		try (MockedStatic<JenkinsStopBuildUtil> stopBuildMockedStatic =
+				Mockito.mockStatic(JenkinsStopBuildUtil.class);
+			MockedStatic<NotificationUtil> notificationMockedStatic =
+				Mockito.mockStatic(NotificationUtil.class)) {
+
+			stopBuildMockedStatic.when(
+				() -> JenkinsStopBuildUtil.abortBuild(Mockito.anyString())
+			).thenAnswer(
+				invocation -> {
+					String buildURL = invocation.getArgument(0);
+
+					if (buildURL.equals(failingBuildURL)) {
+						throw new RuntimeException(
+							"Unable to stop " + buildURL);
+					}
+
+					stoppedBuildURLs.add(buildURL);
+
+					return null;
+				}
+			);
+
+			StaleBuildReaper staleBuildReaper = new StaleBuildReaper(
+				dryRun, _jenkinsCohort);
+
+			staleBuildReaper.reap();
+
+			return staleBuildReaper;
+		}
+	}
+
+	private void _setUpJenkinsMasterUrlReaderOutputs(
+			JSONObject computerAPIJSONObject, String masterName)
+		throws Exception {
+
+		String masterURL = "http://" + masterName;
+
+		JSONObject queueJSONObject = new JSONObject();
+
+		queueJSONObject.put("items", new JSONArray());
+
+		setUrlReaderOutput(
+			queueJSONObject.toString(), masterURL + "/queue/api/json",
+			_urlReader);
+
+		JSONObject modeJSONObject = new JSONObject();
+
+		modeJSONObject.put("mode", "NORMAL");
+
+		setUrlReaderOutput(
+			modeJSONObject.toString(), masterURL + "/api/json?tree=mode",
+			_urlReader);
+
+		setUrlReaderOutput(
+			computerAPIJSONObject.toString(), masterURL + "/computer/api/json",
+			_urlReader);
+	}
+
+	private static final String _BUILD_URL_FLYWEIGHT_STUCK =
+		"http://test-9-1/job/publish-testray-report/7/";
+
+	private static final String _BUILD_URL_HEALTHY =
+		"http://test-9-1/job/test-portal-release-downstream/1/";
+
+	private static final String _BUILD_URL_LIKELY_STUCK =
+		"http://test-9-1/job/test-portal-acceptance-pullrequest(master)/1580/";
+
+	private static final String _BUILD_URL_NODE_REMOVED =
+		"http://test-9-1/job/test-portal-release-downstream/22649/";
+
+	private static final String _BUILD_URL_OFFLINE =
+		"http://test-9-2/job/test-portal-testsuite-downstream/166636/";
+
+	private static final String _BUILD_URL_RECONNECTING =
+		"http://test-9-2/job/test-portal-source-format(master)/99/";
+
+	private static final String _BUILD_URL_TEMPORARILY_OFFLINE =
+		"http://test-9-2/job/test-portal-acceptance-pullrequest(master)/42/";
+
+	private static final long _HOUR = 60 * 60 * 1000L;
+
+	private static final long _MINUTE = 60 * 1000L;
+
+	private JenkinsCohort _jenkinsCohort;
+	private UrlReader _urlReader;
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/StaleBuildReaperTest.java
@@ -184,21 +184,21 @@ public class StaleBuildReaperTest
 		return JenkinsMasterTestUtil.getComputerAPIJSONObject(
 			2,
 			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
-				"test-9-2-1", _getStartTime(30 * _MINUTE),
-				"Connection was broken", false,
+				"test-9-2-1", "Connection was broken",
+				_getStartTime(30 * _MINUTE), false,
 				JenkinsMasterTestUtil.getExecutorJSONObject(
 					_BUILD_URL_OFFLINE, RandomTestUtil.randomLong(),
 					RandomTestUtil.randomString(), false,
 					_getStartTime(46 * _HOUR))),
 			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
-				"test-9-2-2", _getStartTime(2 * _MINUTE),
-				"Connection was broken", false,
+				"test-9-2-2", "Connection was broken",
+				_getStartTime(2 * _MINUTE), false,
 				JenkinsMasterTestUtil.getExecutorJSONObject(
 					_BUILD_URL_RECONNECTING, RandomTestUtil.randomLong(),
 					RandomTestUtil.randomString(), false,
 					_getStartTime(46 * _HOUR))),
 			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
-				"test-9-2-3", _getStartTime(30 * _HOUR), "Disk is full", true,
+				"test-9-2-3", "Disk is full", _getStartTime(30 * _HOUR), true,
 				JenkinsMasterTestUtil.getExecutorJSONObject(
 					_BUILD_URL_TEMPORARILY_OFFLINE, RandomTestUtil.randomLong(),
 					RandomTestUtil.randomString(), false,
@@ -224,8 +224,8 @@ public class StaleBuildReaperTest
 					RandomTestUtil.randomString(), true,
 					_getStartTime(20 * _HOUR))),
 			JenkinsMasterTestUtil.getOfflineComputerJSONObject(
-				"test-9-1-2", _getStartTime(12 * 24 * _HOUR),
-				"Node is being removed", false,
+				"test-9-1-2", "Node is being removed",
+				_getStartTime(12 * 24 * _HOUR), false,
 				JenkinsMasterTestUtil.getExecutorJSONObject(
 					_BUILD_URL_NODE_REMOVED, RandomTestUtil.randomLong(),
 					RandomTestUtil.randomString(), false,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7904

## What Is Being Fixed

A build could hang indefinitely while holding a Jenkins executor. Nothing detected or reclaimed it, so the slave stayed occupied and cohort capacity drained silently until someone noticed and aborted the build by hand.

`JenkinsStopBuildUtil` also failed quietly in several paths. Missing admin credentials and an unreadable build result both passed through without complaint, so an abort that never happened looked the same as one that succeeded.

## How It Is Being Fixed

`StaleBuildReaper` scans each master for builds its executor reports as `likelyStuck`, builds on a node being removed or offline, and builds running well past their estimate. It aborts what it finds and reports how many were stale against how many were actually reaped, so a build that ignores the abort is visible rather than assumed handled.

`JenkinsMaster` gains `getMaxRunningBuildsCount` and `getStartedBuildsCountAfter` to expose the executor and started-build figures the reaper needs, reading the minimal computer API tree so the scan stays cheap.

`JenkinsStopBuildUtil` now fails loudly when the admin credentials are missing or a build's result cannot be read, and returns a distinct outcome when a build ignores the abort rather than reporting success.

Count-bearing methods and locals were renamed to the plural form throughout — `getStartedBuildCountAfter` to `getStartedBuildsCountAfter`, `idleNodeCount` to `idleNodesCount`, and the rest — so the name says the count is over a collection. The last two commits finish that sweep in `JenkinsCohort`, which still spelled the same concept two ways one line apart from the method it delegated to.

## PR Check

**pr-check: SKIPPED** — Baseline reports pre-existing semantic versioning drift in portal-kernel that is unrelated to this branch, so the run is recorded as skipped rather than gating this pull request.

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | SKIPPED |
| Java Unit Tests | PASS |

Baseline was executed rather than omitted, and it reported two `EXCESSIVE VERSION INCREASE` findings: `com.liferay.exportimport.kernel.xstream` at 3.0.0 against a current 2.0.0, and `com.liferay.portal.kernel.servlet` at 18.0.0 against a current 17.2.0. Both packages live in `portal-kernel`. This branch changes eight files, all under `modules/test/jenkins-results-parser`, and touches neither `portal-kernel` nor `portal-impl`, so it cannot have moved those versions — the drift is already present on master and any pull request cut from it hits the same finding. It is recorded as skipped on that basis. Java Unit Tests covered 23 tests with 0 failures and 0 errors.

<!-- pr-check {"reason": "Baseline reports pre-existing semantic versioning drift in portal-kernel, unrelated to this branch", "result": "skipped", "sha": "f46c1ec2e097a4c2d08ca33091feb245c3c9c83c"} -->

