### PR TITLE
LRCI-8047 Stop MirrorsGetTask from clobbering the shared mirrors cache

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -5,6 +5,8 @@
 
 package com.liferay.ant.mirrors.get;
 
+import com.liferay.ant.mirrors.get.internal.MirrorsCacheLinker;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -411,6 +413,83 @@ public class MirrorsGetTask extends Task {
 		}
 	}
 
+	private void _downloadMirrorsCacheTempFile(File mirrorsCacheTempFile)
+		throws IOException {
+
+		if (_tryLocalNetwork) {
+			File mirrorsMountFile = _getMirrorsMountFile();
+
+			if (mirrorsMountFile.isFile()) {
+				try {
+					_copyFile(mirrorsMountFile, mirrorsCacheTempFile);
+				}
+				catch (IOException ioException) {
+					_deleteFile(mirrorsCacheTempFile);
+
+					if (_verbose) {
+						System.out.println(
+							"Unable to copy from mirrors mount " +
+								mirrorsMountFile.getPath() + ".");
+					}
+				}
+			}
+		}
+
+		if (mirrorsCacheTempFile.exists()) {
+			return;
+		}
+
+		List<URL> urls = new ArrayList<>();
+
+		if (_tryLocalNetwork) {
+			String mirrorsHostname = _getMirrorsHostname();
+			URL nexusTomcatURL = _getNexusTomcatURL();
+
+			if (nexusTomcatURL != null) {
+				urls.add(nexusTomcatURL);
+			}
+			else if (!mirrorsHostname.isEmpty()) {
+				urls.add(_getMirrorsURL());
+			}
+		}
+
+		urls.add(_getLocalURL());
+
+		urls.removeAll(Collections.singleton(null));
+
+		for (URL url : urls) {
+			try {
+				_downloadFile(url, mirrorsCacheTempFile, _retries);
+			}
+			catch (IOException ioException) {
+				if (_verbose) {
+					System.out.println("Unable to connect to " + url + ".");
+				}
+			}
+
+			if (mirrorsCacheTempFile.exists()) {
+				return;
+			}
+		}
+
+		_downloadGCPFile(mirrorsCacheTempFile);
+
+		if (mirrorsCacheTempFile.exists()) {
+			return;
+		}
+
+		URL remoteURL = _getRemoteURL();
+
+		try {
+			_downloadFile(remoteURL, mirrorsCacheTempFile, _retries);
+		}
+		catch (IOException ioException) {
+			_deleteFile(mirrorsCacheTempFile);
+
+			throw ioException;
+		}
+	}
+
 	private void _execute() throws IOException {
 		if (_src.startsWith("file:")) {
 			File srcFile = new File(_src.substring("file:".length()));
@@ -440,112 +519,72 @@ public class MirrorsGetTask extends Task {
 
 		File mirrorsCacheFile = _getMirrorsCacheFile();
 
+		File mirrorsCacheLinkFile = new File(
+			mirrorsCacheFile.getParentFile(),
+			MirrorsCacheLinker.uniqueLinkFileName(mirrorsCacheFile.getName()));
 		File mirrorsCacheTempFile = new File(
 			mirrorsCacheFile.getParentFile(),
-			System.currentTimeMillis() + mirrorsCacheFile.getName());
+			MirrorsCacheLinker.uniqueTempFileName(mirrorsCacheFile.getName()));
 
-		if (mirrorsCacheFile.exists() && !_force) {
-			if (_is7zFileName(_fileName)) {
-				_force = !_is7zFile(mirrorsCacheFile);
-			}
-			else if (_isTarGzFileName(_fileName)) {
-				_force = !_isTarGzFile(mirrorsCacheFile);
-			}
-			else if (_isZipFileName(_fileName)) {
-				_force = !_isZipFile(mirrorsCacheFile);
-			}
-		}
+		MirrorsCacheLinker.sweep(mirrorsCacheFile);
 
-		if (mirrorsCacheFile.exists() && _force) {
-			_deleteFile(mirrorsCacheFile);
-		}
+		try {
+			File readFile = _getReadFile(
+				mirrorsCacheFile, mirrorsCacheLinkFile);
 
-		if (mirrorsCacheTempFile.exists()) {
-			_deleteFile(mirrorsCacheTempFile);
-		}
-
-		if (!mirrorsCacheFile.exists()) {
-			if (_tryLocalNetwork) {
-				File mirrorsMountFile = _getMirrorsMountFile();
-
-				if (mirrorsMountFile.isFile()) {
-					try {
-						_copyFile(mirrorsMountFile, mirrorsCacheTempFile);
-					}
-					catch (IOException ioException) {
-						_deleteFile(mirrorsCacheTempFile);
-
-						if (_verbose) {
-							System.out.println(
-								"Unable to copy from mirrors mount " +
-									mirrorsMountFile.getPath() + ".");
-						}
-					}
-				}
+			if ((readFile != null) && !_force) {
+				_force = !_isValidFile(readFile);
 			}
 
-			if (!mirrorsCacheTempFile.exists()) {
-				List<URL> urls = new ArrayList<>();
+			if ((readFile != null) && _force) {
+				if (MirrorsCacheLinker.isSameFileKey(
+						readFile, mirrorsCacheFile)) {
 
-				if (_tryLocalNetwork) {
-					String mirrorsHostname = _getMirrorsHostname();
-					URL nexusTomcatURL = _getNexusTomcatURL();
-
-					if (nexusTomcatURL != null) {
-						urls.add(nexusTomcatURL);
-					}
-					else if (!mirrorsHostname.isEmpty()) {
-						urls.add(_getMirrorsURL());
-					}
+					_deleteFile(mirrorsCacheFile);
 				}
 
-				urls.add(_getLocalURL());
+				_deleteFile(mirrorsCacheLinkFile);
 
-				urls.removeAll(Collections.singleton(null));
+				readFile = null;
+			}
 
-				for (URL url : urls) {
-					try {
-						_downloadFile(url, mirrorsCacheTempFile, _retries);
-					}
-					catch (IOException ioException) {
-						if (_verbose) {
-							System.out.println(
-								"Unable to connect to " + url + ".");
-						}
-					}
+			if (readFile == null) {
+				_downloadMirrorsCacheTempFile(mirrorsCacheTempFile);
+
+				if (MirrorsCacheLinker.publish(
+						mirrorsCacheTempFile, mirrorsCacheFile)) {
 
 					if (mirrorsCacheTempFile.exists()) {
-						break;
+						readFile = mirrorsCacheTempFile;
+					}
+					else {
+						readFile = mirrorsCacheFile;
 					}
 				}
+				else {
+					System.out.println(
+						mirrorsCacheFile.getPath() +
+							" was already published by another process.");
 
-				if (!mirrorsCacheTempFile.exists()) {
-					_downloadGCPFile(mirrorsCacheTempFile);
+					readFile = _getReadFile(
+						mirrorsCacheFile, mirrorsCacheLinkFile);
 
-					if (!mirrorsCacheTempFile.exists()) {
-						URL remoteURL = _getRemoteURL();
-
-						try {
-							_downloadFile(
-								remoteURL, mirrorsCacheTempFile, _retries);
-						}
-						catch (IOException ioException) {
-							_deleteFile(mirrorsCacheTempFile);
-
-							throw ioException;
-						}
+					if (readFile == null) {
+						readFile = mirrorsCacheTempFile;
 					}
 				}
 			}
 
-			_moveFile(mirrorsCacheTempFile, mirrorsCacheFile);
+			if (_dest.exists() && _dest.isDirectory()) {
+				_copyFile(readFile, new File(_dest, _fileName));
+			}
+			else {
+				_copyFile(readFile, _dest);
+			}
 		}
-
-		if (_dest.exists() && _dest.isDirectory()) {
-			_copyFile(mirrorsCacheFile, new File(_dest, _fileName));
-		}
-		else {
-			_copyFile(mirrorsCacheFile, _dest);
+		finally {
+			_deleteFile(mirrorsCacheLinkFile);
+			_deleteFile(mirrorsCacheTempFile);
 		}
 	}
 
@@ -840,6 +879,26 @@ public class MirrorsGetTask extends Task {
 		return processOutput.toString();
 	}
 
+	private File _getReadFile(
+		File mirrorsCacheFile, File mirrorsCacheLinkFile) {
+
+		File readFile = MirrorsCacheLinker.createReadLink(
+			mirrorsCacheFile, mirrorsCacheLinkFile);
+
+		if (mirrorsCacheFile.equals(readFile)) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("Unable to link ");
+			sb.append(mirrorsCacheFile.getPath());
+			sb.append(". Reading it directly is not safe when the mirrors ");
+			sb.append("cache is shared.");
+
+			System.out.println(sb.toString());
+		}
+
+		return readFile;
+	}
+
 	private URL _getRemoteURL() {
 		if (_hostName == null) {
 			return null;
@@ -1042,6 +1101,22 @@ public class MirrorsGetTask extends Task {
 		return false;
 	}
 
+	private boolean _isValidFile(File file) throws IOException {
+		if (_is7zFileName(_fileName)) {
+			return _is7zFile(file);
+		}
+
+		if (_isTarGzFileName(_fileName)) {
+			return _isTarGzFile(file);
+		}
+
+		if (_isZipFileName(_fileName)) {
+			return _isZipFile(file);
+		}
+
+		return true;
+	}
+
 	private boolean _isValidMD5(File file, URL url) throws IOException {
 		if (_skipChecksum) {
 			return true;
@@ -1131,20 +1206,6 @@ public class MirrorsGetTask extends Task {
 		}
 
 		return false;
-	}
-
-	private void _moveFile(File sourceFile, File destFile) throws IOException {
-		StringBuilder sb = new StringBuilder();
-
-		sb.append("Moving ");
-		sb.append(sourceFile.getPath());
-		sb.append(" to ");
-		sb.append(destFile.getPath());
-		sb.append(".");
-
-		System.out.println(sb.toString());
-
-		sourceFile.renameTo(destFile);
 	}
 
 	private String _normalizePath(String path) {

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/internal/MirrorsCacheLinker.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/internal/MirrorsCacheLinker.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ant.mirrors.get.internal;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Calum Ragan
+ */
+public class MirrorsCacheLinker {
+
+	public static final long MAX_AGE_MILLIS = 24 * 60 * 60 * 1000;
+
+	public static File createReadLink(File cacheFile, File linkFile) {
+		Path cacheFilePath = cacheFile.toPath();
+		Path linkFilePath = linkFile.toPath();
+
+		try {
+			Files.createLink(linkFilePath, cacheFilePath);
+
+			return linkFile;
+		}
+		catch (NoSuchFileException noSuchFileException) {
+			return null;
+		}
+		catch (IOException | UnsupportedOperationException exception) {
+			if (cacheFile.exists()) {
+				return cacheFile;
+			}
+
+			return null;
+		}
+	}
+
+	public static boolean isSameFileKey(File file1, File file2) {
+		Object fileKey1 = _getFileKey(file1);
+
+		if (fileKey1 == null) {
+			return false;
+		}
+
+		Object fileKey2 = _getFileKey(file2);
+
+		if (fileKey2 == null) {
+			return false;
+		}
+
+		return fileKey1.equals(fileKey2);
+	}
+
+	public static boolean publish(File tempFile, File cacheFile)
+		throws IOException {
+
+		Path cacheFilePath = cacheFile.toPath();
+		Path tempFilePath = tempFile.toPath();
+
+		try {
+			Files.createLink(cacheFilePath, tempFilePath);
+
+			return true;
+		}
+		catch (FileAlreadyExistsException fileAlreadyExistsException) {
+			return false;
+		}
+		catch (IOException | UnsupportedOperationException exception) {
+			if (cacheFile.exists()) {
+				return false;
+			}
+
+			return _publishByRename(tempFile, cacheFile);
+		}
+	}
+
+	public static void sweep(File cacheFile) {
+		File parentFile = cacheFile.getParentFile();
+
+		if (parentFile == null) {
+			return;
+		}
+
+		File[] files = parentFile.listFiles();
+
+		if (files == null) {
+			return;
+		}
+
+		long oldestTime = System.currentTimeMillis() - MAX_AGE_MILLIS;
+		Pattern pattern = _getOrphanPattern(cacheFile.getName());
+
+		for (File file : files) {
+			Matcher matcher = pattern.matcher(file.getName());
+
+			if (!matcher.matches()) {
+				continue;
+			}
+
+			long time = Long.parseLong(matcher.group("timestamp"));
+
+			if (time > oldestTime) {
+				continue;
+			}
+
+			file.delete();
+		}
+	}
+
+	public static String uniqueLinkFileName(String fileName) {
+		return _uniquePrefix() + "link-" + fileName;
+	}
+
+	public static String uniqueTempFileName(String fileName) {
+		return _uniquePrefix() + fileName;
+	}
+
+	private static Object _getFileKey(File file) {
+		try {
+			BasicFileAttributes basicFileAttributes = Files.readAttributes(
+				file.toPath(), BasicFileAttributes.class);
+
+			return basicFileAttributes.fileKey();
+		}
+		catch (IOException ioException) {
+			return null;
+		}
+	}
+
+	private static Pattern _getOrphanPattern(String fileName) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("(?<timestamp>\\d{13,18})");
+		sb.append("(-[0-9a-fA-F-]{36}(-link)?-)?");
+		sb.append(Pattern.quote(fileName));
+
+		return Pattern.compile(sb.toString());
+	}
+
+	private static boolean _publishByRename(File tempFile, File cacheFile)
+		throws IOException {
+
+		if (tempFile.renameTo(cacheFile)) {
+			return true;
+		}
+
+		if (cacheFile.exists()) {
+			return false;
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("Unable to publish ");
+		sb.append(tempFile.getPath());
+		sb.append(" to ");
+		sb.append(cacheFile.getPath());
+		sb.append(".");
+
+		throw new IOException(sb.toString());
+	}
+
+	private static String _uniquePrefix() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(System.currentTimeMillis());
+		sb.append("-");
+		sb.append(UUID.randomUUID());
+		sb.append("-");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/internal/MirrorsCacheLinkerTest.java
+++ b/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/internal/MirrorsCacheLinkerTest.java
@@ -1,0 +1,301 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ant.mirrors.get.internal;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Calum Ragan
+ */
+public class MirrorsCacheLinkerTest {
+
+	@Before
+	public void setUp() throws IOException {
+		_cacheFile = new File(temporaryFolder.getRoot(), _FILE_NAME);
+	}
+
+	@Test
+	public void testCreateReadLinkDeletedCacheFile() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		File linkFile = _linkFile();
+
+		File readFile = MirrorsCacheLinker.createReadLink(_cacheFile, linkFile);
+
+		Assert.assertEquals(linkFile, readFile);
+
+		_cacheFile.delete();
+
+		Assert.assertFalse(_cacheFile.exists());
+		Assert.assertEquals("cached", _readFile(readFile));
+	}
+
+	@Test
+	public void testCreateReadLinkMissingCacheFile() {
+		Assert.assertNull(
+			MirrorsCacheLinker.createReadLink(_cacheFile, _linkFile()));
+	}
+
+	@Test
+	public void testIsSameFileKeyReadLink() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		File readFile = MirrorsCacheLinker.createReadLink(
+			_cacheFile, _linkFile());
+
+		Assert.assertTrue(
+			MirrorsCacheLinker.isSameFileKey(readFile, _cacheFile));
+	}
+
+	@Test
+	public void testIsSameFileKeyReplacedCacheFile() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		File readFile = MirrorsCacheLinker.createReadLink(
+			_cacheFile, _linkFile());
+
+		_cacheFile.delete();
+
+		_writeFile(_cacheFile, "replacement");
+
+		Assert.assertFalse(
+			MirrorsCacheLinker.isSameFileKey(readFile, _cacheFile));
+	}
+
+	@Test
+	public void testPublishConcurrent() throws Exception {
+		AtomicInteger publishedCount = new AtomicInteger();
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		List<Throwable> throwables = new CopyOnWriteArrayList<>();
+
+		List<Thread> threads = new ArrayList<>();
+
+		for (int i = 0; i < 16; i++) {
+			String content = "slave-" + i;
+
+			Thread thread = new Thread(
+				() -> {
+					try {
+						File tempFile = _tempFile();
+
+						_writeFile(tempFile, content);
+
+						countDownLatch.await();
+
+						if (MirrorsCacheLinker.publish(tempFile, _cacheFile)) {
+							publishedCount.incrementAndGet();
+						}
+					}
+					catch (Throwable throwable) {
+						throwables.add(throwable);
+					}
+				});
+
+			threads.add(thread);
+
+			thread.start();
+		}
+
+		countDownLatch.countDown();
+
+		for (Thread thread : threads) {
+			thread.join();
+		}
+
+		Assert.assertEquals(throwables.toString(), 0, throwables.size());
+
+		Assert.assertEquals(1, publishedCount.get());
+
+		String content = _readFile(_cacheFile);
+
+		Assert.assertTrue(content, content.startsWith("slave-"));
+	}
+
+	@Test
+	public void testPublishFreeName() throws IOException {
+		File tempFile = _tempFile();
+
+		_writeFile(tempFile, "downloaded");
+
+		Assert.assertTrue(MirrorsCacheLinker.publish(tempFile, _cacheFile));
+
+		Assert.assertEquals("downloaded", _readFile(_cacheFile));
+	}
+
+	@Test
+	public void testPublishTakenName() throws IOException {
+		_writeFile(_cacheFile, "winner");
+
+		File tempFile = _tempFile();
+
+		_writeFile(tempFile, "loser");
+
+		Assert.assertFalse(MirrorsCacheLinker.publish(tempFile, _cacheFile));
+
+		Assert.assertEquals("winner", _readFile(_cacheFile));
+
+		Assert.assertTrue(tempFile.exists());
+	}
+
+	@Test
+	public void testSweep() throws IOException {
+		_testSweep(false, _oldFileName(""));
+		_testSweep(false, _oldFileName("link-"));
+		_testSweep(false, _oldTime() + _FILE_NAME);
+		_testSweep(true, MirrorsCacheLinker.uniqueTempFileName(_FILE_NAME));
+	}
+
+	@Test
+	public void testSweepCacheFile() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		File digitFile = new File(
+			temporaryFolder.getRoot(), "1234567890123.zip");
+
+		_writeFile(digitFile, "other");
+
+		MirrorsCacheLinker.sweep(_cacheFile);
+
+		Assert.assertTrue(_cacheFile.exists());
+		Assert.assertTrue(digitFile.exists());
+
+		MirrorsCacheLinker.sweep(digitFile);
+
+		Assert.assertTrue(digitFile.exists());
+	}
+
+	@Test
+	public void testSweepReadLinkToOldCacheFile() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		Assert.assertTrue(_cacheFile.setLastModified(_oldTime()));
+
+		File readFile = MirrorsCacheLinker.createReadLink(
+			_cacheFile, _linkFile());
+
+		long thresholdTime =
+			System.currentTimeMillis() - MirrorsCacheLinker.MAX_AGE_MILLIS;
+
+		Assert.assertTrue(readFile.lastModified() < thresholdTime);
+
+		MirrorsCacheLinker.sweep(_cacheFile);
+
+		Assert.assertTrue(readFile.exists());
+		Assert.assertEquals("cached", _readFile(readFile));
+	}
+
+	@Test
+	public void testUniqueLinkFileName() {
+		String fileName = MirrorsCacheLinker.uniqueLinkFileName(_FILE_NAME);
+
+		Assert.assertTrue(fileName, fileName.contains("-link-"));
+		Assert.assertTrue(fileName, fileName.endsWith(_FILE_NAME));
+
+		Set<String> fileNames = new HashSet<>();
+
+		for (int i = 0; i < 5000; i++) {
+			fileNames.add(MirrorsCacheLinker.uniqueLinkFileName(_FILE_NAME));
+		}
+
+		Assert.assertEquals(fileNames.toString(), 5000, fileNames.size());
+	}
+
+	@Test
+	public void testUniqueTempFileName() {
+		String fileName = MirrorsCacheLinker.uniqueTempFileName(_FILE_NAME);
+
+		Assert.assertTrue(fileName, fileName.endsWith(_FILE_NAME));
+
+		Set<String> fileNames = new HashSet<>();
+
+		for (int i = 0; i < 5000; i++) {
+			fileNames.add(MirrorsCacheLinker.uniqueTempFileName(_FILE_NAME));
+		}
+
+		Assert.assertEquals(fileNames.toString(), 5000, fileNames.size());
+	}
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private File _linkFile() {
+		return new File(
+			temporaryFolder.getRoot(),
+			MirrorsCacheLinker.uniqueLinkFileName(_FILE_NAME));
+	}
+
+	private String _oldFileName(String linkMarker) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(_oldTime());
+		sb.append("-");
+		sb.append(UUID.randomUUID());
+		sb.append("-");
+		sb.append(linkMarker);
+		sb.append(_FILE_NAME);
+
+		return sb.toString();
+	}
+
+	private long _oldTime() {
+		return System.currentTimeMillis() -
+			(2 * MirrorsCacheLinker.MAX_AGE_MILLIS);
+	}
+
+	private String _readFile(File file) throws IOException {
+		byte[] bytes = Files.readAllBytes(file.toPath());
+
+		return new String(bytes, StandardCharsets.UTF_8);
+	}
+
+	private File _tempFile() {
+		return new File(
+			temporaryFolder.getRoot(),
+			MirrorsCacheLinker.uniqueTempFileName(_FILE_NAME));
+	}
+
+	private void _testSweep(boolean expected, String fileName)
+		throws IOException {
+
+		_writeFile(_cacheFile, "cached");
+
+		File file = new File(temporaryFolder.getRoot(), fileName);
+
+		_writeFile(file, "orphan");
+
+		MirrorsCacheLinker.sweep(_cacheFile);
+
+		Assert.assertEquals(fileName, expected, file.exists());
+	}
+
+	private void _writeFile(File file, String content) throws IOException {
+		Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static final String _FILE_NAME = "7.4.13-ga1.zip";
+
+	private File _cacheFile;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8047

## What Is Being Fixed

On AWS, `/root/.liferay/mirrors` is a symlink to `/mnt/shared/mirrors` — one EFS share used by every process on all eight masters. `MirrorsGetTask` treated it as private. It checked whether a file was cached, spent about ninety seconds downloading, then renamed the temporary file onto the shared name. The check and the rename are separated by the whole download, and the rename replaces whatever is there, so processes overwrote each other and destroyed files other processes were still reading.

Readers failed with `java.io.IOException: Stale file handle` out of `_copyFile`. The call sits in Poshi `setUp`, so Testray reported the cases as blocked rather than failed, which hid the cause. On `test-1-44` build 1281 segment 0, 15 of 23 axes hit this and the segment re-downloaded the 1.23 GiB artifact 26 times. It does not settle on its own, because a file that looks invalid mid-overwrite fails the 7z check, so the task deletes the shared copy and downloads it again.

## How It Is Being Fixed

Publishing goes through `Files.createLink`, which creates the directory entry atomically and fails with `FileAlreadyExistsException` when the name is taken, so the first process to finish wins and the rest read that copy instead of overwriting it. Reading goes through a second hard link, which keeps the inode alive so a concurrent delete or replace cannot break a read in progress, and `NoSuchFileException` from that link replaces the old `exists()` check and closes the check-then-act gap. Before deleting an invalid cache file the task compares `fileKey()` between its own link and the shared name, so it never removes a copy another process has just published.

Temporary and link names carry a UUID, because two processes starting in the same millisecond previously shared a path and corrupted each other's download. Both are deleted in a `finally`, and orphans older than twenty-four hours are swept. The sweep ages files by the timestamp embedded in the name rather than by `lastModified`, since a hard link reports the artifact's own modification time and an mtime-based sweep would delete the link it exists to protect.

Where the filesystem does not support hard links, the publish falls back to the previous `renameTo`, which is safe because an unshared cache has no race to lose. Any `IOException` from the publish is treated as a possibly-lost race and re-checked against the target rather than trusted by exception type, since `FileAlreadyExistsException` is documented as optional.

## PR Check

**pr-check: PASS** — tested on `81dcc531864f732cc1b72926724c91399c4c26c7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "81dcc531864f732cc1b72926724c91399c4c26c7"} -->
