### PR TITLE
LRCI-7966 Add the HTTP endpoint monitor (revised)

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
@@ -29,15 +29,7 @@ public abstract class BaseMonitor implements Monitor {
 	}
 
 	protected int getAttemptTimeoutMillis() {
-		long timeoutSeconds = _monitorConfig.getTimeoutSeconds();
-
-		if (timeoutSeconds <= 0) {
-			timeoutSeconds = _SECONDS_TIMEOUT_DEFAULT;
-		}
-
-		timeoutSeconds = Math.min(timeoutSeconds, Integer.MAX_VALUE / 1000);
-
-		return (int)((timeoutSeconds * 1000) / 3);
+		return (int)(_getTimeoutMillis() / 3);
 	}
 
 	protected String getInvalidValueMessage(
@@ -89,12 +81,28 @@ public abstract class BaseMonitor implements Monitor {
 		return value;
 	}
 
+	protected int getSingleAttemptTimeoutMillis() {
+		long timeoutMillis = _getTimeoutMillis();
+
+		return (int)(timeoutMillis - (timeoutMillis / 10));
+	}
+
 	private String _getKey(String category, String name) {
 		return JenkinsResultsParserUtil.combine(
 			"monitor[", _monitorConfig.getId(), "].", category, "[", name, "]");
 	}
 
-	private static final long _SECONDS_TIMEOUT_DEFAULT = 60;
+	private long _getTimeoutMillis() {
+		long timeoutSeconds = _monitorConfig.getTimeoutSeconds();
+
+		if (timeoutSeconds <= 0) {
+			timeoutSeconds = MonitorConfig.SECONDS_TIMEOUT_DEFAULT;
+		}
+
+		timeoutSeconds = Math.min(timeoutSeconds, Integer.MAX_VALUE / 1000);
+
+		return timeoutSeconds * 1000;
+	}
 
 	private final MonitorConfig _monitorConfig;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/BaseMonitor.java
@@ -84,7 +84,7 @@ public abstract class BaseMonitor implements Monitor {
 	protected int getSingleAttemptTimeoutMillis() {
 		long timeoutMillis = _getTimeoutMillis();
 
-		return (int)(timeoutMillis - (timeoutMillis / 10));
+		return (int)((timeoutMillis - (timeoutMillis / 10)) / 2);
 	}
 
 	private String _getKey(String category, String name) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitor.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+
+import java.io.FileNotFoundException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class HTTPEndpointMonitor extends BaseMonitor {
+
+	public HTTPEndpointMonitor(MonitorConfig monitorConfig) {
+		super(monitorConfig);
+
+		_url = getRequiredParameter("url", monitorConfig.getParameters());
+
+		if (_hasUserInfo(_url)) {
+			throw new IllegalArgumentException(
+				getInvalidValueMessage("parameter", "url", "[REDACTED]"));
+		}
+
+		if (!JenkinsResultsParserUtil.isURL(_url)) {
+			throw new IllegalArgumentException(
+				getInvalidValueMessage("parameter", "url", _url));
+		}
+
+		_latencyMaximumMillis = getLongValue(
+			"threshold", 0, "latency.maximum.millis",
+			monitorConfig.getThresholds());
+	}
+
+	@Override
+	public MonitorResult execute() {
+		long currentTimeMillis =
+			JenkinsResultsParserUtil.getCurrentTimeMillis();
+
+		long startTimestamp = System.currentTimeMillis();
+
+		try {
+			JenkinsResultsParserUtil.toString(
+				_url, false, 0, 0, getSingleAttemptTimeoutMillis());
+		}
+		catch (Exception exception) {
+			return new MonitorResult(
+				_getFailureMessage(exception), null,
+				MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		long latencyMillis = System.currentTimeMillis() - startTimestamp;
+
+		Map<String, String> metrics = new LinkedHashMap<>();
+
+		metrics.put("latency.millis", String.valueOf(latencyMillis));
+
+		if ((_latencyMaximumMillis > 0) &&
+			(latencyMillis > _latencyMaximumMillis)) {
+
+			return new MonitorResult(
+				JenkinsResultsParserUtil.combine(
+					"Endpoint ", _url, " responded in ",
+					String.valueOf(latencyMillis),
+					" ms, exceeding its maximum latency of ",
+					String.valueOf(_latencyMaximumMillis), " ms"),
+				metrics, MonitorResult.Status.CRITICAL, currentTimeMillis);
+		}
+
+		return new MonitorResult(
+			JenkinsResultsParserUtil.combine("Endpoint ", _url, " is OK"),
+			metrics, MonitorResult.Status.OK, currentTimeMillis);
+	}
+
+	private String _getFailureMessage(Exception exception) {
+		if (exception instanceof FileNotFoundException) {
+			return JenkinsResultsParserUtil.combine(
+				"Endpoint ", _url, " was not found");
+		}
+
+		String message = exception.getMessage();
+
+		if (message == null) {
+			Class<?> clazz = exception.getClass();
+
+			message = clazz.getName();
+		}
+
+		Matcher matcher = _responseCodePattern.matcher(message);
+
+		if (matcher.find()) {
+			return JenkinsResultsParserUtil.combine(
+				"Endpoint ", _url, " returned the response code ",
+				matcher.group("responseCode"));
+		}
+
+		return JenkinsResultsParserUtil.combine(
+			"Unable to read ", _url, ": ", message);
+	}
+
+	private boolean _hasUserInfo(String url) {
+		Matcher matcher = _userInfoPattern.matcher(url);
+
+		return matcher.matches();
+	}
+
+	private static final Pattern _responseCodePattern = Pattern.compile(
+		"HTTP response code: (?<responseCode>\\d+)");
+	private static final Pattern _userInfoPattern = Pattern.compile(
+		"(//|[^/?#]*://)?[^/?#]*@.*");
+
+	private final long _latencyMaximumMillis;
+	private final String _url;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitor.java
@@ -22,16 +22,17 @@ public class HTTPEndpointMonitor extends BaseMonitor {
 	public HTTPEndpointMonitor(MonitorConfig monitorConfig) {
 		super(monitorConfig);
 
-		_url = getRequiredParameter("url", monitorConfig.getParameters());
+		_endpointURL = getRequiredParameter(
+			"url", monitorConfig.getParameters());
 
-		if (_hasUserInfo(_url)) {
+		if (_hasUserInfo(_endpointURL)) {
 			throw new IllegalArgumentException(
 				getInvalidValueMessage("parameter", "url", "[REDACTED]"));
 		}
 
-		if (!JenkinsResultsParserUtil.isURL(_url)) {
+		if (!JenkinsResultsParserUtil.isURL(_endpointURL)) {
 			throw new IllegalArgumentException(
-				getInvalidValueMessage("parameter", "url", _url));
+				getInvalidValueMessage("parameter", "url", _endpointURL));
 		}
 
 		_latencyMaximumMillis = getLongValue(
@@ -48,7 +49,7 @@ public class HTTPEndpointMonitor extends BaseMonitor {
 
 		try {
 			JenkinsResultsParserUtil.toString(
-				_url, false, 0, 0, getSingleAttemptTimeoutMillis());
+				_endpointURL, false, 0, 0, getSingleAttemptTimeoutMillis());
 		}
 		catch (Exception exception) {
 			return new MonitorResult(
@@ -67,7 +68,7 @@ public class HTTPEndpointMonitor extends BaseMonitor {
 
 			return new MonitorResult(
 				JenkinsResultsParserUtil.combine(
-					"Endpoint ", _url, " responded in ",
+					"Endpoint ", _endpointURL, " responded in ",
 					String.valueOf(latencyMillis),
 					" ms, exceeding its maximum latency of ",
 					String.valueOf(_latencyMaximumMillis), " ms"),
@@ -75,14 +76,15 @@ public class HTTPEndpointMonitor extends BaseMonitor {
 		}
 
 		return new MonitorResult(
-			JenkinsResultsParserUtil.combine("Endpoint ", _url, " is OK"),
+			JenkinsResultsParserUtil.combine(
+				"Endpoint ", _endpointURL, " is OK"),
 			metrics, MonitorResult.Status.OK, currentTimeMillis);
 	}
 
 	private String _getFailureMessage(Exception exception) {
 		if (exception instanceof FileNotFoundException) {
 			return JenkinsResultsParserUtil.combine(
-				"Endpoint ", _url, " was not found");
+				"Endpoint ", _endpointURL, " was not found");
 		}
 
 		String message = exception.getMessage();
@@ -97,12 +99,12 @@ public class HTTPEndpointMonitor extends BaseMonitor {
 
 		if (matcher.find()) {
 			return JenkinsResultsParserUtil.combine(
-				"Endpoint ", _url, " returned the response code ",
+				"Endpoint ", _endpointURL, " returned the response code ",
 				matcher.group("responseCode"));
 		}
 
 		return JenkinsResultsParserUtil.combine(
-			"Unable to read ", _url, ": ", message);
+			"Unable to read ", _endpointURL, ": ", message);
 	}
 
 	private boolean _hasUserInfo(String url) {
@@ -116,7 +118,7 @@ public class HTTPEndpointMonitor extends BaseMonitor {
 	private static final Pattern _userInfoPattern = Pattern.compile(
 		"(//|[^/?#]*://)?[^/?#]*@.*");
 
+	private final String _endpointURL;
 	private final long _latencyMaximumMillis;
-	private final String _url;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfig.java
@@ -14,6 +14,8 @@ import java.util.Map;
  */
 public class MonitorConfig {
 
+	public static final long SECONDS_TIMEOUT_DEFAULT = 60;
+
 	public MonitorConfig(
 		String id, long intervalSeconds, Map<String, String> parameters,
 		Severity severity, Map<String, String> thresholds, long timeoutSeconds,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorConfigLoader.java
@@ -129,7 +129,10 @@ public class MonitorConfigLoader {
 			_getParameters(buildProperties, id),
 			_getSeverity(buildProperties, id),
 			_getThresholds(buildProperties, id),
-			_getLongProperty(buildProperties, 60, id, "timeout"), type);
+			_getLongProperty(
+				buildProperties, MonitorConfig.SECONDS_TIMEOUT_DEFAULT, id,
+				"timeout"),
+			type);
 	}
 
 	private static Map<String, String> _getParameters(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorFactory.java
@@ -15,10 +15,14 @@ public class MonitorFactory {
 	public static Monitor newMonitor(MonitorConfig monitorConfig) {
 		String type = monitorConfig.getType();
 
-		if (!JenkinsResultsParserUtil.isNullOrEmpty(type) &&
-			type.equals("job-health")) {
+		if (!JenkinsResultsParserUtil.isNullOrEmpty(type)) {
+			if (type.equals("http-endpoint")) {
+				return new HTTPEndpointMonitor(monitorConfig);
+			}
 
-			return new JobHealthMonitor(monitorConfig);
+			if (type.equals("job-health")) {
+				return new JobHealthMonitor(monitorConfig);
+			}
 		}
 
 		throw new IllegalArgumentException("Unknown monitor type: " + type);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/monitor/MonitorRunner.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MonitorRunner {
 
 	public MonitorRunner() {
-		this(60 * 1000);
+		this(MonitorConfig.SECONDS_TIMEOUT_DEFAULT * 1000);
 	}
 
 	public MonitorRunner(long defaultTimeoutMillis) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BuildQueueRebalancerTest.java
@@ -18,8 +18,6 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
 /**
  * @author Calum Ragan
  */
@@ -157,20 +155,10 @@ public class BuildQueueRebalancerTest
 
 		UrlReader urlReader = mockUrlReader();
 
-		Mockito.doThrow(
-			new IOException("Connection refused")
-		).when(
-			urlReader
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
-			Mockito.argThat(
-				readURL ->
-					(readURL != null) &&
-					readURL.contains(
-						_BLACKLISTED_JENKINS_MASTER_NAME +
-							".liferay.com/queue/api/json"))
-		);
+		setUrlReaderException(
+			new IOException("Connection refused"),
+			_BLACKLISTED_JENKINS_MASTER_NAME + ".liferay.com/queue/api/json",
+			urlReader);
 
 		setUrlReaderOutput(
 			String.valueOf(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -113,17 +113,9 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		String queueItemAPIURL = "http://test-9-1/queue/item/7800/api/json";
 
-		Mockito.doThrow(
-			new FileNotFoundException(queueItemAPIURL)
-		).when(
-			urlReader
-		).doRead(
-			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
-			Mockito.argThat(
-				readURL ->
-					(readURL != null) && readURL.contains(queueItemAPIURL))
-		);
+		setUrlReaderException(
+			new FileNotFoundException(queueItemAPIURL), queueItemAPIURL,
+			urlReader);
 
 		ByteArrayOutputStream byteArrayOutputStream =
 			new ByteArrayOutputStream();

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -273,14 +273,15 @@ public class Test {
 	}
 
 	protected void verifyUrlReaderRead(
-			boolean checkCache, int timeoutMillis, UrlReader urlReader)
+			boolean checkCache, int maxRetries, int timeoutMillis,
+			UrlReader urlReader)
 		throws Exception {
 
 		Mockito.verify(
 			urlReader
 		).doRead(
 			Mockito.eq(checkCache), Mockito.any(), Mockito.any(),
-			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(),
+			Mockito.eq(maxRetries), Mockito.any(), Mockito.anyInt(),
 			Mockito.eq(timeoutMillis), Mockito.anyString()
 		);
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -199,12 +199,12 @@ public class Test {
 		);
 	}
 
-	protected void setUrlReaderOutput(
-			String standardOut, String url, UrlReader urlReader)
+	protected void setUrlReaderException(
+			Exception exception, String url, UrlReader urlReader)
 		throws Exception {
 
-		Mockito.doAnswer(
-			invocation -> new ByteArrayInputStream(standardOut.getBytes())
+		Mockito.doThrow(
+			exception
 		).when(
 			urlReader
 		).doRead(
@@ -213,6 +213,34 @@ public class Test {
 			Mockito.argThat(
 				readURL -> (readURL != null) && readURL.contains(url))
 		);
+	}
+
+	protected void setUrlReaderOutput(
+			long delayMillis, String standardOut, String url,
+			UrlReader urlReader)
+		throws Exception {
+
+		Mockito.doAnswer(
+			invocation -> {
+				JenkinsResultsParserUtil.sleep(delayMillis);
+
+				return new ByteArrayInputStream(standardOut.getBytes());
+			}
+		).when(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.argThat(
+				readURL -> (readURL != null) && readURL.contains(url))
+		);
+	}
+
+	protected void setUrlReaderOutput(
+			String standardOut, String url, UrlReader urlReader)
+		throws Exception {
+
+		setUrlReaderOutput(0, standardOut, url, urlReader);
 	}
 
 	protected void testEquals(Object expected, Object actual) {
@@ -242,6 +270,19 @@ public class Test {
 			"file:" +
 				JenkinsResultsParserUtil.getCanonicalPath(dependenciesDir),
 			"${dependencies.url}/" + path);
+	}
+
+	protected void verifyUrlReaderRead(
+			boolean checkCache, int timeoutMillis, UrlReader urlReader)
+		throws Exception {
+
+		Mockito.verify(
+			urlReader
+		).doRead(
+			Mockito.eq(checkCache), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(),
+			Mockito.eq(timeoutMillis), Mockito.anyString()
+		);
 	}
 
 	protected List<File> dependenciesDirs = getDependenciesDirs(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -200,11 +200,11 @@ public class Test {
 	}
 
 	protected void setUrlReaderException(
-			Exception exception, String url, UrlReader urlReader)
+			IOException ioException, String url, UrlReader urlReader)
 		throws Exception {
 
 		Mockito.doThrow(
-			exception
+			ioException
 		).when(
 			urlReader
 		).doRead(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/BaseMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/BaseMonitorTest.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class BaseMonitorTest extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testGetAttemptTimeoutMillis() {
+		BaseMonitor baseMonitor = _newBaseMonitor(60);
+
+		testEquals(20000, baseMonitor.getAttemptTimeoutMillis());
+	}
+
+	@Test
+	public void testGetAttemptTimeoutMillisClampedTimeout() {
+		BaseMonitor baseMonitor = _newBaseMonitor(Long.MAX_VALUE);
+
+		testEquals(715827666, baseMonitor.getAttemptTimeoutMillis());
+	}
+
+	@Test
+	public void testGetAttemptTimeoutMillisNonPositiveTimeout() {
+		BaseMonitor baseMonitor = _newBaseMonitor(0);
+
+		testEquals(20000, baseMonitor.getAttemptTimeoutMillis());
+	}
+
+	@Test
+	public void testGetSingleAttemptTimeoutMillis() {
+		BaseMonitor baseMonitor = _newBaseMonitor(10);
+
+		testEquals(9000, baseMonitor.getSingleAttemptTimeoutMillis());
+	}
+
+	@Test
+	public void testGetSingleAttemptTimeoutMillisClampedTimeout() {
+		BaseMonitor baseMonitor = _newBaseMonitor(Long.MAX_VALUE);
+
+		testEquals(1932734700, baseMonitor.getSingleAttemptTimeoutMillis());
+	}
+
+	private BaseMonitor _newBaseMonitor(long timeoutSeconds) {
+		return new TestBaseMonitor(
+			new MonitorConfig(
+				RandomTestUtil.randomString(), 0, null,
+				MonitorConfig.Severity.MEDIUM, null, timeoutSeconds,
+				RandomTestUtil.randomString()));
+	}
+
+	private static class TestBaseMonitor extends BaseMonitor {
+
+		@Override
+		public MonitorResult execute() {
+			return new MonitorResult(
+				RandomTestUtil.randomString(), null, MonitorResult.Status.OK,
+				System.currentTimeMillis());
+		}
+
+		private TestBaseMonitor(MonitorConfig monitorConfig) {
+			super(monitorConfig);
+		}
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/BaseMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/BaseMonitorTest.java
@@ -50,26 +50,18 @@ public class BaseMonitorTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	private BaseMonitor _newBaseMonitor(long timeoutSeconds) {
-		return new TestBaseMonitor(
+		return new BaseMonitor(
 			new MonitorConfig(
 				RandomTestUtil.randomString(), 0, null,
 				MonitorConfig.Severity.MEDIUM, null, timeoutSeconds,
-				RandomTestUtil.randomString()));
-	}
+				RandomTestUtil.randomString())) {
 
-	private static class TestBaseMonitor extends BaseMonitor {
+			@Override
+			public MonitorResult execute() {
+				return null;
+			}
 
-		@Override
-		public MonitorResult execute() {
-			return new MonitorResult(
-				RandomTestUtil.randomString(), null, MonitorResult.Status.OK,
-				System.currentTimeMillis());
-		}
-
-		private TestBaseMonitor(MonitorConfig monitorConfig) {
-			super(monitorConfig);
-		}
-
+		};
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/BaseMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/BaseMonitorTest.java
@@ -39,14 +39,14 @@ public class BaseMonitorTest extends com.liferay.jenkins.results.parser.Test {
 	public void testGetSingleAttemptTimeoutMillis() {
 		BaseMonitor baseMonitor = _newBaseMonitor(10);
 
-		testEquals(9000, baseMonitor.getSingleAttemptTimeoutMillis());
+		testEquals(4500, baseMonitor.getSingleAttemptTimeoutMillis());
 	}
 
 	@Test
 	public void testGetSingleAttemptTimeoutMillisClampedTimeout() {
 		BaseMonitor baseMonitor = _newBaseMonitor(Long.MAX_VALUE);
 
-		testEquals(1932734700, baseMonitor.getSingleAttemptTimeoutMillis());
+		testEquals(966367350, baseMonitor.getSingleAttemptTimeoutMillis());
 	}
 
 	private BaseMonitor _newBaseMonitor(long timeoutSeconds) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
@@ -267,23 +267,23 @@ public class HTTPEndpointMonitorTest
 	private void _testHTTPEndpointMonitorUserInfo(String urlPrefix) {
 		Properties monitorProperties = _newMonitorProperties();
 
+		String password = RandomTestUtil.randomString();
+
 		monitorProperties.setProperty(
 			"monitor[a].parameter[url]",
 			JenkinsResultsParserUtil.combine(
-				urlPrefix, RandomTestUtil.randomString(), ":", _PASSWORD, "@",
+				urlPrefix, RandomTestUtil.randomString(), ":", password, "@",
 				RandomTestUtil.randomString()));
 
 		String message =
 			_testHTTPEndpointMonitorExpectedIllegalArgumentException(
 				monitorProperties);
 
-		Assert.assertFalse(message.contains(_PASSWORD));
+		Assert.assertFalse(message.contains(password));
 		Assert.assertTrue(message.contains("[REDACTED]"));
 	}
 
 	private static final long _MILLIS_LATENCY = 50;
-
-	private static final String _PASSWORD = "correct-horse-battery-staple";
 
 	private static final String _URL = "https://repository.liferay.com";
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
@@ -153,7 +153,7 @@ public class HTTPEndpointMonitorTest
 
 		Assert.assertNotNull(metrics.get("latency.millis"));
 
-		verifyUrlReaderRead(false, 0, 54000, urlReader);
+		verifyUrlReaderRead(false, 0, 27000, urlReader);
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
@@ -55,9 +55,9 @@ public class HTTPEndpointMonitorTest
 
 	@Test
 	public void testExecuteLatencyMaximumWithinBound() throws Exception {
-		_testExecuteLatencyMaximumWithinBound(null);
 		_testExecuteLatencyMaximumWithinBound("0");
 		_testExecuteLatencyMaximumWithinBound("60000");
+		_testExecuteLatencyMaximumWithinBound(null);
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
@@ -55,47 +55,9 @@ public class HTTPEndpointMonitorTest
 
 	@Test
 	public void testExecuteLatencyMaximumWithinBound() throws Exception {
-		UrlReader urlReader = mockUrlReader();
-
-		setUrlReaderOutput(RandomTestUtil.randomString(), _URL, urlReader);
-
-		Properties monitorProperties = _newMonitorProperties();
-
-		monitorProperties.setProperty(
-			"monitor[a].threshold[latency.maximum.millis]", "60000");
-
-		MonitorResult monitorResult = _execute(monitorProperties);
-
-		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
-	}
-
-	@Test
-	public void testExecuteLatencyMaximumWithoutThreshold() throws Exception {
-		UrlReader urlReader = mockUrlReader();
-
-		setUrlReaderOutput(
-			_MILLIS_LATENCY, RandomTestUtil.randomString(), _URL, urlReader);
-
-		MonitorResult monitorResult = _execute(_newMonitorProperties());
-
-		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
-	}
-
-	@Test
-	public void testExecuteLatencyMaximumWithZeroThreshold() throws Exception {
-		UrlReader urlReader = mockUrlReader();
-
-		setUrlReaderOutput(
-			_MILLIS_LATENCY, RandomTestUtil.randomString(), _URL, urlReader);
-
-		Properties monitorProperties = _newMonitorProperties();
-
-		monitorProperties.setProperty(
-			"monitor[a].threshold[latency.maximum.millis]", "0");
-
-		MonitorResult monitorResult = _execute(monitorProperties);
-
-		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		_testExecuteLatencyMaximumWithinBound(null);
+		_testExecuteLatencyMaximumWithinBound("0");
+		_testExecuteLatencyMaximumWithinBound("60000");
 	}
 
 	@Test
@@ -253,6 +215,28 @@ public class HTTPEndpointMonitorTest
 		return monitorProperties;
 	}
 
+	private void _testExecuteLatencyMaximumWithinBound(
+			String latencyMaximumMillis)
+		throws Exception {
+
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			_MILLIS_LATENCY, RandomTestUtil.randomString(), _URL, urlReader);
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		if (latencyMaximumMillis != null) {
+			monitorProperties.setProperty(
+				"monitor[a].threshold[latency.maximum.millis]",
+				latencyMaximumMillis);
+		}
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
 	private void _testHTTPEndpointMonitorAtSignBeyondAuthority(
 		String separator) {
 
@@ -324,6 +308,7 @@ public class HTTPEndpointMonitorTest
 
 	private static final long _MILLIS_LATENCY = 50;
 
-	private static final String _URL = "https://repository.liferay.com";
+	private static final String _URL =
+		"https://" + RandomTestUtil.randomString();
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
@@ -1,0 +1,290 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser.monitor;
+
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.RandomTestUtil;
+import com.liferay.jenkins.results.parser.UrlReader;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import java.net.SocketTimeoutException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Brittney Nguyen
+ */
+public class HTTPEndpointMonitorTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testExecuteLatencyMaximum() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			_MILLIS_LATENCY, RandomTestUtil.randomString(), _URL, urlReader);
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].threshold[latency.maximum.millis]", "1");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"Endpoint ", _URL, " responded in ",
+				metrics.get("latency.millis"),
+				" ms, exceeding its maximum latency of 1 ms"),
+			monitorResult.getMessage());
+	}
+
+	@Test
+	public void testExecuteLatencyMaximumWithinBound() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(RandomTestUtil.randomString(), _URL, urlReader);
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].threshold[latency.maximum.millis]", "60000");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteLatencyMaximumWithoutThreshold() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			_MILLIS_LATENCY, RandomTestUtil.randomString(), _URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
+	public void testExecuteMissingFailureMessage() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderException(new IOException(), _URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"Unable to read ", _URL, ": java.io.IOException"),
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		Assert.assertTrue(metrics.isEmpty());
+	}
+
+	@Test
+	public void testExecuteNotFound() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderException(new FileNotFoundException(_URL), _URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"Endpoint ", _URL, " was not found"),
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		Assert.assertTrue(metrics.isEmpty());
+	}
+
+	@Test
+	public void testExecuteOK() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(RandomTestUtil.randomString(), _URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+		testEquals(
+			JenkinsResultsParserUtil.combine("Endpoint ", _URL, " is OK"),
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		Assert.assertNotNull(metrics.get("latency.millis"));
+
+		verifyUrlReaderRead(false, 54000, urlReader);
+	}
+
+	@Test
+	public void testExecuteResponseCode() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderException(
+			new IOException(
+				"Server returned HTTP response code: 503 for URL: " + _URL),
+			_URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"Endpoint ", _URL, " returned the response code 503"),
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		Assert.assertTrue(metrics.isEmpty());
+	}
+
+	@Test
+	public void testExecuteTimeout() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderException(
+			new SocketTimeoutException("Read timed out"), _URL, urlReader);
+
+		MonitorResult monitorResult = _execute(_newMonitorProperties());
+
+		testEquals(MonitorResult.Status.CRITICAL, monitorResult.getStatus());
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"Unable to read ", _URL, ": Read timed out"),
+			monitorResult.getMessage());
+
+		Map<String, String> metrics = monitorResult.getMetrics();
+
+		Assert.assertTrue(metrics.isEmpty());
+	}
+
+	@Test
+	public void testHTTPEndpointMonitor() {
+		_testHTTPEndpointMonitorInvalidProperty(
+			"monitor[a].parameter[url]",
+			"file:///" + RandomTestUtil.randomString());
+		_testHTTPEndpointMonitorInvalidProperty(
+			"monitor[a].parameter[url]", RandomTestUtil.randomString());
+		_testHTTPEndpointMonitorInvalidProperty(
+			"monitor[a].threshold[latency.maximum.millis]", "-1");
+		_testHTTPEndpointMonitorInvalidProperty(
+			"monitor[a].threshold[latency.maximum.millis]", "not-a-number");
+
+		_testHTTPEndpointMonitorMissingProperty("monitor[a].parameter[url]");
+	}
+
+	@Test
+	public void testHTTPEndpointMonitorUserInfo() {
+		_testHTTPEndpointMonitorUserInfo("");
+		_testHTTPEndpointMonitorUserInfo("//");
+		_testHTTPEndpointMonitorUserInfo("htps://");
+		_testHTTPEndpointMonitorUserInfo("https://");
+	}
+
+	private MonitorResult _execute(Properties monitorProperties) {
+		HTTPEndpointMonitor httpEndpointMonitor = _newHTTPEndpointMonitor(
+			monitorProperties);
+
+		return httpEndpointMonitor.execute();
+	}
+
+	private HTTPEndpointMonitor _newHTTPEndpointMonitor(
+		Properties monitorProperties) {
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(monitorProperties);
+
+		return new HTTPEndpointMonitor(monitorConfigs.get(0));
+	}
+
+	private Properties _newMonitorProperties() {
+		Properties monitorProperties = new Properties();
+
+		monitorProperties.setProperty("monitor[a].parameter[url]", _URL);
+		monitorProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		return monitorProperties;
+	}
+
+	private String _testHTTPEndpointMonitorExpectedIllegalArgumentException(
+		Properties monitorProperties) {
+
+		try {
+			_newHTTPEndpointMonitor(monitorProperties);
+
+			Assert.fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException illegalArgumentException) {
+			return illegalArgumentException.getMessage();
+		}
+
+		return null;
+	}
+
+	private void _testHTTPEndpointMonitorInvalidProperty(
+		String name, String value) {
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(name, value);
+
+		_testHTTPEndpointMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	private void _testHTTPEndpointMonitorMissingProperty(String name) {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.remove(name);
+
+		_testHTTPEndpointMonitorExpectedIllegalArgumentException(
+			monitorProperties);
+	}
+
+	private void _testHTTPEndpointMonitorUserInfo(String urlPrefix) {
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[url]",
+			JenkinsResultsParserUtil.combine(
+				urlPrefix, RandomTestUtil.randomString(), ":", _PASSWORD, "@",
+				RandomTestUtil.randomString()));
+
+		String message =
+			_testHTTPEndpointMonitorExpectedIllegalArgumentException(
+				monitorProperties);
+
+		Assert.assertFalse(message.contains(_PASSWORD));
+		Assert.assertTrue(message.contains("[REDACTED]"));
+	}
+
+	private static final long _MILLIS_LATENCY = 50;
+
+	private static final String _PASSWORD = "correct-horse-battery-staple";
+
+	private static final String _URL = "https://repository.liferay.com";
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/HTTPEndpointMonitorTest.java
@@ -82,6 +82,23 @@ public class HTTPEndpointMonitorTest
 	}
 
 	@Test
+	public void testExecuteLatencyMaximumWithZeroThreshold() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			_MILLIS_LATENCY, RandomTestUtil.randomString(), _URL, urlReader);
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].threshold[latency.maximum.millis]", "0");
+
+		MonitorResult monitorResult = _execute(monitorProperties);
+
+		testEquals(MonitorResult.Status.OK, monitorResult.getStatus());
+	}
+
+	@Test
 	public void testExecuteMissingFailureMessage() throws Exception {
 		UrlReader urlReader = mockUrlReader();
 
@@ -136,7 +153,7 @@ public class HTTPEndpointMonitorTest
 
 		Assert.assertNotNull(metrics.get("latency.millis"));
 
-		verifyUrlReaderRead(false, 54000, urlReader);
+		verifyUrlReaderRead(false, 0, 54000, urlReader);
 	}
 
 	@Test
@@ -197,6 +214,13 @@ public class HTTPEndpointMonitorTest
 	}
 
 	@Test
+	public void testHTTPEndpointMonitorAtSignBeyondAuthority() {
+		_testHTTPEndpointMonitorAtSignBeyondAuthority("#");
+		_testHTTPEndpointMonitorAtSignBeyondAuthority("/");
+		_testHTTPEndpointMonitorAtSignBeyondAuthority("?");
+	}
+
+	@Test
 	public void testHTTPEndpointMonitorUserInfo() {
 		_testHTTPEndpointMonitorUserInfo("");
 		_testHTTPEndpointMonitorUserInfo("//");
@@ -227,6 +251,21 @@ public class HTTPEndpointMonitorTest
 		monitorProperties.setProperty("monitor[a].type", "http-endpoint");
 
 		return monitorProperties;
+	}
+
+	private void _testHTTPEndpointMonitorAtSignBeyondAuthority(
+		String separator) {
+
+		Properties monitorProperties = _newMonitorProperties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[url]",
+			JenkinsResultsParserUtil.combine(
+				"https://", RandomTestUtil.randomString(), separator,
+				RandomTestUtil.randomString(), "@",
+				RandomTestUtil.randomString()));
+
+		_newHTTPEndpointMonitor(monitorProperties);
 	}
 
 	private String _testHTTPEndpointMonitorExpectedIllegalArgumentException(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/monitor/MonitorFactoryTest.java
@@ -21,6 +21,23 @@ public class MonitorFactoryTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
+	public void testNewMonitorHTTPEndpoint() {
+		Properties monitorProperties = new Properties();
+
+		monitorProperties.setProperty(
+			"monitor[a].parameter[url]",
+			"https://" + RandomTestUtil.randomString());
+		monitorProperties.setProperty("monitor[a].type", "http-endpoint");
+
+		List<MonitorConfig> monitorConfigs =
+			MonitorConfigLoader.getMonitorConfigs(monitorProperties);
+
+		Monitor monitor = MonitorFactory.newMonitor(monitorConfigs.get(0));
+
+		Assert.assertTrue(monitor instanceof HTTPEndpointMonitor);
+	}
+
+	@Test
 	public void testNewMonitorJobHealth() {
 		String masterName = RandomTestUtil.randomString();
 


### PR DESCRIPTION
[LRCI-7966](https://liferay.atlassian.net/browse/LRCI-7966)

Revises [#4529](https://github.com/pyoo47/liferay-portal/pull/4529) (opened by @brittneyq) with the following follow-up commits:

- [c8cd530aa589](https://github.com/pyoo47/liferay-portal/commit/c8cd530aa589ae460c8057dc07a83fc4cf8f5de1) LRCI-7966 Sort
- [6e9c5c49cfca](https://github.com/pyoo47/liferay-portal/commit/6e9c5c49cfca3cbbcdba16618b38aeae78257037) LRCI-7966 Inline the single-use BaseMonitor subclass
- [5d356f8bc58e](https://github.com/pyoo47/liferay-portal/commit/5d356f8bc58e0dc596a7730fec1b6d758809c969) LRCI-7966 Narrow setUrlReaderException to IOException
