### PR TITLE
[DEV-ONLY] LRCI-8153 Probe disk usage and slave-mem routing for the upgrade performance batch

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15455,6 +15455,12 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					/>
 
 					<delete file="${liferay.home}/data-archive-portal-partition-large.zip" />
+
+					<echo>[DEV-ONLY] df after data archive expansion</echo>
+
+					<exec executable="df">
+						<arg value="--human-readable" />
+					</exec>
 				</then>
 			</elseif>
 			<else>
@@ -17773,6 +17779,18 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 	<target name="upgrade-legacy-database">
 		<lstopwatch action="start" name="upgrade-legacy-database" />
 
+		<echo>[DEV-ONLY] df before the upgrade, after the database import</echo>
+
+		<exec executable="df">
+			<arg value="--human-readable" />
+		</exec>
+
+		<exec executable="du">
+			<arg value="--human-readable" />
+			<arg value="--max-depth=1" />
+			<arg value="${liferay.home}" />
+		</exec>
+
 		<prepare-database-upgrade-properties />
 
 		<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
@@ -17830,6 +17848,12 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 				</java>
 			</try>
 			<catch>
+				<echo>[DEV-ONLY] df at upgrade failure</echo>
+
+				<exec executable="df">
+					<arg value="--human-readable" />
+				</exec>
+
 				<antcall target="print-jstack-logs">
 					<param name="process.name" value="DBUpgrader" />
 				</antcall>

--- a/test.properties
+++ b/test.properties
@@ -2396,6 +2396,7 @@
     test.batch.size[workspaces-compile]=1
     test.batch.size[workspaces-compile-jdk11]=1
 
+    test.batch.slave.label[functional-upgrade-tomcat101-mysql80]=slave-mem
     test.batch.slave.label[modules-compile]=slave-mem
     test.batch.slave.label[playwright-js-tomcat101-postgresql163][analytics-cloud]=slave-1
 


### PR DESCRIPTION
- [LRCI-8153](https://liferay.atlassian.net/browse/LRCI-8153)

## Summary

Throwaway probe, not a fix. Tests whether the `functional-upgrade-tomcat101-mysql80` ENOSPC can be avoided without adding disk, and measures the peak disk usage that is currently unknown.

Two independent changes, each droppable on its own:

- Prints `df` after the data archive expands, entering the upgrade, and at upgrade failure, plus `du` on the Liferay home. The container prints `df` only once at startup today, so nobody knows how much a large partitioned 7.4.13 upgrade actually consumes.
- Routes the batch to `slave-mem`. These cases declare `minimum.slave.ram=24` but land on 15 GiB instances, and a smaller InnoDB buffer pool means more MySQL temp file spill, which is what fills the volume.

Self-targeted and `[DEV-ONLY]`. Not for forwarding.
