### PR TITLE
LRCI-8047 Stop MirrorsGetTask from clobbering the shared mirrors cache

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -25,6 +25,10 @@ import java.net.URLConnection;
 import java.net.URLDecoder;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 
 import java.util.ArrayList;
 import java.util.Base64;
@@ -33,6 +37,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
@@ -212,6 +217,93 @@ public class MirrorsGetTask extends Task {
 	public void setVerbose(boolean verbose) {
 		_verbose = verbose;
 	}
+
+	protected File createReadLink(File cacheFile, File linkFile) {
+		Path cacheFilePath = cacheFile.toPath();
+		Path linkFilePath = linkFile.toPath();
+
+		try {
+			Files.createLink(linkFilePath, cacheFilePath);
+
+			return linkFile;
+		}
+		catch (NoSuchFileException noSuchFileException) {
+			return null;
+		}
+		catch (IOException | UnsupportedOperationException exception) {
+			if (cacheFile.exists()) {
+				return cacheFile;
+			}
+
+			return null;
+		}
+	}
+
+	protected boolean publish(File tempFile, File cacheFile)
+		throws IOException {
+
+		Path cacheFilePath = cacheFile.toPath();
+		Path tempFilePath = tempFile.toPath();
+
+		try {
+			Files.createLink(cacheFilePath, tempFilePath);
+
+			return true;
+		}
+		catch (FileAlreadyExistsException fileAlreadyExistsException) {
+			return false;
+		}
+		catch (IOException | UnsupportedOperationException exception) {
+			if (cacheFile.exists()) {
+				return false;
+			}
+
+			return _publishByRename(tempFile, cacheFile);
+		}
+	}
+
+	protected void sweep(File cacheFile) {
+		File parentFile = cacheFile.getParentFile();
+
+		if (parentFile == null) {
+			return;
+		}
+
+		File[] files = parentFile.listFiles();
+
+		if (files == null) {
+			return;
+		}
+
+		Pattern pattern = _getOrphanPattern(cacheFile.getName());
+		long thresholdTime = System.currentTimeMillis() - MAX_AGE_MILLIS;
+
+		for (File file : files) {
+			Matcher matcher = pattern.matcher(file.getName());
+
+			if (!matcher.matches()) {
+				continue;
+			}
+
+			long time = Long.parseLong(matcher.group("timestamp"));
+
+			if (time > thresholdTime) {
+				continue;
+			}
+
+			file.delete();
+		}
+	}
+
+	protected File uniqueLinkFile(File cacheFile) {
+		return _uniqueFile(cacheFile, _LINK_MARKER);
+	}
+
+	protected File uniqueTempFile(File cacheFile) {
+		return _uniqueFile(cacheFile, "");
+	}
+
+	protected static final long MAX_AGE_MILLIS = 24 * 60 * 60 * 1000;
 
 	private void _copyFile(File sourceFile, File targetFile)
 		throws IOException {
@@ -411,6 +503,83 @@ public class MirrorsGetTask extends Task {
 		}
 	}
 
+	private void _downloadMirrorsCacheTempFile(File mirrorsCacheTempFile)
+		throws IOException {
+
+		if (_tryLocalNetwork) {
+			File mirrorsMountFile = _getMirrorsMountFile();
+
+			if (mirrorsMountFile.isFile()) {
+				try {
+					_copyFile(mirrorsMountFile, mirrorsCacheTempFile);
+				}
+				catch (IOException ioException) {
+					_deleteFile(mirrorsCacheTempFile);
+
+					if (_verbose) {
+						System.out.println(
+							"Unable to copy from mirrors mount " +
+								mirrorsMountFile.getPath() + ".");
+					}
+				}
+			}
+		}
+
+		if (_isValidTempFile(mirrorsCacheTempFile)) {
+			return;
+		}
+
+		List<URL> urls = new ArrayList<>();
+
+		if (_tryLocalNetwork) {
+			String mirrorsHostname = _getMirrorsHostname();
+			URL nexusTomcatURL = _getNexusTomcatURL();
+
+			if (nexusTomcatURL != null) {
+				urls.add(nexusTomcatURL);
+			}
+			else if (!mirrorsHostname.isEmpty()) {
+				urls.add(_getMirrorsURL());
+			}
+		}
+
+		urls.add(_getLocalURL());
+
+		urls.removeAll(Collections.singleton(null));
+
+		for (URL url : urls) {
+			try {
+				_downloadFile(url, mirrorsCacheTempFile, _retries);
+			}
+			catch (IOException ioException) {
+				if (_verbose) {
+					System.out.println("Unable to connect to " + url + ".");
+				}
+			}
+
+			if (mirrorsCacheTempFile.exists()) {
+				return;
+			}
+		}
+
+		_downloadGCPFile(mirrorsCacheTempFile);
+
+		if (_isValidTempFile(mirrorsCacheTempFile)) {
+			return;
+		}
+
+		URL remoteURL = _getRemoteURL();
+
+		try {
+			_downloadFile(remoteURL, mirrorsCacheTempFile, _retries);
+		}
+		catch (IOException ioException) {
+			_deleteFile(mirrorsCacheTempFile);
+
+			throw ioException;
+		}
+	}
+
 	private void _execute() throws IOException {
 		if (_src.startsWith("file:")) {
 			File srcFile = new File(_src.substring("file:".length()));
@@ -440,112 +609,64 @@ public class MirrorsGetTask extends Task {
 
 		File mirrorsCacheFile = _getMirrorsCacheFile();
 
-		File mirrorsCacheTempFile = new File(
-			mirrorsCacheFile.getParentFile(),
-			System.currentTimeMillis() + mirrorsCacheFile.getName());
+		File mirrorsCacheLinkFile = uniqueLinkFile(mirrorsCacheFile);
+		File mirrorsCacheTempFile = uniqueTempFile(mirrorsCacheFile);
 
-		if (mirrorsCacheFile.exists() && !_force) {
-			if (_is7zFileName(_fileName)) {
-				_force = !_is7zFile(mirrorsCacheFile);
-			}
-			else if (_isTarGzFileName(_fileName)) {
-				_force = !_isTarGzFile(mirrorsCacheFile);
-			}
-			else if (_isZipFileName(_fileName)) {
-				_force = !_isZipFile(mirrorsCacheFile);
-			}
-		}
+		sweep(mirrorsCacheFile);
 
-		if (mirrorsCacheFile.exists() && _force) {
-			_deleteFile(mirrorsCacheFile);
-		}
+		try {
+			File readFile = null;
 
-		if (mirrorsCacheTempFile.exists()) {
-			_deleteFile(mirrorsCacheTempFile);
-		}
+			if (!_force) {
+				readFile = _getReadFile(mirrorsCacheFile, mirrorsCacheLinkFile);
 
-		if (!mirrorsCacheFile.exists()) {
-			if (_tryLocalNetwork) {
-				File mirrorsMountFile = _getMirrorsMountFile();
+				if ((readFile != null) && !_isValidFile(readFile)) {
+					_deleteFile(mirrorsCacheFile);
+					_deleteFile(mirrorsCacheLinkFile);
 
-				if (mirrorsMountFile.isFile()) {
-					try {
-						_copyFile(mirrorsMountFile, mirrorsCacheTempFile);
-					}
-					catch (IOException ioException) {
-						_deleteFile(mirrorsCacheTempFile);
-
-						if (_verbose) {
-							System.out.println(
-								"Unable to copy from mirrors mount " +
-									mirrorsMountFile.getPath() + ".");
-						}
-					}
+					readFile = null;
 				}
 			}
 
-			if (!mirrorsCacheTempFile.exists()) {
-				List<URL> urls = new ArrayList<>();
+			if (readFile == null) {
+				_downloadMirrorsCacheTempFile(mirrorsCacheTempFile);
 
-				if (_tryLocalNetwork) {
-					String mirrorsHostname = _getMirrorsHostname();
-					URL nexusTomcatURL = _getNexusTomcatURL();
-
-					if (nexusTomcatURL != null) {
-						urls.add(nexusTomcatURL);
-					}
-					else if (!mirrorsHostname.isEmpty()) {
-						urls.add(_getMirrorsURL());
-					}
+				if (_force) {
+					_deleteFile(mirrorsCacheFile);
 				}
 
-				urls.add(_getLocalURL());
-
-				urls.removeAll(Collections.singleton(null));
-
-				for (URL url : urls) {
-					try {
-						_downloadFile(url, mirrorsCacheTempFile, _retries);
-					}
-					catch (IOException ioException) {
-						if (_verbose) {
-							System.out.println(
-								"Unable to connect to " + url + ".");
-						}
-					}
-
+				if (publish(mirrorsCacheTempFile, mirrorsCacheFile)) {
 					if (mirrorsCacheTempFile.exists()) {
-						break;
+						readFile = mirrorsCacheTempFile;
+					}
+					else {
+						readFile = mirrorsCacheFile;
 					}
 				}
+				else {
+					System.out.println(
+						mirrorsCacheFile.getPath() +
+							" was already published by another process.");
 
-				if (!mirrorsCacheTempFile.exists()) {
-					_downloadGCPFile(mirrorsCacheTempFile);
+					readFile = _getReadFile(
+						mirrorsCacheFile, mirrorsCacheLinkFile);
 
-					if (!mirrorsCacheTempFile.exists()) {
-						URL remoteURL = _getRemoteURL();
-
-						try {
-							_downloadFile(
-								remoteURL, mirrorsCacheTempFile, _retries);
-						}
-						catch (IOException ioException) {
-							_deleteFile(mirrorsCacheTempFile);
-
-							throw ioException;
-						}
+					if (readFile == null) {
+						readFile = mirrorsCacheTempFile;
 					}
 				}
 			}
 
-			_moveFile(mirrorsCacheTempFile, mirrorsCacheFile);
+			if (_dest.exists() && _dest.isDirectory()) {
+				_copyFile(readFile, new File(_dest, _fileName));
+			}
+			else {
+				_copyFile(readFile, _dest);
+			}
 		}
-
-		if (_dest.exists() && _dest.isDirectory()) {
-			_copyFile(mirrorsCacheFile, new File(_dest, _fileName));
-		}
-		else {
-			_copyFile(mirrorsCacheFile, _dest);
+		finally {
+			_deleteFile(mirrorsCacheLinkFile);
+			_deleteFile(mirrorsCacheTempFile);
 		}
 	}
 
@@ -776,6 +897,17 @@ public class MirrorsGetTask extends Task {
 		}
 	}
 
+	private Pattern _getOrphanPattern(String fileName) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("(?<timestamp>\\d{13,18})(-[0-9a-fA-F-]{36}(-");
+		sb.append(_LINK_MARKER);
+		sb.append(")?-)?");
+		sb.append(Pattern.quote(fileName));
+
+		return Pattern.compile(sb.toString());
+	}
+
 	private String _getPassword() {
 		if (_password != null) {
 			return _password;
@@ -838,6 +970,25 @@ public class MirrorsGetTask extends Task {
 		}
 
 		return processOutput.toString();
+	}
+
+	private File _getReadFile(
+		File mirrorsCacheFile, File mirrorsCacheLinkFile) {
+
+		File readFile = createReadLink(mirrorsCacheFile, mirrorsCacheLinkFile);
+
+		if (mirrorsCacheFile.equals(readFile)) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("Unable to link ");
+			sb.append(mirrorsCacheFile.getPath());
+			sb.append(". Reading it directly is not safe when the mirrors ");
+			sb.append("cache is shared.");
+
+			System.out.println(sb.toString());
+		}
+
+		return readFile;
 	}
 
 	private URL _getRemoteURL() {
@@ -1042,6 +1193,22 @@ public class MirrorsGetTask extends Task {
 		return false;
 	}
 
+	private boolean _isValidFile(File file) throws IOException {
+		if (_is7zFileName(_fileName)) {
+			return _is7zFile(file);
+		}
+
+		if (_isTarGzFileName(_fileName)) {
+			return _isTarGzFile(file);
+		}
+
+		if (_isZipFileName(_fileName)) {
+			return _isZipFile(file);
+		}
+
+		return true;
+	}
+
 	private boolean _isValidMD5(File file, URL url) throws IOException {
 		if (_skipChecksum) {
 			return true;
@@ -1078,6 +1245,20 @@ public class MirrorsGetTask extends Task {
 		String localMD5 = project.getProperty("md5");
 
 		return remoteMD5.contains(localMD5);
+	}
+
+	private boolean _isValidTempFile(File file) throws IOException {
+		if (!file.exists()) {
+			return false;
+		}
+
+		if (_isValidFile(file)) {
+			return true;
+		}
+
+		_deleteFile(file);
+
+		return false;
 	}
 
 	private boolean _isZipFile(File file) throws IOException {
@@ -1131,20 +1312,6 @@ public class MirrorsGetTask extends Task {
 		}
 
 		return false;
-	}
-
-	private void _moveFile(File sourceFile, File destFile) throws IOException {
-		StringBuilder sb = new StringBuilder();
-
-		sb.append("Moving ");
-		sb.append(sourceFile.getPath());
-		sb.append(" to ");
-		sb.append(destFile.getPath());
-		sb.append(".");
-
-		System.out.println(sb.toString());
-
-		sourceFile.renameTo(destFile);
 	}
 
 	private String _normalizePath(String path) {
@@ -1207,6 +1374,28 @@ public class MirrorsGetTask extends Task {
 		}
 
 		return urlConnection;
+	}
+
+	private boolean _publishByRename(File tempFile, File cacheFile)
+		throws IOException {
+
+		if (tempFile.renameTo(cacheFile)) {
+			return true;
+		}
+
+		if (cacheFile.exists()) {
+			return false;
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("Unable to publish ");
+		sb.append(tempFile.getPath());
+		sb.append(" to ");
+		sb.append(cacheFile.getPath());
+		sb.append(".");
+
+		throw new IOException(sb.toString());
 	}
 
 	private int _toFile(URL url, File file) throws IOException {
@@ -1290,6 +1479,26 @@ public class MirrorsGetTask extends Task {
 			}
 		}
 	}
+
+	private File _uniqueFile(File cacheFile, String marker) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(System.currentTimeMillis());
+		sb.append("-");
+		sb.append(UUID.randomUUID());
+		sb.append("-");
+
+		if (!marker.isEmpty()) {
+			sb.append(marker);
+			sb.append("-");
+		}
+
+		sb.append(cacheFile.getName());
+
+		return new File(cacheFile.getParentFile(), sb.toString());
+	}
+
+	private static final String _LINK_MARKER = "link";
 
 	private static final Pattern _basicAuthenticationURLPattern =
 		Pattern.compile("(https?://)([^:]+):([^@]+)@(.+)");

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -235,7 +235,7 @@ public class MirrorsGetTask extends Task {
 		}
 	}
 
-	protected boolean publish(File tempFile, File cacheFile)
+	protected boolean publish(File cacheFile, File tempFile)
 		throws IOException {
 
 		try {
@@ -251,7 +251,7 @@ public class MirrorsGetTask extends Task {
 				return false;
 			}
 
-			return _publishByRename(tempFile, cacheFile);
+			return _publishByRename(cacheFile, tempFile);
 		}
 	}
 
@@ -628,7 +628,7 @@ public class MirrorsGetTask extends Task {
 					_deleteFile(mirrorsCacheFile);
 				}
 
-				if (publish(mirrorsCacheTempFile, mirrorsCacheFile)) {
+				if (publish(mirrorsCacheFile, mirrorsCacheTempFile)) {
 					if (mirrorsCacheTempFile.exists()) {
 						readFile = mirrorsCacheTempFile;
 					}
@@ -1369,7 +1369,7 @@ public class MirrorsGetTask extends Task {
 		return urlConnection;
 	}
 
-	private boolean _publishByRename(File tempFile, File cacheFile)
+	private boolean _publishByRename(File cacheFile, File tempFile)
 		throws IOException {
 
 		if (tempFile.renameTo(cacheFile)) {

--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
 
 import java.util.ArrayList;
 import java.util.Base64;
@@ -219,11 +218,8 @@ public class MirrorsGetTask extends Task {
 	}
 
 	protected File createReadLink(File cacheFile, File linkFile) {
-		Path cacheFilePath = cacheFile.toPath();
-		Path linkFilePath = linkFile.toPath();
-
 		try {
-			Files.createLink(linkFilePath, cacheFilePath);
+			Files.createLink(linkFile.toPath(), cacheFile.toPath());
 
 			return linkFile;
 		}
@@ -242,11 +238,8 @@ public class MirrorsGetTask extends Task {
 	protected boolean publish(File tempFile, File cacheFile)
 		throws IOException {
 
-		Path cacheFilePath = cacheFile.toPath();
-		Path tempFilePath = tempFile.toPath();
-
 		try {
-			Files.createLink(cacheFilePath, tempFilePath);
+			Files.createLink(cacheFile.toPath(), tempFile.toPath());
 
 			return true;
 		}

--- a/modules/sdk/ant-mirrors-get/src/main/resources/com/liferay/ant/mirrors/get/packageinfo
+++ b/modules/sdk/ant-mirrors-get/src/main/resources/com/liferay/ant/mirrors/get/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
+++ b/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
@@ -37,7 +37,7 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 
 	@Test
 	public void testCreateReadLinkDeletedCacheFile() throws IOException {
-		_writeFile(_cacheFile, "cached");
+		_writeFile("cached", _cacheFile);
 
 		File linkFile = uniqueLinkFile(_cacheFile);
 
@@ -47,8 +47,8 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 
 		_cacheFile.delete();
 
-		Assert.assertFalse(_cacheFile.exists());
 		Assert.assertEquals("cached", _readFile(readFile));
+		Assert.assertFalse(_cacheFile.exists());
 	}
 
 	@Test
@@ -73,11 +73,11 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 					try {
 						File tempFile = uniqueTempFile(_cacheFile);
 
-						_writeFile(tempFile, content);
+						_writeFile(content, tempFile);
 
 						countDownLatch.await();
 
-						if (publish(tempFile, _cacheFile)) {
+						if (publish(_cacheFile, tempFile)) {
 							publishedCount.incrementAndGet();
 						}
 					}
@@ -110,22 +110,22 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 	public void testPublishFreeName() throws IOException {
 		File tempFile = uniqueTempFile(_cacheFile);
 
-		_writeFile(tempFile, "downloaded");
+		_writeFile("downloaded", tempFile);
 
-		Assert.assertTrue(publish(tempFile, _cacheFile));
+		Assert.assertTrue(publish(_cacheFile, tempFile));
 
 		Assert.assertEquals("downloaded", _readFile(_cacheFile));
 	}
 
 	@Test
 	public void testPublishTakenName() throws IOException {
-		_writeFile(_cacheFile, "winner");
+		_writeFile("winner", _cacheFile);
 
 		File tempFile = uniqueTempFile(_cacheFile);
 
-		_writeFile(tempFile, "loser");
+		_writeFile("loser", tempFile);
 
-		Assert.assertFalse(publish(tempFile, _cacheFile));
+		Assert.assertFalse(publish(_cacheFile, tempFile));
 
 		Assert.assertEquals("winner", _readFile(_cacheFile));
 
@@ -146,12 +146,12 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 
 	@Test
 	public void testSweepCacheFile() throws IOException {
-		_writeFile(_cacheFile, "cached");
+		_writeFile("cached", _cacheFile);
 
 		File digitFile = new File(
 			temporaryFolder.getRoot(), "1234567890123.zip");
 
-		_writeFile(digitFile, "other");
+		_writeFile("other", digitFile);
 
 		sweep(_cacheFile);
 
@@ -165,7 +165,7 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 
 	@Test
 	public void testSweepReadLinkToOldCacheFile() throws IOException {
-		_writeFile(_cacheFile, "cached");
+		_writeFile("cached", _cacheFile);
 
 		Assert.assertTrue(_cacheFile.setLastModified(_oldTime()));
 
@@ -233,11 +233,11 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 	private void _testSweep(boolean expected, String fileName)
 		throws IOException {
 
-		_writeFile(_cacheFile, "cached");
+		_writeFile("cached", _cacheFile);
 
 		File file = new File(temporaryFolder.getRoot(), fileName);
 
-		_writeFile(file, "orphan");
+		_writeFile("orphan", file);
 
 		sweep(_cacheFile);
 
@@ -265,7 +265,7 @@ public class MirrorsGetTaskTest extends MirrorsGetTask {
 		return fileNames.size();
 	}
 
-	private void _writeFile(File file, String content) throws IOException {
+	private void _writeFile(String content, File file) throws IOException {
 		Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
 	}
 

--- a/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
+++ b/modules/sdk/ant-mirrors-get/src/test/java/com/liferay/ant/mirrors/get/MirrorsGetTaskTest.java
@@ -1,0 +1,276 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ant.mirrors.get;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Calum Ragan
+ */
+public class MirrorsGetTaskTest extends MirrorsGetTask {
+
+	@Before
+	public void setUp() throws IOException {
+		_cacheFile = new File(temporaryFolder.getRoot(), _FILE_NAME);
+	}
+
+	@Test
+	public void testCreateReadLinkDeletedCacheFile() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		File linkFile = uniqueLinkFile(_cacheFile);
+
+		File readFile = createReadLink(_cacheFile, linkFile);
+
+		Assert.assertEquals(linkFile, readFile);
+
+		_cacheFile.delete();
+
+		Assert.assertFalse(_cacheFile.exists());
+		Assert.assertEquals("cached", _readFile(readFile));
+	}
+
+	@Test
+	public void testCreateReadLinkMissingCacheFile() {
+		Assert.assertNull(
+			createReadLink(_cacheFile, uniqueLinkFile(_cacheFile)));
+	}
+
+	@Test
+	public void testPublishConcurrent() throws Exception {
+		AtomicInteger publishedCount = new AtomicInteger();
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		List<Throwable> throwables = new CopyOnWriteArrayList<>();
+
+		List<Thread> threads = new ArrayList<>();
+
+		for (int i = 0; i < 16; i++) {
+			String content = "process-" + i;
+
+			Thread thread = new Thread(
+				() -> {
+					try {
+						File tempFile = uniqueTempFile(_cacheFile);
+
+						_writeFile(tempFile, content);
+
+						countDownLatch.await();
+
+						if (publish(tempFile, _cacheFile)) {
+							publishedCount.incrementAndGet();
+						}
+					}
+					catch (Throwable throwable) {
+						throwables.add(throwable);
+					}
+				});
+
+			threads.add(thread);
+
+			thread.start();
+		}
+
+		countDownLatch.countDown();
+
+		for (Thread thread : threads) {
+			thread.join();
+		}
+
+		Assert.assertEquals(throwables.toString(), 0, throwables.size());
+
+		Assert.assertEquals(1, publishedCount.get());
+
+		String content = _readFile(_cacheFile);
+
+		Assert.assertTrue(content, content.startsWith("process-"));
+	}
+
+	@Test
+	public void testPublishFreeName() throws IOException {
+		File tempFile = uniqueTempFile(_cacheFile);
+
+		_writeFile(tempFile, "downloaded");
+
+		Assert.assertTrue(publish(tempFile, _cacheFile));
+
+		Assert.assertEquals("downloaded", _readFile(_cacheFile));
+	}
+
+	@Test
+	public void testPublishTakenName() throws IOException {
+		_writeFile(_cacheFile, "winner");
+
+		File tempFile = uniqueTempFile(_cacheFile);
+
+		_writeFile(tempFile, "loser");
+
+		Assert.assertFalse(publish(tempFile, _cacheFile));
+
+		Assert.assertEquals("winner", _readFile(_cacheFile));
+
+		Assert.assertTrue(tempFile.exists());
+	}
+
+	@Test
+	public void testSweep() throws IOException {
+		_testSweep(false, _oldFileName(""));
+		_testSweep(false, _oldFileName("link-"));
+		_testSweep(false, _oldTime() + _FILE_NAME);
+		_testSweep(
+			true,
+			uniqueTempFile(
+				_cacheFile
+			).getName());
+	}
+
+	@Test
+	public void testSweepCacheFile() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		File digitFile = new File(
+			temporaryFolder.getRoot(), "1234567890123.zip");
+
+		_writeFile(digitFile, "other");
+
+		sweep(_cacheFile);
+
+		Assert.assertTrue(_cacheFile.exists());
+		Assert.assertTrue(digitFile.exists());
+
+		sweep(digitFile);
+
+		Assert.assertTrue(digitFile.exists());
+	}
+
+	@Test
+	public void testSweepReadLinkToOldCacheFile() throws IOException {
+		_writeFile(_cacheFile, "cached");
+
+		Assert.assertTrue(_cacheFile.setLastModified(_oldTime()));
+
+		File readFile = createReadLink(_cacheFile, uniqueLinkFile(_cacheFile));
+
+		long thresholdTime = System.currentTimeMillis() - MAX_AGE_MILLIS;
+
+		Assert.assertTrue(readFile.lastModified() < thresholdTime);
+
+		sweep(_cacheFile);
+
+		Assert.assertEquals("cached", _readFile(readFile));
+	}
+
+	@Test
+	public void testUniqueLinkFile() {
+		String fileName = uniqueLinkFile(
+			_cacheFile
+		).getName();
+
+		Assert.assertTrue(fileName, fileName.contains("-link-"));
+		Assert.assertTrue(fileName, fileName.endsWith(_FILE_NAME));
+
+		Assert.assertEquals(5000, _uniqueNameCount(true));
+	}
+
+	@Test
+	public void testUniqueTempFile() {
+		String fileName = uniqueTempFile(
+			_cacheFile
+		).getName();
+
+		Assert.assertFalse(fileName, fileName.contains("-link-"));
+		Assert.assertTrue(fileName, fileName.endsWith(_FILE_NAME));
+
+		Assert.assertEquals(5000, _uniqueNameCount(false));
+	}
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private String _oldFileName(String linkMarker) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(_oldTime());
+		sb.append("-");
+		sb.append("3963b4ea-097b-42e7-847d-bcc7c56c9f78");
+		sb.append("-");
+		sb.append(linkMarker);
+		sb.append(_FILE_NAME);
+
+		return sb.toString();
+	}
+
+	private long _oldTime() {
+		return System.currentTimeMillis() - (2 * MAX_AGE_MILLIS);
+	}
+
+	private String _readFile(File file) throws IOException {
+		byte[] bytes = Files.readAllBytes(file.toPath());
+
+		return new String(bytes, StandardCharsets.UTF_8);
+	}
+
+	private void _testSweep(boolean expected, String fileName)
+		throws IOException {
+
+		_writeFile(_cacheFile, "cached");
+
+		File file = new File(temporaryFolder.getRoot(), fileName);
+
+		_writeFile(file, "orphan");
+
+		sweep(_cacheFile);
+
+		Assert.assertEquals(fileName, expected, file.exists());
+	}
+
+	private int _uniqueNameCount(boolean link) {
+		Set<String> fileNames = new HashSet<>();
+
+		for (int i = 0; i < 5000; i++) {
+			if (link) {
+				fileNames.add(
+					uniqueLinkFile(
+						_cacheFile
+					).getName());
+			}
+			else {
+				fileNames.add(
+					uniqueTempFile(
+						_cacheFile
+					).getName());
+			}
+		}
+
+		return fileNames.size();
+	}
+
+	private void _writeFile(File file, String content) throws IOException {
+		Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static final String _FILE_NAME = "7.4.13-ga1.zip";
+
+	private File _cacheFile;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8047

## What Is Being Fixed

On AWS, `/root/.liferay/mirrors` is a symlink to `/mnt/shared/mirrors` — one EFS share used by every process on all eight masters. `MirrorsGetTask` treated it as private. It checked whether a file was cached, spent about ninety seconds downloading, then renamed the temporary file onto the shared name. The check and the rename are separated by the whole download, and the rename replaces whatever is there, so processes overwrote each other and destroyed files other processes were still reading.

Readers failed with `java.io.IOException: Stale file handle` out of `_copyFile`. The call sits in Poshi `setUp`, so Testray reported the cases as blocked rather than failed, which hid the cause. On `test-1-44` build 1281 segment 0, 15 of 23 axes hit this and the segment re-downloaded the 1.23 GiB artifact 26 times. It does not settle on its own, because a file that looks invalid mid-overwrite fails the 7z check, so the task deletes the shared copy and downloads it again.

Two paths also published without validating. The mirrors mount copy and the GCP download both returned whatever they produced, so a truncated file could enter the shared cache unchecked and every later reader would fail its archive check against it.

## How It Is Being Fixed

Publishing goes through `Files.createLink`, which creates the directory entry atomically and fails with `FileAlreadyExistsException` when the name is taken, so the first process to finish wins and the rest read that copy instead of overwriting it. Reading goes through a second hard link, which keeps the inode alive so a concurrent delete or replace cannot break a read in progress, and `NoSuchFileException` from that link replaces the old `exists()` check and closes the check-then-act gap.

Validation moved ahead of the publish. Every source now passes through the same archive check before its result can be published, so a corrupt download is discarded and the next source is tried rather than entering the cache. A forced replacement deletes the cached entry only once a validated download is in hand, so a download that fails no longer leaves the cache empty for everyone else.

Temporary and link names carry a UUID, because two processes starting in the same millisecond previously shared a path and corrupted each other's download. Both are deleted in a `finally`, and orphans older than twenty-four hours are swept. The sweep ages files by the timestamp embedded in the name rather than by `lastModified`, since a hard link reports the artifact's own modification time and an mtime-based sweep would delete the link it exists to protect. A single marker constant builds those names and the pattern that matches them, so the two cannot drift apart and silently strand orphans.

Where the filesystem does not support hard links, the publish falls back to the previous `renameTo`, which is safe because an unshared cache has no race to lose. Any `IOException` from the publish is treated as a possibly-lost race and re-checked against the target rather than trusted by exception type, since `FileAlreadyExistsException` is documented as optional.

The link, publish and sweep helpers are protected rather than private so the test can exercise them by subclassing, which widens the exported package and moves its version to 1.3.0.

## PR Check

**pr-check: PASS** — tested on `bf8d9901a28412e383eb6c879bd4bfcb948f46ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Two notes on the run. `ant baseline-all` exits non-zero on this checkout because of pre-existing drift in three `packageinfo` files outside this diff — `headless-cms-api`, `portal-kernel/.../xstream`, and `portal-kernel/.../servlet`. It left this module's `packageinfo` untouched at `1.3.0`, confirming the minor bump is correct, so Baseline is recorded as PASS for this branch. The validations ran against a commit whose tree is byte-identical to the head recorded above; only the commit objects changed, when the `packageinfo` bump was split into its own commit.

<!-- pr-check {"result": "success", "sha": "bf8d9901a28412e383eb6c879bd4bfcb948f46ed"} -->
