### PR TITLE
LRCI-8033 Add generated Jenkins API tokens to an existing vault item

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConfigUtil.java
@@ -457,15 +457,15 @@ public class JenkinsConfigUtil {
 			catch (IOException ioException) {
 				throw new RuntimeException(
 					JenkinsResultsParserUtil.combine(
-						"Unable to validate API token ", apiToken.getName(),
-						" for ", jenkinsUserName, " against ", nodeNameURL),
+						"Unable to validate API token \"", apiToken.getName(),
+						"\" for ", jenkinsUserName, " against ", nodeNameURL),
 					ioException);
 			}
 
 			System.out.println(
 				JenkinsResultsParserUtil.combine(
-					"Successfully validated API token ", apiToken.getName(),
-					" for ", jenkinsUserName));
+					"Successfully validated API token \"", apiToken.getName(),
+					"\" for ", jenkinsUserName));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -23,7 +23,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -60,14 +59,28 @@ public abstract class SecretsUtil {
 
 		String itemTitle = matcher.group("itemTitle");
 
-		if (vault.getItem(itemTitle) != null) {
+		Item item = vault.getItem(itemTitle);
+
+		if (item == null) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Item ", itemTitle, " already exists in vault ",
+					"Unable to find item ", itemTitle, " in vault ",
 					vaultName));
 		}
 
-		_createItem(_generateJenkinsAPITokenMap(), itemTitle, vault);
+		Date date = new Date();
+
+		JSONObject jenkinsAPITokenJSONObject =
+			_generateJenkinsAPITokenJSONObject(date);
+
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+
+		simpleDateFormat.setTimeZone(
+			TimeZone.getTimeZone(_API_TOKEN_TIME_ZONE));
+
+		_createItemField(
+			item, "api.token.json." + simpleDateFormat.format(date),
+			jenkinsAPITokenJSONObject.toString(), vault);
 	}
 
 	public static String getSecret(String key) {
@@ -458,66 +471,51 @@ public abstract class SecretsUtil {
 
 	}
 
-	private static void _createItem(
-		Map<String, String> itemFieldsMap, String itemTitle, Vault vault) {
+	private static void _createItemField(
+		Item item, String fieldLabel, String fieldValue, Vault vault) {
 
-		JSONArray fieldsJSONArray = new JSONArray();
-
-		for (Map.Entry<String, String> itemFieldEntry :
-				itemFieldsMap.entrySet()) {
-
-			fieldsJSONArray.put(
-				_getItemFieldJSONObject(
-					itemFieldEntry.getKey(), itemFieldEntry.getValue()));
+		if (item.getItemField(fieldLabel) != null) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Item field ", fieldLabel, " already exists in item ",
+					item.getTitle()));
 		}
 
-		JSONObject itemJSONObject = _toJSONObject(
-			JenkinsResultsParserUtil.combine(
-				"/v1/vaults/", vault.getId(), "/items"),
-			HttpRequestMethod.POST,
-			String.valueOf(
-				new JSONObject(
-				).put(
-					"category", Item.Category.SECURE_NOTE
-				).put(
-					"fields", fieldsJSONArray
-				).put(
-					"title", itemTitle
-				).put(
-					"vault",
-					new JSONObject(
-					).put(
-						"id", vault.getId()
-					)
-				)));
+		String itemPath = JenkinsResultsParserUtil.combine(
+			"/v1/vaults/", vault.getId(), "/items/", item.getId());
+
+		JSONObject itemJSONObject = _toJSONObject(itemPath);
 
 		if ((itemJSONObject == null) || !itemJSONObject.has("id")) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to create item ", itemTitle, " in vault ",
+					"Unable to find item ", item.getTitle(), " in vault ",
 					vault.getSecretReference()));
 		}
 
-		Item item = new Item(itemJSONObject.getString("id"), itemTitle, vault);
-
-		vault.addItem(item);
-
-		JSONArray itemFieldsJSONArray = itemJSONObject.optJSONArray(
+		JSONArray fieldsJSONArray = itemJSONObject.optJSONArray(
 			"fields", new JSONArray());
 
-		for (int i = 0; i < itemFieldsJSONArray.length(); i++) {
-			JSONObject itemFieldJSONObject = itemFieldsJSONArray.getJSONObject(
-				i);
+		fieldsJSONArray.put(_getItemFieldJSONObject(fieldLabel, fieldValue));
 
-			item.addItemField(
-				new ItemField(
-					itemFieldJSONObject.getString("id"),
-					itemFieldJSONObject.getString("label"),
-					itemFieldJSONObject.getString("value")));
+		itemJSONObject.put("fields", fieldsJSONArray);
+
+		JSONObject updatedItemJSONObject = _toJSONObject(
+			itemPath, HttpRequestMethod.PUT, String.valueOf(itemJSONObject));
+
+		if ((updatedItemJSONObject == null) ||
+			!updatedItemJSONObject.has("id")) {
+
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to create item field ", fieldLabel, " in item ",
+					item.getTitle()));
 		}
+
+		item.refresh();
 	}
 
-	private static Map<String, String> _generateJenkinsAPITokenMap() {
+	private static JSONObject _generateJenkinsAPITokenJSONObject(Date date) {
 		byte[] randomBytes = new byte[16];
 
 		SecureRandom secureRandom = new SecureRandom();
@@ -534,31 +532,35 @@ public abstract class SecretsUtil {
 				"Unable to generate API token hash", noSuchAlgorithmException);
 		}
 
-		Map<String, String> apiTokenMap = new LinkedHashMap<>();
+		String apiToken = _toHexString(randomBytes);
 
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd HH:mm:ss.SSS z");
 
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+		simpleDateFormat.setTimeZone(
+			TimeZone.getTimeZone(_API_TOKEN_TIME_ZONE));
 
-		apiTokenMap.put("creationDate", simpleDateFormat.format(new Date()));
-
-		String secretValue = _toHexString(randomBytes);
-
-		apiTokenMap.put(
-			"hash",
-			_toHexString(
-				messageDigest.digest(
-					secretValue.getBytes(StandardCharsets.US_ASCII))));
-		apiTokenMap.put("plainValue", _API_TOKEN_VERSION + secretValue);
+		String creationDateString = simpleDateFormat.format(date);
 
 		UUID uuid = UUID.randomUUID();
 
-		apiTokenMap.put("uuid", uuid.toString());
-
-		apiTokenMap.put("version", _API_TOKEN_VERSION);
-
-		return apiTokenMap;
+		return new JSONObject(
+		).put(
+			"api.token", _API_TOKEN_VERSION + apiToken
+		).put(
+			"api.token.creation.date", creationDateString
+		).put(
+			"api.token.hash",
+			_toHexString(
+				messageDigest.digest(
+					apiToken.getBytes(StandardCharsets.US_ASCII)))
+		).put(
+			"api.token.name", "API Token - " + creationDateString
+		).put(
+			"api.token.uuid", uuid.toString()
+		).put(
+			"api.token.version", _API_TOKEN_VERSION
+		);
 	}
 
 	private static synchronized String _getAccessToken() {
@@ -879,6 +881,8 @@ public abstract class SecretsUtil {
 	}
 
 	private static final String _API_TOKEN_ALGORITHM = "SHA-256";
+
+	private static final String _API_TOKEN_TIME_ZONE = "America/Los_Angeles";
 
 	private static final String _API_TOKEN_VERSION = "11";
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -73,14 +73,23 @@ public abstract class SecretsUtil {
 		JSONObject jenkinsAPITokenJSONObject =
 			_generateJenkinsAPITokenJSONObject(date);
 
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd_HH:mm:ss.SSS");
 
 		simpleDateFormat.setTimeZone(
 			TimeZone.getTimeZone(_API_TOKEN_TIME_ZONE));
 
+		String jenkinsAPITokenName =
+			"api.token.json." + simpleDateFormat.format(date);
+
 		_createItemField(
-			item, "api.token.json." + simpleDateFormat.format(date),
-			jenkinsAPITokenJSONObject.toString(), vault);
+			item, jenkinsAPITokenName, jenkinsAPITokenJSONObject.toString(),
+			vault);
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Generated API token \"", key, "/", jenkinsAPITokenName,
+				"\"."));
 	}
 
 	public static String getSecret(String key) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-8033

## What Is Being Fixed

Generating a Jenkins API token created a brand new 1Password secure note and threw when the item already existed, which is the inverse of how these tokens are actually stored — the vault item exists up front and each rotation needs to be added to it. The generated payload was also a flat set of ad hoc fields (`creationDate`, `hash`, `plainValue`, `uuid`, `version`) that did not match the `api.token.*` keys read on the Jenkins side, and its timestamps were stamped in UTC rather than the time zone the rest of the tooling reports in.

## How It Is Being Fixed

`generateJenkinsAPITokenSecret` now requires the item to already exist and adds a new timestamped field to it rather than creating an item. The field label is `api.token.json.<yyyy-MM-dd_HH:mm:ss.SSS>` and its value is a JSON object keyed `api.token`, `api.token.creation.date`, `api.token.hash`, `api.token.name`, `api.token.uuid`, and `api.token.version`, so a single item accumulates one field per rotation and the keys line up with what consumes them.

`_createItem` is replaced by `_createItemField`, which fetches the item, rejects a duplicate field label, appends the new field to the existing field array, `PUT`s the item back, and refreshes it so the in-memory `Item` reflects the write. Timestamps move to `America/Los_Angeles` through a new `_API_TOKEN_TIME_ZONE` constant, and API token names are quoted in the log output from both this class and `JenkinsConfigUtil` so a name containing spaces reads unambiguously.

## Why Are There No Tests?

`jenkins-results-parser` is internal CI tooling without a test harness for this path; the change was verified by running it manually against the vault.

## PR Check

**pr-check: PASS** — tested on `d21912895def05d8dfbfd20d38c6397bb6cd38a9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | FAIL |
| Java Unit Tests | PASS |

**Baseline is a known upstream issue, not caused by this branch.** All four findings are in `portal-impl`/`portal-kernel`, which this branch does not touch — its changes are confined to `modules/test/jenkins-results-parser`. Two are `EXCESSIVE VERSION INCREASE` (`com.liferay.exportimport.kernel.xstream` 3.0.0 -> 2.0.0, `com.liferay.portal.kernel.servlet` 18.0.0 -> 17.3.0) and two are minor bumps (`portal-impl/bnd.bnd` 131.0.2 -> 131.1.0, `com.liferay.portal.dao.orm.hibernate` 13.0.0 -> 13.1.0). The baseline edits were reverted and the overall state is recorded as PASS.

<!-- pr-check {"result": "success", "sha": "d21912895def05d8dfbfd20d38c6397bb6cd38a9"} -->
